### PR TITLE
fix(axorcist): preserve CFRange values in ValueUnwrapper

### DIFF
--- a/Sources/AXorcist/Values/ValueUnwrapper.swift
+++ b/Sources/AXorcist/Values/ValueUnwrapper.swift
@@ -68,15 +68,8 @@ enum ValueUnwrapper {
         """.trimmingCharacters(in: .whitespacesAndNewlines)
         axDebugLog(message)
 
-        // Handle special boolean type
-        if axValueType.rawValue == 4 { // kAXValueBooleanType (private)
-            var boolResult: DarwinBoolean = false
-            if AXValueGetValue(axVal, axValueType, &boolResult) {
-                return boolResult.boolValue
-            }
-        }
-
-        // Use new AXValue extensions for cleaner unwrapping
+        // AXValueType.cfRange also uses raw value 4, so raw-value guesses can corrupt
+        // range-based attributes like selectedTextRange into booleans.
         let unwrappedExtensionValue = axVal.value()
         let valueDescription = String(describing: unwrappedExtensionValue)
         let returnMessage = "ValueUnwrapper.unwrapAXValue: axVal.value() returned: \(valueDescription) " +

--- a/Tests/AXorcistTests/ValueUnwrapperTests.swift
+++ b/Tests/AXorcistTests/ValueUnwrapperTests.swift
@@ -1,0 +1,24 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("ValueUnwrapper Tests", .tags(.safe))
+struct ValueUnwrapperTests {
+    @MainActor
+    @Test("unwrap preserves CFRange AXValue", .tags(.safe))
+    func unwrapPreservesCFRangeAXValue() {
+        let expected = CFRange(location: 12, length: 34)
+        guard let axValue = AXValue.create(range: expected) else {
+            Issue.record("Failed to create AXValue from CFRange")
+            return
+        }
+
+        guard let actual = ValueUnwrapper.unwrap(axValue) as? CFRange else {
+            Issue.record("Expected ValueUnwrapper to return a CFRange")
+            return
+        }
+
+        #expect(actual.location == expected.location)
+        #expect(actual.length == expected.length)
+    }
+}


### PR DESCRIPTION
## Summary
- remove the raw-value boolean special case in `ValueUnwrapper.unwrapAXValue`
- rely on typed `AXValue` decoding so `CFRange`-backed attributes stay ranges
- add regression coverage for `AXValue.create(range:)` round-tripping through `ValueUnwrapper`

## Context
This addresses issue #2, where `selectedRange()` values were being treated as booleans because `AXValueType.cfRange` shares raw value `4`.

## Verification
- added a regression test for `CFRange` unwrapping
- confirmed locally that `AXValueType.cfRange.rawValue == 4`
- could not run `swift build`/test in this environment because the repo requires Swift tools 6.2 while the installed toolchain here is 6.1.0