### PR TITLE
fix: respect active keyboard layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to AXorcist will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- Printable ASCII typing now uses physical key events before falling back to Unicode events, improving reliability in VM and headless launch paths.
-- Hotkey automation now emits and releases physical modifier key events, preventing modifiers from remaining stuck after shortcuts.
+- Printable ASCII typing now derives physical key events from the active macOS keyboard layout before falling back to Unicode events, improving VM and headless reliability without producing incorrect text on non-US layouts.
+- Hotkey automation now builds complete event sequences before emitting and releasing physical modifier key events, preventing modifiers from remaining stuck after shortcuts or event-creation failures.
 - Unsupported command dispatch now returns an `unknown_command` error instead of trapping, and JSON path hint parsing no longer writes warnings to stdout for unknown attributes.
 - Preserve CFRange-backed AXValue attributes such as selected text ranges instead of misclassifying raw value 4 as a boolean. Thanks @WinnCook.
 

--- a/Sources/AXorcist/Core/Element+UIAutomation.swift
+++ b/Sources/AXorcist/Core/Element+UIAutomation.swift
@@ -1,5 +1,6 @@
 import AppKit
 import ApplicationServices
+import Carbon.HIToolbox
 
 // MARK: - Mouse Button Types
 
@@ -182,6 +183,7 @@ extension Element {
     /// Type a single character
     @MainActor public static func typeCharacter(_ character: Character) throws {
         // Physical key events survive VM/headless launch paths that can silently drop Unicode-only events.
+        // Resolve them through the active layout so the resulting text remains layout-independent.
         if let stroke = self.keyboardStroke(for: character) {
             try self.postKeyboardStroke(stroke)
             return
@@ -191,77 +193,95 @@ extension Element {
     }
 
     static func keyboardStroke(for character: Character) -> (keyCode: CGKeyCode, flags: CGEventFlags)? {
-        let string = String(character)
-        guard string.count == 1 else { return nil }
-
-        if let scalar = string.unicodeScalars.first,
-           CharacterSet.lowercaseLetters.contains(scalar),
-           let key = SpecialKey(rawValue: string),
-           let keyCode = key.keyCode
-        {
-            return (keyCode, [])
+        guard
+            let inputSource = TISCopyCurrentKeyboardLayoutInputSource()?.takeRetainedValue(),
+            let rawLayoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData)
+        else {
+            return nil
         }
 
-        if let scalar = string.unicodeScalars.first,
-           CharacterSet.uppercaseLetters.contains(scalar),
-           let key = SpecialKey(rawValue: string.lowercased()),
-           let keyCode = key.keyCode
-        {
-            return (keyCode, .maskShift)
+        let layoutData = Unmanaged<CFData>.fromOpaque(rawLayoutData).takeUnretainedValue()
+        guard let layoutBytes = CFDataGetBytePtr(layoutData) else { return nil }
+        let layout = UnsafeRawPointer(layoutBytes).assumingMemoryBound(to: UCKeyboardLayout.self)
+
+        return self.keyboardStroke(for: character) { keyCode, flags in
+            self.translatedString(for: keyCode, flags: flags, layout: layout)
+        }
+    }
+
+    static func keyboardStroke(
+        for character: Character,
+        translatingWith translate: (CGKeyCode, CGEventFlags) -> KeyboardTranslation?)
+        -> (keyCode: CGKeyCode, flags: CGEventFlags)?
+    {
+        let expected = String(character)
+        guard expected.unicodeScalars.count == 1,
+              let scalar = expected.unicodeScalars.first,
+              scalar.isASCII,
+              (0x20...0x7E).contains(scalar.value)
+        else {
+            return nil
         }
 
-        if let key = SpecialKey(rawValue: string),
-           let keyCode = key.keyCode
-        {
-            return (keyCode, [])
-        }
-
-        let shiftedSymbols: [Character: CGKeyCode] = [
-            "!": 18,
-            "@": 19,
-            "#": 20,
-            "$": 21,
-            "%": 23,
-            "^": 22,
-            "&": 26,
-            "*": 28,
-            "(": 25,
-            ")": 29,
-            "_": 27,
-            "+": 24,
-            "{": 33,
-            "}": 30,
-            "|": 42,
-            ":": 41,
-            "\"": 39,
-            "<": 43,
-            ">": 47,
-            "?": 44,
-            "~": 50,
+        let modifierOptions: [CGEventFlags] = [
+            [],
+            .maskShift,
+            .maskAlternate,
+            .maskShift.union(.maskAlternate),
         ]
-        if let keyCode = shiftedSymbols[character] {
-            return (keyCode, .maskShift)
-        }
 
-        let symbols: [Character: CGKeyCode] = [
-            " ": 49,
-            "-": 27,
-            "=": 24,
-            "[": 33,
-            "]": 30,
-            "\\": 42,
-            ";": 41,
-            "'": 39,
-            ",": 43,
-            ".": 47,
-            "/": 44,
-            "`": 50,
-        ]
-        if let keyCode = symbols[character] {
-            return (keyCode, [])
+        for flags in modifierOptions {
+            for keyCode in CGKeyCode(0)...CGKeyCode(127) {
+                guard let translation = translate(keyCode, flags),
+                      translation.deadKeyState == 0,
+                      translation.text == expected
+                else {
+                    continue
+                }
+                return (keyCode, flags)
+            }
         }
 
         return nil
+    }
+
+    private static func translatedString(
+        for keyCode: CGKeyCode,
+        flags: CGEventFlags,
+        layout: UnsafePointer<UCKeyboardLayout>) -> KeyboardTranslation?
+    {
+        var carbonModifiers: UInt32 = 0
+        if flags.contains(.maskShift) {
+            carbonModifiers |= UInt32(shiftKey)
+        }
+        if flags.contains(.maskAlternate) {
+            carbonModifiers |= UInt32(optionKey)
+        }
+
+        var deadKeyState: UInt32 = 0
+        var actualLength = 0
+        var codeUnits = [UniChar](repeating: 0, count: 8)
+        let status = UCKeyTranslate(
+            layout,
+            keyCode,
+            UInt16(kUCKeyActionDown),
+            (carbonModifiers >> 8) & 0xFF,
+            UInt32(LMGetKbdType()),
+            OptionBits(0),
+            &deadKeyState,
+            codeUnits.count,
+            &actualLength,
+            &codeUnits)
+
+        guard status == noErr else { return nil }
+        return KeyboardTranslation(
+            text: String(utf16CodeUnits: codeUnits, count: actualLength),
+            deadKeyState: deadKeyState)
+    }
+
+    struct KeyboardTranslation {
+        let text: String
+        let deadKeyState: UInt32
     }
 
     private static func postKeyboardStroke(_ stroke: (keyCode: CGKeyCode, flags: CGEventFlags)) throws {
@@ -332,22 +352,22 @@ extension Element {
 
     /// Perform a hotkey combination
     @MainActor public static func performHotkey(keys: [String], holdDuration: TimeInterval = 0.1) throws {
-        var modifiers: [(keyCode: CGKeyCode?, flag: CGEventFlags)] = []
+        var modifiers: [HotkeyModifier] = []
         var mainKey: SpecialKey?
 
         // Parse keys
         for key in keys {
             switch key.lowercased() {
             case "cmd", "command":
-                modifiers.append((keyCode: 0x37, flag: .maskCommand))
+                modifiers.append(HotkeyModifier(keyCode: 0x37, flag: .maskCommand))
             case "shift":
-                modifiers.append((keyCode: 0x38, flag: .maskShift))
+                modifiers.append(HotkeyModifier(keyCode: 0x38, flag: .maskShift))
             case "option", "opt", "alt":
-                modifiers.append((keyCode: 0x3A, flag: .maskAlternate))
+                modifiers.append(HotkeyModifier(keyCode: 0x3A, flag: .maskAlternate))
             case "ctrl", "control":
-                modifiers.append((keyCode: 0x3B, flag: .maskControl))
+                modifiers.append(HotkeyModifier(keyCode: 0x3B, flag: .maskControl))
             case "fn", "function":
-                modifiers.append((keyCode: nil, flag: .maskSecondaryFn))
+                modifiers.append(HotkeyModifier(keyCode: nil, flag: .maskSecondaryFn))
             default:
                 // Try to parse as special key
                 if let special = SpecialKey(rawValue: key.lowercased()) {
@@ -369,37 +389,71 @@ extension Element {
             throw UIAutomationError.unsupportedKey(key.rawValue)
         }
 
-        func makeKeyboardEvent(keyCode: CGKeyCode, keyDown: Bool, flags: CGEventFlags) throws -> CGEvent {
-            guard let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: keyDown) else {
-                throw UIAutomationError.failedToCreateEvent
+        let descriptors = self.hotkeyEventDescriptors(modifiers: modifiers, mainKeyCode: mainKeyCode)
+        // Build the complete sequence before posting anything. Event creation can fail; posting cannot.
+        let events = try self.keyboardEvents(for: descriptors) { descriptor in
+            CGEvent(
+                keyboardEventSource: nil,
+                virtualKey: descriptor.keyCode,
+                keyDown: descriptor.keyDown)
+        }
+
+        for (descriptor, event) in zip(descriptors, events) {
+            event.post(tap: .cghidEventTap)
+            if descriptor.keyCode == mainKeyCode, descriptor.keyDown, holdDuration > 0 {
+                Thread.sleep(forTimeInterval: holdDuration)
             }
-            event.flags = flags
-            return event
         }
+    }
 
-        func postKeyboardEvent(keyCode: CGKeyCode, keyDown: Bool, flags: CGEventFlags) throws {
-            try makeKeyboardEvent(keyCode: keyCode, keyDown: keyDown, flags: flags).post(tap: .cghidEventTap)
-        }
+    struct HotkeyModifier {
+        let keyCode: CGKeyCode?
+        let flag: CGEventFlags
+    }
 
+    struct KeyboardEventDescriptor: Equatable {
+        let keyCode: CGKeyCode
+        let keyDown: Bool
+        let flags: CGEventFlags
+    }
+
+    static func hotkeyEventDescriptors(
+        modifiers: [HotkeyModifier],
+        mainKeyCode: CGKeyCode) -> [KeyboardEventDescriptor]
+    {
+        var descriptors: [KeyboardEventDescriptor] = []
         var activeFlags: CGEventFlags = []
+
         for modifier in modifiers {
             activeFlags.insert(modifier.flag)
             if let keyCode = modifier.keyCode {
-                try postKeyboardEvent(keyCode: keyCode, keyDown: true, flags: activeFlags)
+                descriptors.append(KeyboardEventDescriptor(keyCode: keyCode, keyDown: true, flags: activeFlags))
             }
         }
 
-        try postKeyboardEvent(keyCode: mainKeyCode, keyDown: true, flags: activeFlags)
-        if holdDuration > 0 {
-            Thread.sleep(forTimeInterval: holdDuration)
-        }
-        try postKeyboardEvent(keyCode: mainKeyCode, keyDown: false, flags: activeFlags)
+        descriptors.append(KeyboardEventDescriptor(keyCode: mainKeyCode, keyDown: true, flags: activeFlags))
+        descriptors.append(KeyboardEventDescriptor(keyCode: mainKeyCode, keyDown: false, flags: activeFlags))
 
         for modifier in modifiers.reversed() {
             activeFlags.remove(modifier.flag)
             if let keyCode = modifier.keyCode {
-                try postKeyboardEvent(keyCode: keyCode, keyDown: false, flags: activeFlags)
+                descriptors.append(KeyboardEventDescriptor(keyCode: keyCode, keyDown: false, flags: activeFlags))
             }
+        }
+
+        return descriptors
+    }
+
+    static func keyboardEvents(
+        for descriptors: [KeyboardEventDescriptor],
+        factory: (KeyboardEventDescriptor) -> CGEvent?) throws -> [CGEvent]
+    {
+        try descriptors.map { descriptor in
+            guard let event = factory(descriptor) else {
+                throw UIAutomationError.failedToCreateEvent
+            }
+            event.flags = descriptor.flags
+            return event
         }
     }
 }

--- a/Tests/AXorcistTests/InputDriverTests.swift
+++ b/Tests/AXorcistTests/InputDriverTests.swift
@@ -4,53 +4,144 @@ import Testing
 
 @Suite("InputDriver cursor helpers")
 struct InputDriverTests {
-    @Test("cachedLocation returns cached value when present")
-    func cachedLocationUsesCache() {
+    @Test
+    func `cachedLocation returns cached value when present`() {
         var cache: CGPoint? = CGPoint(x: 10, y: 20)
         let result = InputDriver.cachedLocation(using: &cache)
         #expect(result == CGPoint(x: 10, y: 20))
     }
 
-    @Test("cachedLocation populates cache when empty")
-    func cachedLocationPopulatesCache() {
+    @Test
+    func `cachedLocation populates cache when empty`() {
         var cache: CGPoint?
         _ = InputDriver.cachedLocation(using: &cache)
         // If running in CI without UI, location may be nil; just assert cache mirrors result.
         #expect(cache == InputDriver.currentLocation())
     }
 
-    @Test("keyboardStroke maps printable ASCII to physical key events")
+    @Test
     @MainActor
-    func keyboardStrokeMapsPrintableASCII() throws {
-        let lower = try #require(Element.keyboardStroke(for: "a"))
+    func `keyboardStroke maps printable ASCII to physical key events`() throws {
+        let translateUSLayout: (CGKeyCode, CGEventFlags) -> Element.KeyboardTranslation? = { keyCode, flags in
+            let text: String? = switch (keyCode, flags) {
+            case (0, []): "a"
+            case (0, .maskShift): "A"
+            case (18, []): "1"
+            case (18, .maskShift): "!"
+            case (27, []): "-"
+            case (27, .maskShift): "_"
+            default: nil
+            }
+            return text.map { Element.KeyboardTranslation(text: $0, deadKeyState: 0) }
+        }
+
+        let lower = try #require(Element.keyboardStroke(for: "a", translatingWith: translateUSLayout))
         #expect(lower.keyCode == 0)
         #expect(!lower.flags.contains(.maskShift))
 
-        let upper = try #require(Element.keyboardStroke(for: "A"))
+        let upper = try #require(Element.keyboardStroke(for: "A", translatingWith: translateUSLayout))
         #expect(upper.keyCode == 0)
         #expect(upper.flags.contains(.maskShift))
 
-        let digit = try #require(Element.keyboardStroke(for: "1"))
+        let digit = try #require(Element.keyboardStroke(for: "1", translatingWith: translateUSLayout))
         #expect(digit.keyCode == 18)
         #expect(!digit.flags.contains(.maskShift))
 
-        let symbol = try #require(Element.keyboardStroke(for: "!"))
+        let symbol = try #require(Element.keyboardStroke(for: "!", translatingWith: translateUSLayout))
         #expect(symbol.keyCode == 18)
         #expect(symbol.flags.contains(.maskShift))
 
-        let hyphen = try #require(Element.keyboardStroke(for: "-"))
+        let hyphen = try #require(Element.keyboardStroke(for: "-", translatingWith: translateUSLayout))
         #expect(hyphen.keyCode == 27)
         #expect(!hyphen.flags.contains(.maskShift))
 
-        let underscore = try #require(Element.keyboardStroke(for: "_"))
+        let underscore = try #require(Element.keyboardStroke(for: "_", translatingWith: translateUSLayout))
         #expect(underscore.keyCode == 27)
         #expect(underscore.flags.contains(.maskShift))
     }
 
-    @Test("keyboardStroke leaves non-ASCII for Unicode fallback")
+    @Test
     @MainActor
-    func keyboardStrokeLeavesNonASCIIForUnicodeFallback() {
-        #expect(Element.keyboardStroke(for: "é") == nil)
-        #expect(Element.keyboardStroke(for: "🙂") == nil)
+    func `keyboardStroke follows the active keyboard layout`() throws {
+        let translateQWERTZLayout: (CGKeyCode, CGEventFlags) -> Element.KeyboardTranslation? = { keyCode, flags in
+            let text: String? = if keyCode == 6, flags.isEmpty {
+                "y"
+            } else if keyCode == 16, flags.isEmpty {
+                "z"
+            } else if keyCode == 37, flags == .maskAlternate {
+                "@"
+            } else {
+                nil
+            }
+            return text.map { Element.KeyboardTranslation(text: $0, deadKeyState: 0) }
+        }
+
+        let z = try #require(Element.keyboardStroke(for: "z", translatingWith: translateQWERTZLayout))
+        #expect(z.keyCode == 16)
+        #expect(z.flags.isEmpty)
+
+        let at = try #require(Element.keyboardStroke(for: "@", translatingWith: translateQWERTZLayout))
+        #expect(at.keyCode == 37)
+        #expect(at.flags == .maskAlternate)
+    }
+
+    @Test
+    @MainActor
+    func `keyboardStroke rejects dead key candidates`() throws {
+        let translateDeadKeyLayout: (CGKeyCode, CGEventFlags) -> Element.KeyboardTranslation? = { keyCode, flags in
+            guard flags.isEmpty else { return nil }
+            if keyCode == 10 {
+                return Element.KeyboardTranslation(text: "^", deadKeyState: 1)
+            }
+            if keyCode == 11 {
+                return Element.KeyboardTranslation(text: "^", deadKeyState: 0)
+            }
+            return nil
+        }
+
+        let caret = try #require(Element.keyboardStroke(for: "^", translatingWith: translateDeadKeyLayout))
+        #expect(caret.keyCode == 11)
+    }
+
+    @Test
+    @MainActor
+    func `keyboardStroke leaves non-ASCII for Unicode fallback`() {
+        let translate: (CGKeyCode, CGEventFlags) -> Element.KeyboardTranslation? = { _, _ in
+            Element.KeyboardTranslation(text: "é", deadKeyState: 0)
+        }
+        #expect(Element.keyboardStroke(for: "é", translatingWith: translate) == nil)
+        #expect(Element.keyboardStroke(for: "🙂", translatingWith: translate) == nil)
+    }
+
+    @Test
+    @MainActor
+    func `hotkey events are fully built before posting`() throws {
+        let descriptors = Element.hotkeyEventDescriptors(
+            modifiers: [Element.HotkeyModifier(keyCode: 0x37, flag: .maskCommand)],
+            mainKeyCode: 0)
+        #expect(descriptors == [
+            Element.KeyboardEventDescriptor(keyCode: 0x37, keyDown: true, flags: .maskCommand),
+            Element.KeyboardEventDescriptor(keyCode: 0, keyDown: true, flags: .maskCommand),
+            Element.KeyboardEventDescriptor(keyCode: 0, keyDown: false, flags: .maskCommand),
+            Element.KeyboardEventDescriptor(keyCode: 0x37, keyDown: false, flags: []),
+        ])
+
+        var creationCount = 0
+        do {
+            _ = try Element.keyboardEvents(for: descriptors) { descriptor in
+                creationCount += 1
+                guard creationCount < 3 else { return nil }
+                return CGEvent(
+                    keyboardEventSource: nil,
+                    virtualKey: descriptor.keyCode,
+                    keyDown: descriptor.keyDown)
+            }
+            Issue.record("Expected event creation to fail")
+        } catch UIAutomationError.failedToCreateEvent {
+            // Expected: no caller can post this incomplete event array.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(creationCount == 3)
     }
 }


### PR DESCRIPTION
## Summary

- derive printable ASCII key codes and modifiers from the active macOS keyboard layout instead of assuming US ANSI positions
- reject dead-key translations so accents cannot leak into the next typed character
- construct the entire hotkey event sequence before posting, preventing partial modifier key-down state when event creation fails
- add regression coverage for QWERTZ, option-modified symbols, dead keys, and injected mid-sequence creation failure

## Root cause

The unreleased physical-key path hard-coded US key positions and created/posted hotkey events incrementally. Non-US layouts could emit the wrong character, while a later event-creation failure could leave already-posted modifiers held.

## Proof

- `swift test --filter InputDriverTests` — 7 passed
- `swift test` — 36 passed; Accessibility-authorized UI suites skipped by their existing tags
- `swift build -c release -Xswiftc -warnings-as-errors`
- `swift test --sanitize address` — 36 passed
- changed-file SwiftFormat and strict SwiftLint — clean
- clean remote-consumer archive: Commander 0.2.2 + swift-log 1.14.0, release build, focused tests, release-binary ping
- Accessibility-authorized live proof on the exact PR head: real German layout, built candidate event posting into a dedicated TextEdit document, exact 13-byte readback
- autoreview: final fresh branch review clean with no accepted/actionable findings
- public model identifier gate: PASS; no model-bearing surfaces

## Live keyboard-layout proof

- exact candidate: `dcf03465aa034222d37a98fd95994e1b8ca8d6d8`
- verified Accessibility and event-synthesis permission before posting
- temporarily selected the real macOS German keyboard layout
- ran the built candidate's `Element.typeText` path with Accessibility trust asserted
- typed probe `yYzZ@^[]{}\|~`, covering QWERTZ-swapped letters, option-modified symbols, and a dead-key character
- saved/read the dedicated TextEdit fixture as exactly 13 bytes: `79 59 7a 5a 40 5e 5b 5d 7b 7d 5c 7c 7e`
- restored U.S. as the selected layout and disabled the temporary German source after the run
