### PR TITLE
[codex] fix SwiftPM installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/yourusername/AXorcist.git", from: "1.0.0")
+    .package(url: "https://github.com/openclaw/AXorcist.git", from: "0.1.2")
 ]
 ```
 


### PR DESCRIPTION
## Summary

- replace the placeholder repository URL in the SwiftPM installation example
- use the latest released AXorcist version, 0.1.2, instead of the unreleased 1.0.0

## Validation

- confirmed the public repository URL and latest GitHub release
- `git diff --check`
