### PR TITLE
fix: keep logger overloads nonisolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Keep the public swift-log convenience overloads nonisolated so importing AXorcist does not impose main-actor isolation on downstream log calls.
+
 ## [0.1.3] - 2026-07-14
 
 ### Fixed

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
             name: "AXorcistTests",
             dependencies: [
                 "AXorcist", // Dependency restored to AXorcist
+                .product(name: "Logging", package: "swift-log"),
             ],
             path: "Tests/AXorcistTests", // Explicit path
             swiftSettings: approachableConcurrencySettings

--- a/Sources/AXorcist/Logging/GlobalAXLogger.swift
+++ b/Sources/AXorcist/Logging/GlobalAXLogger.swift
@@ -171,22 +171,22 @@ public class GlobalAXLogger {
 
 extension Logging.Logger {
     @inlinable
-    public func debug(_ message: @autoclosure () -> String) {
+    public nonisolated func debug(_ message: @autoclosure () -> String) {
         self.log(level: .debug, "\(message())")
     }
 
     @inlinable
-    public func info(_ message: @autoclosure () -> String) {
+    public nonisolated func info(_ message: @autoclosure () -> String) {
         self.log(level: .info, "\(message())")
     }
 
     @inlinable
-    public func warning(_ message: @autoclosure () -> String) {
+    public nonisolated func warning(_ message: @autoclosure () -> String) {
         self.log(level: .warning, "\(message())")
     }
 
     @inlinable
-    public func error(_ message: @autoclosure () -> String) {
+    public nonisolated func error(_ message: @autoclosure () -> String) {
         self.log(level: .error, "\(message())")
     }
 }

--- a/Tests/AXorcistTests/LoggerIsolationTests.swift
+++ b/Tests/AXorcistTests/LoggerIsolationTests.swift
@@ -1,0 +1,19 @@
+import Logging
+import Testing
+@testable import AXorcist
+
+@Suite("Logger isolation")
+struct LoggerIsolationTests {
+    @Test("convenience overloads are callable outside the main actor")
+    func convenienceOverloadsAreNonisolated() {
+        let logger = Logger(label: "AXorcistTests.LoggerIsolation")
+        Self.logAllLevels(logger)
+    }
+
+    nonisolated private static func logAllLevels(_ logger: Logger) {
+        logger.debug("debug")
+        logger.info("info")
+        logger.warning("warning")
+        logger.error("error")
+    }
+}


### PR DESCRIPTION
## Summary

- keep AXorcist's public swift-log overloads explicitly nonisolated
- add a compile-time regression test covering every overload from nonisolated code
- document the downstream Swift 6 build fix

Fixes #15.

## Proof

- `swift test` with Apple Swift 6.3.3: 38 tests, 15 suites passed
- `swift test` on ClawMac with Xcode beta / Swift 6.4: 38 tests, 15 suites passed
- OpenClaw macOS full `swift build` on ClawMac with the patched AXorcist checkout: passed
- autoreview: clean, no accepted or actionable findings
