### PR TITLE
fix: make AXError descriptions nonisolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to AXorcist will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- Keep `AXError.localizedDescription` callable from nonisolated code when clients enable Swift 6.2 strict concurrency.
 - Printable ASCII typing now derives physical key events from the active macOS keyboard layout before falling back to Unicode events, improving VM and headless reliability without producing incorrect text on non-US layouts.
 - Hotkey automation now builds complete event sequences before emitting and releasing physical modifier key events, preventing modifiers from remaining stuck after shortcuts or event-creation failures.
 - Unsupported command dispatch now returns an `unknown_command` error instead of trapping, and JSON path hint parsing no longer writes warnings to stdout for unknown attributes.

--- a/Sources/AXorcist/Core/AXError+Extensions.swift
+++ b/Sources/AXorcist/Core/AXError+Extensions.swift
@@ -9,7 +9,7 @@ import ApplicationServices
 import Foundation
 
 // Create a custom error type that wraps AXError
-public struct AccessibilitySystemError: Error, LocalizedError {
+nonisolated public struct AccessibilitySystemError: Error, LocalizedError {
     public let axError: AXError
 
     public init(_ axError: AXError) {
@@ -87,7 +87,7 @@ extension AXError {
     }
 
     /// Provides a localized description for AXError
-    public var localizedDescription: String {
+    nonisolated public var localizedDescription: String {
         AccessibilitySystemError(self).errorDescription ?? "Unknown AXError: \(self.rawValue)"
     }
 }

--- a/Tests/AXorcistTests/AXErrorExtensionsTests.swift
+++ b/Tests/AXorcistTests/AXErrorExtensionsTests.swift
@@ -1,0 +1,15 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("AXError extensions")
+struct AXErrorExtensionsTests {
+    @Test("localized descriptions are available outside the main actor")
+    func localizedDescriptionIsNonisolated() {
+        #expect(Self.describe(.actionUnsupported) == "Action is not supported")
+    }
+
+    nonisolated private static func describe(_ error: AXError) -> String {
+        error.localizedDescription
+    }
+}


### PR DESCRIPTION
## Summary

- opt the value-only `AccessibilitySystemError` wrapper out of package default main-actor isolation
- expose `AXError.localizedDescription` as nonisolated
- add compile-time and runtime regression coverage for nonisolated callers

Fixes #13.

## Validation

- `swift test` — 37 tests passed across 14 suites
- autoreview — clean, no accepted/actionable findings
- reproduced downstream failure in OpenClaw's pinned Peekaboo 3.9.0 build under Swift 6.2
