### PR TITLE
[codex] update checkout action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     
     - name: Fetch Commander dependency
       shell: bash


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v4 to v7

## Compatibility

Checkout v7 moves the action to the Node 24 runtime and requires Actions Runner v2.327.1 or newer. AXorcist uses GitHub-hosted `macos-15`, which receives current runner releases; the same action version is already green in CrawlBar's `macos-15` CI.

## Validation

- reviewed the checkout v7.0.0 release notes and runner requirement
- `git diff --check`
- this PR's `build-and-lint` workflow
