### PR TITLE
feat(cli): ship supported standalone axorc interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,9 @@ jobs:
       with:
         swift-version: ${{ env.SWIFT_VERSION }}
     
-    - name: Install SwiftLint and SwiftFormat
+    - name: Install validation tools
       run: |
-        brew install swiftlint swiftformat
+        brew install shellcheck swiftlint swiftformat
     
     - name: Build
       run: |
@@ -79,3 +79,17 @@ jobs:
     
     - name: Run safe tests
       run: swift test
+
+    - name: Verify CLI release packaging
+      shell: bash
+      run: |
+        shellcheck scripts/*.sh
+        version="$(sed -n 's/.*axorcVersion = "\([^"]*\)".*/\1/p' Sources/axorc/Models/AXORCModels.swift)"
+        scripts/build-release-artifact.sh "$version" --adhoc
+        archive="dist/axorc-$version-macos-universal.zip"
+        test "$(unzip -Z1 "$archive")" = "axorc"
+        (cd dist && shasum -a 256 -c "$(basename "$archive").sha256")
+        sha256="$(shasum -a 256 "$archive" | awk '{print $1}')"
+        scripts/render-homebrew-formula.sh "$version" "$sha256" > /tmp/axorc.rb
+        grep -Fq 'skip_clean "bin/axorc"' /tmp/axorc.rb
+        ruby -c /tmp/axorc.rb

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ playground.xcworkspace
 .swiftpm
 
 .build/
+dist/
 
 # CocoaPods
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add discoverable `permissions`, `find`, `tree`, and `raw` CLI commands with help, version, stable JSON output, signed universal artifact tooling, and a Homebrew formula template.
+
+### Fixed
+- Return nonzero exit codes for failed raw commands, keep routine CLI output free of library logs, resolve applications by name, PID, bundle ID, or focus, return real requested attribute values, repair documented examples, and let `collectAll` filters match descendants below nonmatching parents.
+
 ## [0.1.5] - 2026-07-15
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,14 @@ clean:
 	rm -f $(UNIVERSAL_BINARY_PATH)
 	@echo "Clean complete."
 
