### PR TITLE
ci: run safe tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,5 @@ jobs:
         fi
         echo "::endgroup::"
     
-    - name: Run Tests (would require accessibility permissions)
-      run: |
-        echo "⚠️  Tests require accessibility permissions and cannot run on CI"
-        echo "📝 Run 'make test' locally after granting accessibility permissions"
+    - name: Run safe tests
+      run: swift test

--- a/Tests/AXorcistTests/ApplicationQueryTests.swift
+++ b/Tests/AXorcistTests/ApplicationQueryTests.swift
@@ -33,8 +33,11 @@ struct AnyDecodable: Decodable {
 
 @Suite("AXorcist Application Query Tests", .tags(.safe))
 struct ApplicationQueryTests {
-    @Test("Collect all running applications", .tags(.safe))
-    func getAllApplications() async throws {
+    @Test(
+        "Collect all elements in the frontmost application",
+        .tags(.automation),
+        .enabled(if: AXTestEnvironment.runAutomationScenarios))
+    func collectAllFromFrontmostApplication() async throws {
         let command = CommandEnvelope(
             commandId: "test-get-all-apps",
             command: .collectAll,


### PR DESCRIPTION
## Summary

- run the safe Swift test suite in CI instead of printing a placeholder
- classify the `collectAll` frontmost-application scenario as automation-only because it requires a live GUI application and Accessibility context

## Root cause

CI skipped every test even though UI-dependent suites already use the `RUN_AUTOMATION_TESTS` gate. The remaining `collectAll` case was incorrectly tagged safe and fails correctly when a headless process has no focused application.

## Proof

- `swift test` — 33 tests across 13 suites passed; UI automation scenarios skipped
- `autoreview --mode local --parallel-tests 'swift test'` — clean, no actionable findings
- GitHub Actions exact-head CI required before merge

## Risk

Low. Test metadata and CI execution only; no runtime or public API behavior changes.
