### PR TITLE
docs: note hotkey modifier fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to AXorcist will be documented in this file.
 
 ### Fixed
 - Printable ASCII typing now uses physical key events before falling back to Unicode events, improving reliability in VM and headless launch paths.
+- Hotkey automation now emits and releases physical modifier key events, preventing modifiers from remaining stuck after shortcuts.
 - Unsupported command dispatch now returns an `unknown_command` error instead of trapping, and JSON path hint parsing no longer writes warnings to stdout for unknown attributes.
 - Preserve CFRange-backed AXValue attributes such as selected text ranges instead of misclassifying raw value 4 as a boolean. Thanks @WinnCook.
 


### PR DESCRIPTION
## Summary

Add the missing Unreleased changelog entry for `931e59e80ccd25fd9d581735493271561cc33326`, which now posts explicit modifier key-down/key-up events and prevents shortcut modifiers from remaining stuck.

## Proof

- verified the entry against the landed runtime diff in `Element+UIAutomation.swift`
- `git diff --check`

## Risk

Low. Documentation only; no runtime or package changes.