+release-artifact:
+	@test -n "$(VERSION)" || (echo "VERSION is required" >&2; exit 2)
+	@if test "$(ADHOC)" = "1"; then \
+		./scripts/build-release-artifact.sh "$(VERSION)" --adhoc; \
+	else \
+		./scripts/build-release-artifact.sh "$(VERSION)"; \
+	fi
+
 # Format code with SwiftFormat
 format:
 	@echo "Formatting code with SwiftFormat..."

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1402ff8188f8fe568d3feaca4cd51cb8a08328bc6c3df27c978e106f1b777ba2",
+  "originHash" : "35f754252cf3111a509f6a9ee7ca1a07d40bbe953ef8bd9ac7150f2faf87174b",
   "pins" : [
     {
       "identity" : "commander",

--- a/Package.swift
+++ b/Package.swift
@@ -58,6 +58,7 @@ let package = Package(
             name: "AXorcistTests",
             dependencies: [
                 "AXorcist", // Dependency restored to AXorcist
+                "axorc",
                 .product(name: "Logging", package: "swift-log"),
             ],
             path: "Tests/AXorcistTests", // Explicit path

--- a/README.md
+++ b/README.md
@@ -55,9 +55,12 @@ public class AXorcist {
 import AXorcist
 
 let axorcist = AXorcist.shared
+let query = QueryCommand(
+    appIdentifier: "Safari",
+    locator: Locator(criteria: [Criterion(attribute: "AXRole", value: "AXButton")]))
 let command = AXCommandEnvelope(
     commandID: "find-button",
-    command: .query(QueryCommand(appName: "Safari", searchCriteria: [.role(.button)]))
+    command: .query(query)
 )
 let response = axorcist.runCommand(command)
 ```
@@ -69,7 +72,7 @@ Swift wrapper around `AXUIElement` providing modern API patterns.
 ```swift
 public struct Element: Equatable, Hashable {
     public let underlyingElement: AXUIElement
-    public var attributes: [String: AnyCodable]?
+    public var attributes: [String: AttributeValue]?
     public var prefetchedChildren: [Element]?
     public var actions: [String]?
 }
@@ -88,13 +91,13 @@ public struct Element: Equatable, Hashable {
 let element = Element(axUIElement)
 
 // Access properties safely
-let title = element.title
-let role = element.role
-let isEnabled = element.isEnabled
+let title = element.title()
+let role = element.role()
+let isEnabled = element.isEnabled()
 
 // Perform actions
 try element.performAction(.press)
-try element.setValue("Hello World")
+_ = element.setValue("Hello World", forAttribute: "AXValue")
 
 // Navigate hierarchy
 let children = element.children()
@@ -173,18 +176,22 @@ Add to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/openclaw/AXorcist.git", from: "0.1.2")
+    .package(url: "https://github.com/openclaw/AXorcist.git", from: "0.1.5")
 ]
 ```
 
 ### Command Line Tool
 
-Build and install the CLI tool:
+Until the prebuilt Homebrew formula is published, build and install the CLI tool from source:
 
 ```bash
-swift build -c release
-cp .build/release/axorc /usr/local/bin/
+swift build -c release --product axorc
+install -m 755 .build/release/axorc /usr/local/bin/axorc
 ```
+
+Run `axorc permissions` after installation. macOS will need Accessibility permission for inspection and automation.
+
+Prebuilt Homebrew distribution is prepared for the next signed release. Maintainers: see [docs/releasing.md](docs/releasing.md) for the artifact and tap workflow.
 
 ## Quick Start
 
@@ -199,8 +206,8 @@ let axorcist = AXorcist()
 // Create a query command
 let query = QueryCommand(
     appIdentifier: "com.apple.TextEdit",
-    locator: AXLocator(criteria: [
-        AXCriterion(attribute: "AXRole", value: "AXTextArea")
+    locator: Locator(criteria: [
+        Criterion(attribute: "AXRole", value: "AXTextArea")
     ]),
     attributesToReturn: ["AXValue", "AXRole"]
 )
@@ -215,11 +222,14 @@ let response = axorcist.runCommand(AXCommandEnvelope(
 ### Command Line
 
 ```bash
-# Find all buttons in Safari
-echo '{"command": "query", "application": "com.apple.Safari", "locator": {"criteria": [{"attribute": "AXRole", "value": "AXButton"}]}}' | axorc --stdin
+# Print a shallow accessibility tree
+axorc tree --app Safari --depth 3
 
-# Click the Back button
-echo '{"command": "performAction", "application": "Safari", "locator": {"criteria": [{"attribute": "AXTitle", "value": "Back"}]}, "action": "AXPress"}' | axorc --stdin
+# Find the Back button
+axorc find --app Safari --role AXButton --title Back
+
+# Use the full JSON protocol for actions and advanced queries
+echo '{"command_id":"back","command":"performAction","application":"Safari","locator":{"criteria":[{"attribute":"AXTitle","value":"Back"}]},"action_name":"AXPress"}' | axorc raw --stdin
 ```
 
 ## Element Search and Matching
@@ -329,13 +339,14 @@ Find elements and retrieve their attributes.
 
 ```json
 {
+  "command_id": "find-text-area",
   "command": "query",
   "application": "com.apple.TextEdit",
   "locator": {
     "criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]
   },
   "attributes": ["AXValue", "AXRole", "AXTitle"],
-  "maxDepthForSearch": 10
+  "max_depth": 10
 }
 ```
 
@@ -344,12 +355,13 @@ Execute actions on elements.
 
 ```json
 {
+  "command_id": "press-back",
   "command": "performAction",
   "application": "Safari",
   "locator": {
     "criteria": [{"attribute": "AXTitle", "value": "Back"}]
   },
-  "action": "AXPress"
+  "action_name": "AXPress"
 }
 ```
 
@@ -358,8 +370,8 @@ Retrieve the currently focused element.
 
 ```json
 {
+  "command_id": "focused-element",
   "command": "getFocusedElement",
-  "application": "focused",
   "attributes": ["AXRole", "AXTitle", "AXValue"]
 }
 ```
@@ -369,9 +381,9 @@ Find element at specific screen coordinates.
 
 ```json
 {
+  "command_id": "element-at-point",
   "command": "getElementAtPoint",
-  "xCoordinate": 500,
-  "yCoordinate": 300,
+  "point": [500, 300],
   "attributes": ["AXRole", "AXTitle"]
 }
 ```
@@ -381,19 +393,22 @@ Execute multiple commands in sequence.
 
 ```json
 {
+  "command_id": "inspect-and-fill",
   "command": "batch",
-  "commands": [
+  "sub_commands": [
     {
+      "command_id": "find-text-area",
       "command": "query",
       "application": "TextEdit",
       "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]}
     },
     {
+      "command_id": "fill-text-area",
       "command": "performAction",
       "application": "TextEdit",
       "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]},
-      "action": "AXSetValue",
-      "actionValue": "Hello, World!"
+      "action_name": "AXSetValue",
+      "action_value": "Hello, World!"
     }
   ]
 }
@@ -404,11 +419,12 @@ Monitor UI changes in real-time.
 
 ```json
 {
+  "command_id": "watch-text-edit",
   "command": "observe",
   "application": "com.apple.TextEdit",
   "notifications": ["AXValueChanged", "AXFocusedUIElementChanged"],
-  "includeDetails": true,
-  "watchChildren": false
+  "include_element_details": ["AXRole", "AXTitle", "AXValue"],
+  "watch_children": false
 }
 ```
 
@@ -417,11 +433,12 @@ Recursively collect all elements.
 
 ```json
 {
+  "command_id": "collect-buttons",
   "command": "collectAll",
   "application": "Safari",
   "attributes": ["AXRole", "AXTitle"],
-  "maxDepth": 5,
-  "filterCriteria": [{"attribute": "AXRole", "value": "AXButton"}]
+  "max_depth": 5,
+  "filter_criteria": {"AXRole": "AXButton"}
 }
 ```
 
@@ -443,11 +460,12 @@ Available actions to perform on elements:
 
 ```json
 {
+  "command_id": "replace-text",
   "command": "performAction",
   "application": "TextEdit",
   "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]},
-  "action": "AXSetValue",
-  "actionValue": "New text content"
+  "action_name": "AXSetValue",
+  "action_value": "New text content"
 }
 ```
 
@@ -468,37 +486,48 @@ Monitor UI changes with these notifications:
 
 ```json
 {
+  "command_id": "watch-text",
   "command": "observe",
   "application": "TextEdit",
   "notifications": ["AXValueChanged", "AXFocusedUIElementChanged"],
   "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]},
-  "includeDetails": true
+  "include_element_details": ["AXRole", "AXTitle", "AXValue"]
 }
 ```
 
 ## Command-Line Usage
 
-### Basic Usage
+`axorc` has human-readable inspection commands and a stable JSON mode for scripts and advanced automation.
+
+### Inspect Applications
 
 ```bash
-# Run command from file
-axorc --file command.json
+# Check permission and recovery instructions
+axorc permissions
 
-# Run command from stdin
-echo '{"command": "ping"}' | axorc --stdin
+# Print a hierarchy; use a bundle identifier when names are ambiguous
+axorc tree --app com.apple.dock --depth 3
 
-# Pretty print output
-axorc --file command.json --pretty
+# Limit a tree to one role and emit JSON for scripts
+axorc tree --app com.apple.dock --role AXDockItem --json
 
-# Include debug logging
-axorc --file command.json --debug
+# Find one element with exact matching
+axorc find --app Safari --role AXButton --title Back
+
+# Use case-insensitive substring matching
+axorc find --app Safari --title address --contains
 ```
 
-### Advanced CLI Examples
+Run `axorc --help` or `axorc help find` for the complete terminal reference. Human-readable output goes to stdout, diagnostics go to stderr, and failures return nonzero exit codes.
+
+### JSON Protocol
+
+Every JSON command requires `command_id` and `command`. Input can come from standard input, a file, an argument, or the legacy root-level syntax:
 
 ```bash
-# Find all enabled buttons
+# Standard input
 echo '{
+  "command_id": "enabled-button",
   "command": "query",
   "application": "Safari",
   "locator": {
@@ -507,10 +536,17 @@ echo '{
       {"attribute": "AXEnabled", "value": "true"}
     ]
   }
-}' | axorc --stdin --pretty
+}' | axorc raw --stdin
 
-# Click button using path navigation
+# File
+axorc raw --file command.json
+
+# Argument
+axorc raw --json '{"command_id":"health","command":"ping"}'
+
+# Action using path navigation
 echo '{
+  "command_id": "press-back",
   "command": "performAction",
   "application": "com.apple.Safari",
   "locator": {
@@ -520,9 +556,11 @@ echo '{
     ],
     "criteria": [{"attribute": "AXTitle", "value": "Back"}]
   },
-  "action": "AXPress"
-}' | axorc --stdin
+  "action_name": "AXPress"
+}' | axorc raw --stdin
 ```
+
+Existing invocations such as `axorc --stdin` and `axorc '{...}'` remain supported. Prefer the explicit `raw` subcommand in new scripts.
 
 ## Advanced Examples
 
@@ -530,6 +568,7 @@ echo '{
 
 ```json
 {
+  "command_id": "find-submit",
   "command": "query",
   "application": "com.apple.Safari",
   "locator": {
@@ -550,9 +589,11 @@ echo '{
 
 ```json
 {
+  "command_id": "fill-form",
   "command": "batch",
-  "commands": [
+  "sub_commands": [
     {
+      "command_id": "fill-email",
       "command": "performAction",
       "application": "Safari",
       "locator": {
@@ -561,10 +602,11 @@ echo '{
           {"attribute": "AXPlaceholderValue", "value": "Email", "match_type": "contains"}
         ]
       },
-      "action": "AXSetValue",
-      "actionValue": "user@example.com"
+      "action_name": "AXSetValue",
+      "action_value": "user@example.com"
     },
     {
+      "command_id": "fill-password",
       "command": "performAction",
       "application": "Safari",
       "locator": {
@@ -573,10 +615,11 @@ echo '{
           {"attribute": "AXPlaceholderValue", "value": "Password", "match_type": "contains"}
         ]
       },
-      "action": "AXSetValue",
-      "actionValue": "secretpassword"
+      "action_name": "AXSetValue",
+      "action_value": "example-value"
     },
     {
+      "command_id": "submit-form",
       "command": "performAction",
       "application": "Safari",
       "locator": {
@@ -585,7 +628,7 @@ echo '{
           {"attribute": "AXTitle", "value": "Sign In", "match_type": "contains"}
         ]
       },
-      "action": "AXPress"
+      "action_name": "AXPress"
     }
   ]
 }
@@ -595,14 +638,15 @@ echo '{
 
 ```json
 {
+  "command_id": "watch-text",
   "command": "observe",
   "application": "com.apple.TextEdit",
   "notifications": ["AXValueChanged", "AXSelectedTextChanged"],
   "locator": {
     "criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]
   },
-  "includeDetails": true,
-  "watchChildren": true
+  "include_element_details": ["AXRole", "AXTitle", "AXValue"],
+  "watch_children": true
 }
 ```
 
@@ -632,12 +676,10 @@ All operations are MainActor-isolated for thread safety when interacting with th
 
 ### Permission Issues
 
-Ensure your app has accessibility permissions:
+Check Accessibility permission and print recovery instructions:
 
-```json
-{
-  "command": "isProcessTrusted"
-}
+```bash
+axorc permissions
 ```
 
 ### Finding Elements
@@ -645,7 +687,7 @@ Ensure your app has accessibility permissions:
 Use the debug flag to see detailed search logs:
 
 ```bash
-axorc --file command.json --debug
+axorc raw --file command.json --debug
 ```
 
 ### Common Issues
@@ -660,15 +702,16 @@ Enable debug logging in commands:
 
 ```json
 {
+  "command_id": "debug-query",
   "command": "query",
-  "debugLogging": true,
+  "debug_logging": true,
   ...
 }
 ```
 
 ## License
 
-AXorcist is released under the MIT License. See [../LICENSE](../LICENSE) for details.
+AXorcist is released under the MIT License. See [LICENSE](LICENSE) for details.
 
 ## Contributing
 

--- a/Sources/AXorcist/Core/AXCommands.swift
+++ b/Sources/AXorcist/Core/AXCommands.swift
@@ -39,7 +39,9 @@ import Foundation
 ///
 /// ```swift
 /// // Create a query command
-/// let queryCmd = QueryCommand(appName: "Safari", searchCriteria: [.role(.button)])
+/// let queryCmd = QueryCommand(
+///     appIdentifier: "Safari",
+///     locator: Locator(criteria: [Criterion(attribute: "AXRole", value: "AXButton")]))
 /// let command = AXCommand.query(queryCmd)
 ///
 /// // Execute through AXorcist
@@ -121,7 +123,9 @@ public enum AXCommand: Sendable {
 /// ## Usage
 ///
 /// ```swift
-/// let queryCommand = QueryCommand(appName: "TextEdit", searchCriteria: [.role(.window)])
+/// let queryCommand = QueryCommand(
+///     appIdentifier: "TextEdit",
+///     locator: Locator(criteria: [Criterion(attribute: "AXRole", value: "AXWindow")]))
 /// let envelope = AXCommandEnvelope(
 ///     commandID: "find-window",
 ///     command: .query(queryCommand)
@@ -156,7 +160,7 @@ public struct AXCommandEnvelope: Sendable {
     public let command: AXCommand
 }
 
-// Individual command structs
+/// Individual command structs
 public struct QueryCommand: Sendable {
     // MARK: Lifecycle
 
@@ -400,7 +404,7 @@ public struct ObserveCommand: Sendable {
     public let maxDepthForSearch: Int
 }
 
-// Command struct for collectAll
+/// Command struct for collectAll
 public struct CollectAllCommand: Sendable {
     // MARK: Lifecycle
 
@@ -427,7 +431,7 @@ public struct CollectAllCommand: Sendable {
     public let valueFormatOption: ValueFormatOption?
 }
 
-// Batch command structures
+/// Batch command structures
 /// Command for executing multiple accessibility operations in a single batch.
 ///
 /// AXBatchCommand allows you to group multiple accessibility commands together

--- a/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
@@ -89,14 +89,9 @@ extension AXorcist {
             .debug,
             "HandleGetAttrs: Found element: \(element.briefDescription(option: ValueFormatOption.smart))")
 
-        var attributesDict: [String: AXValueWrapper] = [:]
-        for attrName in command.attributes {
-            if let value: Any = element.attribute(Attribute<Any>(attrName)) {
-                attributesDict[attrName] = AXValueWrapper(value: value)
-            } else {
-                attributesDict[attrName] = AXValueWrapper(value: nil) // Explicitly store nil for missing attributes
-            }
-        }
+        let attributesDict = self.fetchInstanceElementAttributes(
+            element: element,
+            attributeNames: command.attributes)
 
         let briefDesc = element.briefDescription(option: ValueFormatOption.smart)
         self.logQuery(
@@ -225,7 +220,9 @@ extension AXorcist {
                         includeIgnored: includeIgnored,
                         currentDepth: currentDepth + 1))
                 }
-                if childrenDescriptions?.isEmpty ?? true { childrenDescriptions = nil }
+                if childrenDescriptions?.isEmpty ?? true {
+                    childrenDescriptions = nil
+                }
             }
         }
 
@@ -242,13 +239,8 @@ extension AXorcist {
     {
         var attributesDict: [String: AXValueWrapper] = [:]
         for name in attributeNames {
-            if let value: Any = element.attribute(Attribute<Any>(name)) {
-                attributesDict[name] = AXValueWrapper(value: value)
-            } else {
-                // For attributes explicitly requested but not found, we might represent them as nil
-                // or simply omit them. Current AXValueWrapper handles nils.
-                attributesDict[name] = AXValueWrapper(value: nil)
-            }
+            let value = ValueUnwrapper.unwrap(element.rawAttributeValue(named: name))
+            attributesDict[name] = AXValueWrapper(value: value)
         }
         return attributesDict
     }

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -51,10 +51,9 @@ public class AXorcist {
     /// ## Example
     ///
     /// ```swift
-    /// let queryCommand = AXQueryCommand(
-    ///     appName: "Finder",
-    ///     searchCriteria: [.role(.window)]
-    /// )
+    /// let queryCommand = QueryCommand(
+    ///     appIdentifier: "Finder",
+    ///     locator: Locator(criteria: [Criterion(attribute: "AXRole", value: "AXWindow")]))
     /// let envelope = AXCommandEnvelope(
     ///     commandID: "find-window",
     ///     command: .query(queryCommand)
@@ -218,17 +217,18 @@ public class AXorcist {
         let hashValue = CFHash(element.underlyingElement)
         guard visited.insert(hashValue).inserted else { return }
 
-        // Apply filter criteria if provided
-        if let criteria = context.filterCriteria {
-            guard elementMatchesCriteria(element, criteria: criteria) else { return }
+        // A filter controls which elements are returned, not which branches are traversed.
+        // Descendants can match even when their parent does not.
+        let shouldInclude = context.filterCriteria.map { criteria in
+            elementMatchesCriteria(element, criteria: criteria)
+        } ?? true
+        if shouldInclude {
+            let elementData = buildQueryResponse(
+                element: element,
+                attributesToFetch: context.attributesToFetch,
+                includeChildrenBrief: false)
+            collectedElements.append(elementData)
         }
-
-        // Build element data
-        let elementData = buildQueryResponse(
-            element: element,
-            attributesToFetch: context.attributesToFetch,
-            includeChildrenBrief: false)
-        collectedElements.append(elementData)
 
         // Recursively collect children
         if let children = element.children() {

--- a/Sources/AXorcist/Core/Element.swift
+++ b/Sources/AXorcist/Core/Element.swift
@@ -23,8 +23,8 @@ import Foundation
 /// - ``actions``
 ///
 /// ### Element Operations
-/// - ``getAttribute(_:)``
-/// - ``setAttribute(_:value:)``
+/// - ``attribute(_:)``
+/// - ``setValue(_:forAttribute:)``
 /// - ``performAction(_:)``
 ///
 /// ## Usage
@@ -34,8 +34,8 @@ import Foundation
 /// let element = Element(axElement)
 ///
 /// // Get element properties
-/// let role = element.role
-/// let title = element.title
+/// let role = element.role()
+/// let title = element.title()
 ///
 /// // Perform actions
 /// try element.performAction(.press)
@@ -104,17 +104,17 @@ public struct Element: Equatable, Hashable, Sendable {
     /// this element (e.g., "AXPress", "AXShowMenu").
     public var actions: [String]?
 
-    // Implement Equatable
+    /// Implement Equatable
     public static func == (lhs: Element, rhs: Element) -> Bool {
         CFEqual(lhs.underlyingElement, rhs.underlyingElement)
     }
 
-    // Implement Hashable
+    /// Implement Hashable
     public func hash(into hasher: inout Hasher) {
         hasher.combine(CFHash(self.underlyingElement))
     }
 
-    // Generic method to get an attribute's value (converted to Swift type T)
+    /// Generic method to get an attribute's value (converted to Swift type T)
     @MainActor
     public func attribute<T>(_ attribute: Attribute<T>) -> T? {
         // Try to get from pre-fetched attributes first
@@ -300,11 +300,20 @@ public struct Element: Equatable, Hashable, Sendable {
             message: "Found '\\(attribute.rawValue)' in stored attributes."))
 
         // Attempt to convert AttributeValue to T
-        if T.self == String.self, let strValue = attributeValue.stringValue { return strValue as? T }
-        if T.self == Bool.self, let boolValue = attributeValue.boolValue { return boolValue as? T }
-        if T.self == Int.self, let intValue = attributeValue.intValue { return intValue as? T }
+        if T.self == String.self, let strValue = attributeValue.stringValue {
+            return strValue as? T
+        }
+        if T.self == Bool.self, let boolValue = attributeValue.boolValue {
+            return boolValue as? T
+        }
+        if T.self == Int.self, let intValue = attributeValue.intValue {
+            return intValue as? T
+        }
         if T.self == [Element].self,
-           let elementArray = attributeValue.anyValue as? [Element] { return elementArray as? T }
+           let elementArray = attributeValue.anyValue as? [Element]
+        {
+            return elementArray as? T
+        }
         if T.self == AXUIElement.self,
            let cfValue = attributeValue.anyValue as CFTypeRef?,
            CFGetTypeID(cfValue) == AXUIElementGetTypeID()
@@ -403,7 +412,7 @@ public struct Element: Equatable, Hashable, Sendable {
     }
 }
 
-// Path structure to represent element path
+/// Path structure to represent element path
 public struct Path {
     // MARK: Lifecycle
 

--- a/Sources/AXorcist/Documentation.docc/AXorcist.md
+++ b/Sources/AXorcist/Documentation.docc/AXorcist.md
@@ -40,9 +40,9 @@ if hasPermissions {
 ### Commands
 
 - `AXCommand`
-- `AXQueryCommand`
-- `AXActionCommand`
-- `AXGetAttributesCommand`
+- `QueryCommand`
+- `PerformActionCommand`
+- `GetAttributesCommand`
 
 ### Elements
 

--- a/Sources/AXorcist/Search/PathNavigationUtilities.swift
+++ b/Sources/AXorcist/Search/PathNavigationUtilities.swift
@@ -16,23 +16,20 @@ private func logPathNavigation(_ level: AXLogLevel, _ message: String) {
 // MARK: - Application Element Utilities
 
 @MainActor
-public func getApplicationElement(for bundleIdentifier: String) -> Element? {
-    let attemptMessage = "PN/AppEl: Attempting to get application element for bundle identifier '"
-        + "\(bundleIdentifier)'."
+public func getApplicationElement(for appIdentifier: String) -> Element? {
+    let attemptMessage = "PN/AppEl: Attempting to get application element for identifier '"
+        + "\(appIdentifier)'."
     logPathNavigation(.debug, attemptMessage)
 
-    guard let runningApp = NSWorkspace.shared.runningApplications.first(where: {
-        $0.bundleIdentifier == bundleIdentifier
-    }) else {
+    guard let processId = pid(forAppIdentifier: appIdentifier) else {
         let failureMessage =
-            "PN/AppEl: Could not find running application with bundle identifier '\(bundleIdentifier)'."
+            "PN/AppEl: Could not find running application for identifier '\(appIdentifier)'."
         logPathNavigation(.warning, failureMessage)
         return nil
     }
-    let pid = runningApp.processIdentifier
-    let appElement = Element(AXUIElementCreateApplication(pid))
+    let appElement = Element(AXUIElementCreateApplication(processId))
     let description = appElement.briefDescription(option: smartValueFormat)
-    let successMessage = "PN/AppEl: Obtained application element for '\(bundleIdentifier)' (PID: \(pid)): "
+    let successMessage = "PN/AppEl: Obtained application element for '\(appIdentifier)' (PID: \(processId)): "
         + "[\(description)]"
     logPathNavigation(.info, successMessage)
     return appElement

--- a/Sources/axorc/AXORCMain.swift
+++ b/Sources/axorc/AXORCMain.swift
@@ -4,21 +4,35 @@ import AXorcist
 @preconcurrency import Commander
 import CoreFoundation
 import Foundation
+import Logging
 
 @main
 struct AXORCCommand: ParsableCommand {
     static func main() async {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        Self.configureSwiftLogging(arguments: arguments)
         do {
-            let parsedValues = try Self.parseCommandLineArguments()
+            let frontendExitCode: Int32? = try await MainActor.run {
+                try CLIFrontend.handle(arguments: arguments)
+            }
+            if let exitCode = frontendExitCode {
+                Foundation.exit(exitCode)
+            }
+
+            let rawArguments = CLIFrontend.rawArguments(from: arguments)
+            let parsedValues = try Self.parseCommandLineArguments(arguments: rawArguments)
             var command = AXORCCommand()
             try command.apply(parsedValues: parsedValues)
             try await command.run()
+        } catch let error as CLIFrontend.UserError {
+            CLIFrontend.emit(error)
+            Foundation.exit(error.exitCode)
         } catch let error as CommanderError {
-            Self.emitArgumentError(message: error.description)
-            Foundation.exit(ExitCode.failure.rawValue)
+            Self.printErrorResponse(commandId: "argument_error", error: error.description, logs: nil)
+            Foundation.exit(2)
         } catch let validation as ValidationError {
-            Self.emitArgumentError(message: validation.description)
-            Foundation.exit(ExitCode.failure.rawValue)
+            Self.printErrorResponse(commandId: "argument_error", error: validation.description, logs: nil)
+            Foundation.exit(2)
         } catch let exitCode as ExitCode {
             Foundation.exit(exitCode.rawValue)
         } catch {
@@ -28,14 +42,13 @@ struct AXORCCommand: ParsableCommand {
     }
 
     @preconcurrency nonisolated static var commandDescription: CommandDescription {
-        let version = MainActor.assumeIsolated { axorcVersion }
-        return CommandDescription(
+        CommandDescription(
             commandName: "axorc",
-            // Use axorcVersion from AXORCModels.swift or a shared constant place
-            abstract: "AXORC CLI - Handles JSON commands via various input methods. Version \(version)")
+            abstract: "Inspect and automate macOS Accessibility from the shell.",
+            version: axorcVersion)
     }
 
-    // `--debug` now enables *normal* diagnostic output. Use the new `--verbose` flag for the extremely chatty logs.
+    /// `--debug` now enables *normal* diagnostic output. Use the new `--verbose` flag for the extremely chatty logs.
     @Flag(name: .long, help: "Enable debug logging (normal detail level). Use --verbose for maximum detail.")
     var debug: Bool = false
 
@@ -69,8 +82,12 @@ struct AXORCCommand: ParsableCommand {
     @MainActor
     private var suppressFinalLogDump = false
 
-    // Helper function to process and execute a CommandEnvelope
-    @MainActor private func processAndExecuteCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI: Bool) {
+    /// Helper function to process and execute a CommandEnvelope
+    @MainActor private func processAndExecuteCommand(
+        command: CommandEnvelope,
+        axorcist: AXorcist,
+        debugCLI: Bool) throws
+    {
         if debugCLI {
             axDebugLog("Successfully parsed command: \(command.command) (ID: \(command.commandId))")
         }
@@ -81,6 +98,10 @@ struct AXORCCommand: ParsableCommand {
             debugCLI: debugCLI)
         print(resultJsonString)
         fflush(stdout)
+
+        guard CLIFrontend.responseSucceeded(resultJsonString) else {
+            throw ExitCode.failure
+        }
 
         if command.command == .observe {
             self.handleObserveCommand(resultJsonString: resultJsonString, debugCLI: self.debug)
@@ -183,12 +204,12 @@ struct AXORCCommand: ParsableCommand {
         let axorcistInstance = AXorcist.shared
 
         if self.handleInputError(inputResult) {
-            return
+            throw ExitCode.failure
         }
 
         guard let jsonStringFromInput = inputResult.jsonString else {
             self.handleMissingInput()
-            return
+            throw ExitCode.failure
         }
 
         self.logDebug(
@@ -266,43 +287,36 @@ struct AXORCCommand: ParsableCommand {
                 commandId: "data_conversion_error",
                 error: "Failed to convert JSON string to data",
                 logs: self.debug ? axGetLogsAsStrings() : nil)
-            return
+            throw ExitCode.failure
         }
 
+        let commands: [CommandEnvelope]
         do {
-            let commands = try decoder.decode([CommandEnvelope].self, from: data)
-            self.suppressFinalLogDump = commands.contains { $0.command == .observe }
-            if let command = commands.first {
-                self.processAndExecuteCommand(command: command, axorcist: axorcist, debugCLI: self.debug)
-                return
-            }
-            self.logDebug("AXORCMain Test: Decode attempt 1: Decoded [CommandEnvelope] but array was empty.")
-            throw NSError(
-                domain: "AXORCErrorDomain",
-                code: 1001,
-                userInfo: [NSLocalizedDescriptionKey: "Decoded empty command array from [CommandEnvelope] attempt."])
+            commands = try decoder.decode([CommandEnvelope].self, from: data)
         } catch let arrayDecodeError {
-            logDebug(
-                logSegments(
-                    "AXORCMain Test: Decode attempt 1 (as [CommandEnvelope]) FAILED",
-                    "Error: \(arrayDecodeError)",
-                    "Will try as single CommandEnvelope"))
+            self.logDebug("Array decode failed: \(arrayDecodeError). Trying a single command.")
             do {
-                let command = try decoder.decode(CommandEnvelope.self, from: data)
-                suppressFinalLogDump = command.command == .observe
-                processAndExecuteCommand(command: command, axorcist: axorcist, debugCLI: debug)
+                commands = try [decoder.decode(CommandEnvelope.self, from: data)]
             } catch let singleDecodeError {
-                logDebug(
-                    logSegments(
-                        "AXORCMain Test: Decode attempt 2 (as single CommandEnvelope) ALSO FAILED",
-                        "Error: \(singleDecodeError)",
-                        "Original array decode error was: \(arrayDecodeError)"))
-                respondWithError(
+                self.logDebug("Single-command decode failed: \(singleDecodeError).")
+                self.respondWithError(
                     commandId: "decode_error",
                     error: "Failed to decode JSON input: \(singleDecodeError.localizedDescription)",
-                    logs: debug ? axGetLogsAsStrings() : nil)
+                    logs: self.debug ? axGetLogsAsStrings() : nil)
+                throw ExitCode.failure
             }
         }
+
+        guard let command = commands.first else {
+            self.respondWithError(
+                commandId: "decode_error",
+                error: "JSON command array must not be empty",
+                logs: self.debug ? axGetLogsAsStrings() : nil)
+            throw ExitCode.failure
+        }
+
+        self.suppressFinalLogDump = command.command == .observe
+        try self.processAndExecuteCommand(command: command, axorcist: axorcist, debugCLI: self.debug)
     }
 
     private func flushDebugLogs() {
@@ -326,12 +340,11 @@ struct AXORCCommand: ParsableCommand {
 // MARK: - Commander Parsing
 
 extension AXORCCommand {
-    private static func parseCommandLineArguments() throws -> ParsedValues {
+    private static func parseCommandLineArguments(arguments: [String]) throws -> ParsedValues {
         let prototype = Self()
         let signature = CommandSignature.describe(prototype)
         let parser = CommandParser(signature: signature)
-        let rawArguments = Array(CommandLine.arguments.dropFirst())
-        return try parser.parse(arguments: rawArguments)
+        return try parser.parse(arguments: arguments)
     }
 
     private mutating func apply(parsedValues: ParsedValues) throws {
@@ -359,10 +372,6 @@ extension AXORCCommand {
         self.directPayload = parsedValues.positional.first
     }
 
-    private static func emitArgumentError(message: String) {
-        self.printErrorResponse(commandId: "argument_error", error: message, logs: nil)
-    }
-
     private static func printErrorResponse(commandId: String, error: String, logs: [String]?) {
         let errorResponse = ErrorResponse(commandId: commandId, error: error, debugLogs: logs)
         let encoder = JSONEncoder()
@@ -374,6 +383,22 @@ extension AXORCCommand {
             print(jsonString)
         } else {
             print("{\"error\": \"Failed to encode error response\"}")
+        }
+    }
+
+    private static func configureSwiftLogging(arguments: [String]) {
+        let level: Logger.Level = if arguments.contains("--verbose") {
+            .trace
+        } else if arguments.contains("--debug") {
+            .debug
+        } else {
+            .critical
+        }
+
+        LoggingSystem.bootstrap { label in
+            var handler = StreamLogHandler.standardError(label: label)
+            handler.logLevel = level
+            return handler
         }
     }
 }

--- a/Sources/axorc/CLIFrontend.swift
+++ b/Sources/axorc/CLIFrontend.swift
@@ -1,0 +1,385 @@
+import ApplicationServices
+import AXorcist
+@preconcurrency import Commander
+import Foundation
+
+enum CLIFrontend {
+    struct UserError: Error {
+        let message: String
+        let exitCode: Int32
+        let helpTopic: String?
+
+        init(_ message: String, exitCode: Int32 = 2, helpTopic: String? = nil) {
+            self.message = message
+            self.exitCode = exitCode
+            self.helpTopic = helpTopic
+        }
+    }
+
+    private struct FindOptions: ParsableCommand {
+        @Option(names: [.short("a"), .long("app")], help: "Application name, bundle identifier, PID, or 'focused'.")
+        var app: String?
+
+        @Option(name: .long, help: "Accessibility role, for example AXButton.")
+        var role: String?
+
+        @Option(name: .long, help: "Element title.")
+        var title: String?
+
+        @Option(name: .long, help: "Accessibility identifier.")
+        var identifier: String?
+
+        @Option(name: .long, help: "Element value.")
+        var value: String?
+
+        @Option(name: .long, help: "Attribute to include. Repeatable.")
+        var attribute: String?
+
+        @Option(name: .long, help: "Maximum traversal depth (default: 10).")
+        var depth: String?
+
+        @Flag(name: .long, help: "Use case-insensitive substring matching.")
+        var contains = false
+
+        @Flag(names: [.short("j"), .long("json")], help: "Emit the complete JSON response.")
+        var json = false
+    }
+
+    private struct TreeOptions: ParsableCommand {
+        @Option(names: [.short("a"), .long("app")], help: "Application name, bundle identifier, PID, or 'focused'.")
+        var app: String?
+
+        @Option(name: .long, help: "Maximum traversal depth (default: 3).")
+        var depth: String?
+
+        @Option(name: .long, help: "Only include elements with this accessibility role.")
+        var role: String?
+
+        @Flag(names: [.short("j"), .long("json")], help: "Emit the complete JSON response.")
+        var json = false
+    }
+
+    private struct PermissionsOptions: ParsableCommand {
+        @Flag(names: [.short("j"), .long("json")], help: "Emit JSON.")
+        var json = false
+    }
+
+    @MainActor
+    static func handle(arguments: [String]) throws -> Int32? {
+        guard let first = arguments.first else {
+            Swift.print(self.help())
+            return 0
+        }
+
+        switch first {
+        case "-h", "--help":
+            Swift.print(self.help())
+            return 0
+        case "--version":
+            Swift.print("axorc \(axorcVersion)")
+            return 0
+        case "help":
+            let topic = arguments.dropFirst().first
+            if let topic, !["permissions", "find", "tree", "raw"].contains(topic) {
+                throw UserError("Unknown help topic '\(topic)'.")
+            }
+            Swift.print(self.help(topic: topic))
+            return 0
+        case "permissions":
+            return try self.runPermissions(arguments: Array(arguments.dropFirst()))
+        case "find":
+            return try self.runFind(arguments: Array(arguments.dropFirst()))
+        case "tree":
+            return try self.runTree(arguments: Array(arguments.dropFirst()))
+        case "raw":
+            if arguments.dropFirst().contains(where: { $0 == "-h" || $0 == "--help" }) {
+                Swift.print(self.help(topic: "raw"))
+                return 0
+            }
+            return nil
+        default:
+            let trimmedFirst = first.trimmingCharacters(in: .whitespacesAndNewlines)
+            if first.hasPrefix("-") || trimmedFirst.hasPrefix("{") || trimmedFirst.hasPrefix("[") {
+                return nil
+            }
+            throw UserError("Unknown command '\(first)'.")
+        }
+    }
+
+    static func rawArguments(from arguments: [String]) -> [String] {
+        arguments.first == "raw" ? Array(arguments.dropFirst()) : arguments
+    }
+
+    static func emit(_ error: UserError) {
+        fputs("Error: \(error.message)\n", stderr)
+        let helpCommand = error.helpTopic.map { "axorc help \($0)" } ?? "axorc --help"
+        fputs("Run '\(helpCommand)' for usage.\n", stderr)
+        fflush(stderr)
+    }
+
+    static func responseSucceeded(_ response: String) -> Bool {
+        guard let object = self.object(from: response) else { return false }
+        if let success = object["success"] as? Bool {
+            return success
+        }
+        if let status = object["status"] as? String {
+            return status == "success" || status == "pong" || status == "observer_started"
+        }
+        return object["error"] == nil
+    }
+
+    @MainActor
+    private static func runPermissions(arguments: [String]) throws -> Int32 {
+        let parsed = try self.parse(PermissionsOptions(), arguments: arguments, topic: "permissions")
+        let trusted = AXIsProcessTrusted()
+        if parsed.flags.contains("json") {
+            Swift.print("{\"accessibility\":\(trusted ? "true" : "false")}")
+        } else {
+            Swift.print("Accessibility: \(trusted ? "granted" : "missing")")
+            if !trusted {
+                Swift.print("Grant access in System Settings > Privacy & Security > Accessibility.")
+            }
+        }
+        return trusted ? 0 : 1
+    }
+
+    @MainActor
+    private static func runFind(arguments: [String]) throws -> Int32 {
+        let parsed = try self.parse(FindOptions(), arguments: arguments, topic: "find")
+        let app = try self.requiredOption("app", in: parsed, topic: "find")
+        let depth = try self.depth(from: parsed, defaultValue: 10, topic: "find")
+        let matchType: JSONPathHintComponent.MatchType = parsed.flags.contains("contains") ? .contains : .exact
+
+        let criterionOptions = [
+            ("role", "AXRole"),
+            ("title", "AXTitle"),
+            ("identifier", "AXIdentifier"),
+            ("value", "AXValue"),
+        ]
+        let criteria = criterionOptions.compactMap { label, attribute -> Criterion? in
+            guard let value = parsed.options[label]?.last else { return nil }
+            return Criterion(attribute: attribute, value: value, matchType: matchType)
+        }
+        guard !criteria.isEmpty else {
+            throw UserError(
+                "Provide at least one of --role, --title, --identifier, or --value.",
+                helpTopic: "find")
+        }
+
+        let defaultAttributes = ["AXRole", "AXTitle", "AXDescription", "AXIdentifier", "AXValue", "AXEnabled"]
+        let attributes = parsed.options["attribute"] ?? defaultAttributes
+        let envelope = CommandEnvelope(
+            commandId: "find",
+            command: .query,
+            application: app,
+            attributes: attributes,
+            locator: Locator(criteria: criteria),
+            maxDepth: depth)
+        return try self.execute(envelope, json: parsed.flags.contains("json"), renderer: self.renderFind)
+    }
+
+    @MainActor
+    private static func runTree(arguments: [String]) throws -> Int32 {
+        let parsed = try self.parse(TreeOptions(), arguments: arguments, topic: "tree")
+        let app = try self.requiredOption("app", in: parsed, topic: "tree")
+        let depth = try self.depth(from: parsed, defaultValue: 3, topic: "tree")
+        let role = parsed.options["role"]?.last
+        let envelope = CommandEnvelope(
+            commandId: "tree",
+            command: .collectAll,
+            application: app,
+            attributes: ["AXRole", "AXTitle", "AXDescription", "AXIdentifier", "AXValue"],
+            maxDepth: depth,
+            filterCriteria: role.map { ["AXRole": $0] })
+        let renderer = role == nil ? self.renderTree : self.renderFlatTree
+        return try self.execute(envelope, json: parsed.flags.contains("json"), renderer: renderer)
+    }
+
+    @MainActor
+    private static func execute(
+        _ envelope: CommandEnvelope,
+        json: Bool,
+        renderer: ([String: Any]) throws -> String) throws -> Int32
+    {
+        let response = CommandExecutor.execute(command: envelope, axorcist: AXorcist.shared, debugCLI: false)
+        guard let object = self.object(from: response) else {
+            throw UserError("AXorcist returned malformed JSON.", exitCode: 1)
+        }
+        guard self.responseSucceeded(response) else {
+            if json {
+                Swift.print(response)
+                return 1
+            }
+            throw UserError(
+                self.errorMessage(from: object) ?? "Accessibility operation failed.",
+                exitCode: 1)
+        }
+
+        if json {
+            Swift.print(response)
+        } else {
+            try Swift.print(renderer(object))
+        }
+        return 0
+    }
+
+    @MainActor
+    private static func parse(
+        _ command: some ParsableCommand,
+        arguments: [String],
+        topic: String) throws -> ParsedValues
+    {
+        if arguments.contains(where: { $0 == "-h" || $0 == "--help" }) {
+            Swift.print(self.help(topic: topic))
+            throw ExitCode.success
+        }
+        do {
+            return try CommandParser(signature: CommandSignature.describe(command)).parse(arguments: arguments)
+        } catch let error as CommanderError {
+            throw UserError(error.description, helpTopic: topic)
+        }
+    }
+
+    private static func requiredOption(_ name: String, in values: ParsedValues, topic: String) throws -> String {
+        guard let value = values.options[name]?.last, !value.isEmpty else {
+            throw UserError("Missing required option --\(name).", helpTopic: topic)
+        }
+        return value
+    }
+
+    private static func depth(from values: ParsedValues, defaultValue: Int, topic: String) throws -> Int {
+        guard let raw = values.options["depth"]?.last else { return defaultValue }
+        guard let value = Int(raw), (1...100).contains(value) else {
+            throw UserError("--depth must be an integer from 1 through 100.", helpTopic: topic)
+        }
+        return value
+    }
+
+    private static func object(from response: String) -> [String: Any]? {
+        guard let data = response.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func errorMessage(from object: [String: Any]) -> String? {
+        if let error = object["error"] as? String {
+            return error
+        }
+        if let error = object["error"] as? [String: Any], let message = error["message"] as? String {
+            return message
+        }
+        return object["message"] as? String
+    }
+
+    static func help(topic: String? = nil) -> String {
+        switch topic {
+        case "permissions": self.permissionsHelp
+        case "find": self.findHelp
+        case "tree": self.treeHelp
+        case "raw": self.rawHelp
+        default: self.rootHelp
+        }
+    }
+
+    private static let permissionsHelp = """
+    OVERVIEW: Check whether axorc can use macOS Accessibility.
+
+    USAGE: axorc permissions [--json]
+
+    OPTIONS:
+      -j, --json  Emit JSON.
+      -h, --help  Show help.
+    """
+
+    private static let findHelp = """
+    OVERVIEW: Find one accessibility element.
+
+    USAGE: axorc find --app <app> [criteria] [options]
+
+    CRITERIA:
+      --role <role>              Accessibility role, such as AXButton.
+      --title <title>            Element title.
+      --identifier <identifier>  Accessibility identifier.
+      --value <value>            Element value.
+
+    OPTIONS:
+      -a, --app <app>            Name, bundle identifier, PID, or 'focused'.
+      --contains                 Use case-insensitive substring matching.
+      --attribute <name>         Attribute to include. Repeatable.
+      --depth <number>           Traversal depth (default: 10).
+      -j, --json                 Emit the complete JSON response.
+      -h, --help                 Show help.
+
+    EXAMPLE:
+      axorc find --app Safari --role AXButton --title Back
+    """
+
+    private static let treeHelp = """
+    OVERVIEW: Print an application's accessibility tree.
+
+    USAGE: axorc tree --app <app> [options]
+
+    OPTIONS:
+      -a, --app <app>   Name, bundle identifier, PID, or 'focused'.
+      --depth <number>  Traversal depth (default: 3).
+      --role <role>     Only include this accessibility role.
+      -j, --json        Emit the complete JSON response.
+      -h, --help        Show help.
+
+    EXAMPLE:
+      axorc tree --app com.apple.dock --depth 3
+    """
+
+    private static let rawHelp = """
+    OVERVIEW: Execute the stable JSON command protocol.
+
+    USAGE:
+      axorc raw --stdin
+      axorc raw --file <path>
+      axorc raw --json <payload>
+      axorc raw '<payload>'
+
+    RAW OPTIONS:
+      --stdin          Read JSON from standard input.
+      --file <path>    Read JSON from a file.
+      --json <json>    Read JSON from an argument.
+      --timeout <sec>  Override the 30-second traversal timeout.
+      --scan-all       Disable container pruning.
+      --no-stop-first  Continue below the first match.
+      --debug          Include normal diagnostic logs.
+      --verbose        Include maximum diagnostic logs.
+
+    Every command requires command_id and command fields. Legacy root-level
+    raw invocations remain supported.
+
+    EXAMPLE:
+      echo '{"command_id":"health","command":"ping"}' | axorc raw --stdin
+    """
+
+    private static let rootHelp = """
+    OVERVIEW: Inspect and automate macOS Accessibility from the shell.
+
+    USAGE:
+      axorc <command> [options]
+      axorc raw <json-input-options>
+
+    COMMANDS:
+      permissions  Check Accessibility permission.
+      find         Find one element by role, title, identifier, or value.
+      tree         Print an application's accessibility tree.
+      raw          Execute the complete JSON automation protocol.
+      help         Show help for a command.
+
+    OPTIONS:
+      -h, --help  Show help.
+      --version   Show the version.
+
+    EXAMPLES:
+      axorc permissions
+      axorc tree --app com.apple.dock --depth 2
+      axorc find --app Safari --role AXButton --title Back
+      echo '{"command_id":"health","command":"ping"}' | axorc raw --stdin
+
+    Accessibility permission required for inspection and automation.
+    Documentation: https://github.com/openclaw/AXorcist#command-line-tool
+    """
+}

--- a/Sources/axorc/CLIOutputRenderer.swift
+++ b/Sources/axorc/CLIOutputRenderer.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+extension CLIFrontend {
+    static func renderFind(_ object: [String: Any]) throws -> String {
+        guard let data = object["data"] as? [String: Any] else {
+            throw UserError("Find response contained no element.", exitCode: 1)
+        }
+        if let description = data["brief_description"] as? String, !description.isEmpty {
+            return self.sanitizeForTerminal(description)
+        }
+        if let text = data["textual_content"] as? String, !text.isEmpty {
+            return self.sanitizeForTerminal(text)
+        }
+        throw UserError("Found an element, but it had no printable description.", exitCode: 1)
+    }
+
+    static func renderTree(_ object: [String: Any]) throws -> String {
+        guard
+            let data = object["data"] as? [String: Any],
+            let elements = data["elements"] as? [[String: Any]]
+        else {
+            throw UserError("Tree response contained no elements.", exitCode: 1)
+        }
+        guard !elements.isEmpty else { return "No elements found." }
+
+        let lines = elements.map { element -> (depth: Int, description: String) in
+            let pathCount = (element["path"] as? [Any])?.count ?? 1
+            let pathDepth = max(0, pathCount - 1)
+            let description = element["brief_description"] as? String
+                ?? element["textual_content"] as? String
+                ?? "Unknown element"
+            return (pathDepth, self.sanitizeForTerminal(description))
+        }
+        let minimumDepth = lines.map(\.depth).min() ?? 0
+        return lines.map { line in
+            String(repeating: "  ", count: line.depth - minimumDepth) + line.description
+        }.joined(separator: "\n")
+    }
+
+    static func renderFlatTree(_ object: [String: Any]) throws -> String {
+        guard
+            let data = object["data"] as? [String: Any],
+            let elements = data["elements"] as? [[String: Any]]
+        else {
+            throw UserError("Tree response contained no elements.", exitCode: 1)
+        }
+        guard !elements.isEmpty else { return "No elements found." }
+
+        return elements.map { element in
+            let description = element["brief_description"] as? String
+                ?? element["textual_content"] as? String
+                ?? "Unknown element"
+            return self.sanitizeForTerminal(description)
+        }.joined(separator: "\n")
+    }
+
+    static func sanitizeForTerminal(_ value: String) -> String {
+        value.unicodeScalars.map { scalar in
+            switch scalar.value {
+            case 0x09: "\\t"
+            case 0x0A: "\\n"
+            case 0x0D: "\\r"
+            case 0x2028: "\\u{2028}"
+            case 0x2029: "\\u{2029}"
+            default:
+                if CharacterSet.controlCharacters.contains(scalar) {
+                    "\\u{\(String(scalar.value, radix: 16, uppercase: true))}"
+                } else {
+                    String(scalar)
+                }
+            }
+        }.joined()
+    }
+}

--- a/Sources/axorc/Models/AXORCModels.swift
+++ b/Sources/axorc/Models/AXORCModels.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - Version and Configuration
 
-let axorcVersion = "0.1.3"
+nonisolated let axorcVersion = "0.1.6"
 
 /// Returns a human-readable build stamp (yyMMddHHmm) evaluated at runtime.
 /// Good enough for confirming we're on the binary we just built.
@@ -20,7 +20,7 @@ var axorcBuildStamp: String {
 
 // MARK: - Shared Error Detail
 
-// Moved ErrorDetail to be a top-level struct
+/// Moved ErrorDetail to be a top-level struct
 struct ErrorDetail: Codable {
     let message: String
 }
@@ -94,7 +94,7 @@ struct AXElementForEncoding: Codable {
 struct QueryResponse: Codable {
     // MARK: Lifecycle
 
-    // Custom initializer to bridge from HandlerResponse (from AXorcist module)
+    /// Custom initializer to bridge from HandlerResponse (from AXorcist module)
     init(commandId: String, success: Bool, command: String, handlerResponse: HandlerResponse, debugLogs: [String]?) {
         self.commandId = commandId
         self.success = success
@@ -114,7 +114,7 @@ struct QueryResponse: Codable {
         self.debugLogs = debugLogs
     }
 
-    // Legacy initializer for compatibility
+    /// Legacy initializer for compatibility
     init(
         success: Bool = true,
         commandId: String? = nil,
@@ -169,7 +169,7 @@ struct BatchResponse: Codable {
     let debugLogs: [String]?
 }
 
-// For batch operations that may have mixed results
+/// For batch operations that may have mixed results
 struct BatchQueryResponse: Codable {
     enum CodingKeys: String, CodingKey {
         case commandId
@@ -188,7 +188,7 @@ struct BatchQueryResponse: Codable {
     var debugLogs: [String]?
 }
 
-// Generic query response for commands (renamed to avoid conflict)
+/// Generic query response for commands (renamed to avoid conflict)
 struct GenericQueryResponse: Codable {
     enum CodingKeys: String, CodingKey {
         case commandId
@@ -207,7 +207,7 @@ struct GenericQueryResponse: Codable {
     var debugLogs: [String]?
 }
 
-// Helper for DecodingError display
+/// Helper for DecodingError display
 extension DecodingError {
     var humanReadableDescription: String {
         switch self {

--- a/Tests/AXorcistTests/ApplicationQueryTests.swift
+++ b/Tests/AXorcistTests/ApplicationQueryTests.swift
@@ -2,7 +2,7 @@ import AppKit
 import Testing
 @testable import AXorcist
 
-// Helper type for decoding arbitrary JSON values
+/// Helper type for decoding arbitrary JSON values
 struct AnyDecodable: Decodable {
     let value: Any
 
@@ -34,10 +34,9 @@ struct AnyDecodable: Decodable {
 @Suite("AXorcist Application Query Tests", .tags(.safe))
 struct ApplicationQueryTests {
     @Test(
-        "Collect all elements in the frontmost application",
         .tags(.automation),
         .enabled(if: AXTestEnvironment.runAutomationScenarios))
-    func collectAllFromFrontmostApplication() async throws {
+    func `Collect all elements in the frontmost application`() throws {
         let command = CommandEnvelope(
             commandId: "test-get-all-apps",
             command: .collectAll,
@@ -87,11 +86,57 @@ struct ApplicationQueryTests {
     }
 
     @Test(
-        "List TextEdit windows",
+        .tags(.automation),
+        .enabled(if: AXTestEnvironment.runAutomationScenarios))
+    func `CollectAll filters descendants without pruning their parents`() throws {
+        let json = """
+        {
+          "command_id": "test-filter-descendants",
+          "command": "collectAll",
+          "application": "com.apple.dock",
+          "attributes": ["AXRole", "AXTitle"],
+          "max_depth": 3,
+          "filter_criteria": {"AXRole": "AXDockItem"}
+        }
+        """
+        let result = try runAXORCCommand(arguments: [json])
+
+        #expect(result.exitCode == 0)
+        let outputData = try #require(result.output?.data(using: String.Encoding.utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: outputData) as? [String: Any])
+        let responseData = try #require(object["data"] as? [String: Any])
+        let elements = try #require(responseData["elements"] as? [[String: Any]])
+        #expect(!elements.isEmpty)
+        #expect(elements.allSatisfy { $0["role"] as? String == "AXDockItem" })
+    }
+
+    @Test(
+        .tags(.automation),
+        .enabled(if: AXTestEnvironment.runAutomationScenarios))
+    func `Human CLI resolves app names and returns requested attributes`() throws {
+        let result = try runAXORCCommand(arguments: [
+            "find",
+            "--app", "Dock",
+            "--role", "AXApplication",
+            "--attribute", "AXRole",
+            "--json",
+        ])
+
+        #expect(result.exitCode == 0)
+        #expect(result.errorOutput?.isEmpty ?? true)
+        let outputData = try #require(result.output?.data(using: String.Encoding.utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: outputData) as? [String: Any])
+        let responseData = try #require(object["data"] as? [String: Any])
+        let attributes = try #require(responseData["attributes"] as? [String: Any])
+        let role = try #require(attributes["AXRole"] as? [String: Any])
+        #expect(role["any_value"] as? String == "AXApplication")
+    }
+
+    @Test(
         .tags(.automation),
         .enabled(if: AXTestEnvironment.runAutomationScenarios))
     @MainActor
-    func getWindowsOfApplication() async throws {
+    func `List TextEdit windows`() async throws {
         await closeTextEdit()
         try await Task.sleep(for: .milliseconds(500))
 
@@ -140,8 +185,8 @@ struct ApplicationQueryTests {
         }
     }
 
-    @Test("Query non-existent application", .tags(.safe))
-    func queryNonExistentApp() async throws {
+    @Test(.tags(.safe))
+    func `Query non-existent application`() throws {
         let command = CommandEnvelope(
             commandId: "test-nonexistent",
             command: .query,
@@ -157,7 +202,7 @@ struct ApplicationQueryTests {
 
         let result = try runAXORCCommand(arguments: [jsonString])
 
-        #expect(result.exitCode == 0, "Command should succeed even when no elements found")
+        #expect(result.exitCode == 1, "Missing applications should return a failure exit status")
 
         guard let output = result.output,
               let responseData = output.data(using: String.Encoding.utf8)

--- a/Tests/AXorcistTests/CLIFrontendTests.swift
+++ b/Tests/AXorcistTests/CLIFrontendTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import axorc
+@testable import AXorcist
+
+@Suite("axorc user-facing CLI", .tags(.safe))
+struct CLIFrontendTests {
+    @Test
+    func `Help and version are discoverable`() throws {
+        let help = try runAXORCCommand(arguments: ["--help", "--not-a-real-flag"])
+        #expect(help.exitCode == 0)
+        #expect(help.output?.contains("COMMANDS:") == true)
+        #expect(help.output?.contains("permissions") == true)
+        #expect(help.errorOutput?.isEmpty ?? true)
+
+        let version = try runAXORCCommand(arguments: ["--version"])
+        #expect(version.exitCode == 0)
+        #expect(version.output?.hasPrefix("axorc 0.") == true)
+        #expect(version.errorOutput?.isEmpty ?? true)
+    }
+
+    @Test
+    func `Subcommand help ignores other arguments`() throws {
+        let result = try runAXORCCommand(arguments: ["find", "--garbage", "--help"])
+        #expect(result.exitCode == 0)
+        #expect(result.output?.contains("USAGE: axorc find") == true)
+        #expect(result.errorOutput?.isEmpty ?? true)
+    }
+
+    @Test
+    func `Unknown commands use usage exit status and stderr`() throws {
+        let result = try runAXORCCommand(arguments: ["frobnicate"])
+        #expect(result.exitCode == 2)
+        #expect(result.output?.isEmpty ?? true)
+        #expect(result.errorOutput?.contains("Unknown command 'frobnicate'") == true)
+        #expect(result.errorOutput?.contains("axorc --help") == true)
+    }
+
+    @Test
+    func `Find validates required options before Accessibility access`() throws {
+        let missingApp = try runAXORCCommand(arguments: ["find", "--role", "AXButton"])
+        #expect(missingApp.exitCode == 2)
+        #expect(missingApp.errorOutput?.contains("Missing required option --app") == true)
+
+        let missingCriteria = try runAXORCCommand(arguments: ["find", "--app", "Finder"])
+        #expect(missingCriteria.exitCode == 2)
+        #expect(missingCriteria.errorOutput?.contains("Provide at least one") == true)
+    }
+
+    @Test
+    func `Permissions JSON is stable and truthful`() throws {
+        let result = try runAXORCCommand(arguments: ["permissions", "--json"])
+        #expect(result.exitCode == 0 || result.exitCode == 1)
+        #expect(result.errorOutput?.isEmpty ?? true)
+
+        let data = try #require(result.output?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["accessibility"] is Bool)
+    }
+
+    @Test
+    func `Raw subcommand and legacy invocation both execute JSON`() throws {
+        let payload = "{\"command_id\":\"compat\",\"command\":\"ping\"}"
+        let raw = try runAXORCCommand(arguments: ["raw", payload])
+        let legacy = try runAXORCCommand(arguments: [payload])
+        let whitespacePrefixedLegacy = try runAXORCCommand(arguments: [" \n\t\(payload)"])
+
+        #expect(raw.exitCode == 0)
+        #expect(legacy.exitCode == 0)
+        #expect(whitespacePrefixedLegacy.exitCode == 0)
+        #expect(raw.output?.contains("\"success\":true") == true)
+        #expect(legacy.output?.contains("\"success\":true") == true)
+        #expect(whitespacePrefixedLegacy.output?.contains("\"success\":true") == true)
+    }
+
+    @Test
+    func `Malformed raw commands fail with JSON on stdout`() throws {
+        let result = try runAXORCCommand(arguments: ["raw", "{\"command\":\"ping\"}"])
+        #expect(result.exitCode == 1)
+        #expect(result.errorOutput?.isEmpty ?? true)
+
+        let data = try #require(result.output?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["success"] as? Bool == false)
+        #expect(object["command_id"] as? String == "decode_error")
+    }
+
+    @Test
+    func `JSON mode preserves operation failures as JSON`() throws {
+        let result = try runAXORCCommand(arguments: [
+            "find",
+            "--app", "com.example.axorc.missing",
+            "--role", "AXApplication",
+            "--json",
+        ])
+
+        #expect(result.exitCode == 1)
+        #expect(result.errorOutput?.isEmpty ?? true)
+        let data = try #require(result.output?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["status"] as? String == "error")
+        #expect(object["error"] is String)
+    }
+
+    @Test
+    func `Raw argument failures remain structured JSON`() throws {
+        let result = try runAXORCCommand(arguments: ["raw", "--file"])
+
+        #expect(result.exitCode == 2)
+        #expect(result.errorOutput?.isEmpty ?? true)
+        let data = try #require(result.output?.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["success"] as? Bool == false)
+        #expect(object["command_id"] as? String == "argument_error")
+    }
+
+    @Test
+    func `Human output visibly escapes terminal controls`() {
+        let input = "title\nnext\t\u{1B}]52;clipboard\u{7}"
+        let sanitized = CLIFrontend.sanitizeForTerminal(input)
+
+        #expect(sanitized == "title\\nnext\\t\\u{1B}]52;clipboard\\u{7}")
+    }
+
+    @Test
+    func `Filtered tree output does not invent ancestry`() throws {
+        let object: [String: Any] = [
+            "data": [
+                "elements": [
+                    ["brief_description": "Sibling", "path": ["root", "first"]],
+                    ["brief_description": "Unrelated deep match", "path": ["root", "second", "child"]],
+                ],
+            ],
+        ]
+
+        #expect(try CLIFrontend.renderFlatTree(object) == "Sibling\nUnrelated deep match")
+    }
+}

--- a/Tests/AXorcistTests/PingIntegrationTests.swift
+++ b/Tests/AXorcistTests/PingIntegrationTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @Suite("AXorcist Ping Integration Tests", .tags(.safe))
 struct PingIntegrationTests {
-    @Test("Ping via stdin", .tags(.safe))
-    func pingViaStdin() async throws {
+    @Test(.tags(.safe))
+    func `Ping via stdin`() throws {
         let inputJSON = """
         {
             "command_id": "test_ping_stdin",
@@ -45,8 +45,8 @@ struct PingIntegrationTests {
         #expect(decodedResponse.details == "Hello from testPingViaStdin")
     }
 
-    @Test("Ping via file input", .tags(.safe))
-    func pingViaFile() async throws {
+    @Test(.tags(.safe))
+    func `Ping via file input`() throws {
         let payloadMessage = "Hello from testPingViaFile"
         let inputJSON = """
         {
@@ -84,8 +84,8 @@ struct PingIntegrationTests {
         #expect(decodedResponse.details == payloadMessage)
     }
 
-    @Test("Ping via direct payload argument", .tags(.safe))
-    func pingViaDirectPayload() async throws {
+    @Test(.tags(.safe))
+    func `Ping via direct payload argument`() throws {
         let payloadMessage = "Hello from testPingViaDirectPayload"
         let inputJSON = """
         {"command_id":"test_ping_direct","command":"ping","payload":{"message":"\(payloadMessage)"}}
@@ -117,8 +117,8 @@ struct PingIntegrationTests {
         #expect(decodedResponse.details == payloadMessage)
     }
 
-    @Test("Reject multiple input sources", .tags(.safe))
-    func errorMultipleInputMethods() async throws {
+    @Test(.tags(.safe))
+    func `Reject multiple input sources`() throws {
         let inputJSON = """
         {
             "command_id": "test_error_multiple_inputs",
@@ -134,11 +134,11 @@ struct PingIntegrationTests {
             arguments: ["--file", tempFilePath])
 
         let multiInputMessage = """
-        axorc command should return 0 with error on stdout.
+        axorc command should return 1 with error JSON on stdout.
         Status: \(result.exitCode). Error STDOUT: \(result.output ?? "nil").
         Error STDERR: \(result.errorOutput ?? "nil")
         """
-        #expect(result.exitCode == 0, Comment(multiInputMessage))
+        #expect(result.exitCode == 1, Comment(multiInputMessage))
 
         guard let outputString = result.output, !outputString.isEmpty else {
             Issue.record("Output was nil or empty for multiple input methods error test")
@@ -155,27 +155,13 @@ struct PingIntegrationTests {
             "Unexpected error message: \(errorResponse.error.message)")
     }
 
-    @Test("Reject ping without input", .tags(.safe))
-    func errorNoInputProvidedForPing() async throws {
+    @Test(.tags(.safe))
+    func `Show help without arguments`() throws {
         let result = try runAXORCCommand(arguments: [])
 
-        let noInputMessage = """
-        axorc should return 0 with error on stdout. Status: \(result.exitCode).
-        Error STDOUT: \(result.output ?? "nil"). Error STDERR: \(result.errorOutput ?? "nil")
-        """
-        #expect(result.exitCode == 0, Comment(noInputMessage))
-
-        guard let outputString = result.output, !outputString.isEmpty else {
-            Issue.record("Output was nil or empty for no input test.")
-            return
-        }
-        guard let responseData = outputString.data(using: .utf8) else {
-            Issue.record("Failed to convert output to Data for no input error. Output: \(outputString)")
-            return
-        }
-        let errorResponse = try JSONDecoder().decode(ErrorResponse.self, from: responseData)
-        #expect(errorResponse.success == false)
-        let commandIdMessage = "Expected commandId to be input_error, got \(errorResponse.commandId)"
-        #expect(errorResponse.commandId == "input_error", Comment(commandIdMessage))
+        #expect(result.exitCode == 0)
+        #expect(result.output?.contains("USAGE:") == true)
+        #expect(result.output?.contains("axorc tree") == true)
+        #expect(result.errorOutput?.isEmpty ?? true)
     }
 }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,43 @@
+# Releasing `axorc`
+
+The Homebrew formula consumes a Developer ID-signed universal binary. Do not publish the ad-hoc artifact produced by `--adhoc`; a stable signature keeps the macOS Accessibility identity consistent across upgrades.
+
+## Prepare
+
+1. Update `axorcVersion` in `Sources/axorc/Models/AXORCModels.swift` and move the changelog entries into the matching release section.
+2. Run `swift test`, SwiftFormat, SwiftLint, the live CLI smoke checks, and autoreview.
+3. Build with the existing Developer ID Application identity:
+
+   ```bash
+   AXORC_CODESIGN_IDENTITY='Developer ID Application: ...' scripts/build-release-artifact.sh 0.1.6
+   ```
+
+4. Submit `dist/axorc-0.1.6-macos-universal.zip` to `notarytool` using the approved release credentials. Wait for acceptance. Zip archives cannot be stapled; verify the downloaded archive online with Gatekeeper after publication.
+
+## Publish and update Homebrew
+
+1. Upload the zip and `.sha256` file to the matching GitHub Release.
+2. Download the public artifact into a clean temporary directory. Verify its checksum, universal architectures, stable signature, `spctl` assessment, `--version`, and `--help`.
+3. Render the formula with the public artifact checksum:
+
+   ```bash
+   scripts/render-homebrew-formula.sh 0.1.6 <sha256> > axorc.rb
+   ```
+
+4. Add `axorc.rb` to `openclaw/homebrew-tap`, then run `brew audit --strict axorc`, `brew install --build-from-source ./axorc.rb`, `axorc --version`, `axorc --help`, and `axorc permissions` on a clean host.
+5. Confirm Homebrew preserved the published executable byte-for-byte and retained its Developer ID requirement:
+
+   ```bash
+   cmp axorc "$(brew --prefix axorc)/bin/axorc"
+   codesign --verify --strict "$(brew --prefix axorc)/bin/axorc"
+   codesign -d -r- "$(brew --prefix axorc)/bin/axorc"
+   ```
+
+   The designated requirement must contain `anchor apple generic`; an ad-hoc requirement is a release blocker.
+6. After the tap change lands, update the README with `brew install openclaw/tap/axorc` and verify a fresh public installation.
+
+## Close out
+
+- Confirm the GitHub Release contains the signed universal archive and checksum.
+- Confirm the Homebrew formula uses the public archive URL and exact checksum.
+- Open the next patch `Unreleased` section and commit it.

--- a/packaging/homebrew/axorc.rb.template
+++ b/packaging/homebrew/axorc.rb.template
@@ -1,0 +1,29 @@
+class Axorc < Formula
+  desc "Inspect and automate macOS Accessibility from the shell"
+  homepage "https://github.com/openclaw/AXorcist"
+  url "https://github.com/openclaw/AXorcist/releases/download/v@VERSION@/axorc-@VERSION@-macos-universal.zip"
+  sha256 "@SHA256@"
+  license "MIT"
+
+  depends_on macos: :sonoma
+
+  skip_clean "bin/axorc"
+
+  def install
+    bin.install "axorc"
+  end
+
+  def caveats
+    <<~EOS
+      axorc requires Accessibility permission:
+        System Settings > Privacy & Security > Accessibility
+    EOS
+  end
+
+  test do
+    assert_match "axorc #{version}", shell_output("#{bin}/axorc --version")
+    assert_match "USAGE:", shell_output("#{bin}/axorc --help")
+    system "/usr/bin/codesign", "--verify", "--strict", bin/"axorc"
+    assert_match "anchor apple generic", shell_output("/usr/bin/codesign -d -r- #{bin}/axorc 2>&1")
+  end
+end

--- a/scripts/build-release-artifact.sh
+++ b/scripts/build-release-artifact.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-release-artifact.sh <version> [--adhoc]
+
+Builds dist/axorc-<version>-macos-universal.zip and its SHA-256 file.
+
+Release builds require AXORC_CODESIGN_IDENTITY to name a Developer ID
+Application identity already available in the current keychain. Use --adhoc
+only for local or CI verification; ad-hoc artifacts must not be published.
+EOF
+}
+
+if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+version="$1"
+shift
+adhoc=false
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must use x.y.z form." >&2
+  exit 2
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --adhoc)
+      adhoc=true
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+source_version="$(sed -n 's/.*axorcVersion = "\([^"]*\)".*/\1/p' Sources/axorc/Models/AXORCModels.swift)"
+if [[ "$source_version" != "$version" ]]; then
+  echo "Version mismatch: source has $source_version, requested $version" >&2
+  exit 1
+fi
+
+if [[ "$adhoc" == false && -z "${AXORC_CODESIGN_IDENTITY:-}" ]]; then
+  echo "AXORC_CODESIGN_IDENTITY is required for publishable artifacts." >&2
+  exit 1
+fi
+
+dist_dir="$repo_root/dist"
+stage_dir="$dist_dir/stage"
+binary_path="$stage_dir/axorc"
+archive_path="$dist_dir/axorc-$version-macos-universal.zip"
+checksum_path="$archive_path.sha256"
+
+rm -rf "$stage_dir" "$archive_path" "$checksum_path"
+mkdir -p "$stage_dir"
+
+swift build -c release --arch arm64 --product axorc
+swift build -c release --arch x86_64 --product axorc
+
+lipo -create \
+  .build/arm64-apple-macosx/release/axorc \
+  .build/x86_64-apple-macosx/release/axorc \
+  -output "$binary_path"
+strip -x "$binary_path"
+
+if [[ "$adhoc" == true ]]; then
+  codesign --force --sign - "$binary_path"
+else
+  codesign --force --options runtime --timestamp --sign "$AXORC_CODESIGN_IDENTITY" "$binary_path"
+fi
+
+codesign --verify --strict --verbose=2 "$binary_path"
+file "$binary_path" | grep -q 'universal binary'
+"$binary_path" --version | grep -Fx "axorc $version"
+
+(
+  cd "$stage_dir"
+  ditto --norsrc -c -k axorc "$archive_path"
+)
+(
+  cd "$dist_dir"
+  shasum -a 256 "$(basename "$archive_path")"
+) | tee "$checksum_path"
+
+rm -rf "$stage_dir"
+echo "Created $archive_path"

--- a/scripts/render-homebrew-formula.sh
+++ b/scripts/render-homebrew-formula.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "Usage: scripts/render-homebrew-formula.sh <version> <sha256>" >&2
+  exit 2
+fi
+
+version="$1"
+sha256="$2"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must use x.y.z form." >&2
+  exit 2
+fi
+if [[ ! "$sha256" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "SHA-256 must be 64 lowercase hexadecimal characters." >&2
+  exit 2
+fi
+
+sed \
+  -e "s/@VERSION@/$version/g" \
+  -e "s/@SHA256@/$sha256/g" \
+  "$repo_root/packaging/homebrew/axorc.rb.template"


### PR DESCRIPTION
## Summary

- turn `axorc` into a discoverable standalone CLI with `permissions`, `find`, `tree`, `raw`, help, version, human output, and stable JSON mode
- fix app resolution by name/PID/focus, requested attribute values, descendant filtering, failure exit codes, raw compatibility, and terminal-safe rendering
- add signed universal artifact tooling, release verification docs, a Homebrew formula template that preserves the Developer ID signature, and CI packaging proof

## Product decision

Standalone `axorc` is supported. Distribution contract: Developer ID-signed universal release binary through the official OpenClaw Homebrew tap. Source builds remain available; published binaries preserve a stable Accessibility/TCC identity.

This PR prepares v0.1.6. It does not publish a release or tap formula.

## Proof

- `swiftlint lint --strict`
- `swift test` — 51 tests passed
- live Dock automation: descendant role filtering and app-name/requested-attribute query
- source-blind release-binary contract: 10/10 clauses, JSON failure paths, flat filtered tree
- isolated checkout with remote Commander: `swift test`
- universal arm64/x86_64 ad-hoc archive, signature, checksum, formula render, Ruby syntax, and shellcheck
- autoreview: clean

Related to #12.
