### PR TITLE
fix: use AXUIElementCopyActionNames for supportedActions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Discover element actions through the dedicated macOS Accessibility API so supported actions such as `AXPress` work in SwiftUI apps. Thanks @dalsoop.
+
 ## [0.1.6] - 2026-07-15
 
 ### Added

--- a/Sources/AXorcist/Core/Element+Properties.swift
+++ b/Sources/AXorcist/Core/Element+Properties.swift
@@ -115,7 +115,15 @@ extension Element {
     // Action-related - simplified
     @MainActor
     public func supportedActions() -> [String]? {
-        attribute(Attribute<[String]>.actionNames)
+        // AXActionNames is not reliably readable via AXUIElementCopyAttributeValue —
+        // SwiftUI apps return nothing there, which made every AXPress support check fail.
+        // Use the dedicated API first and keep the attribute read as a fallback.
+        var names: CFArray?
+        if AXUIElementCopyActionNames(underlyingElement, &names) == .success,
+           let actions = names as? [String] {
+            return actions
+        }
+        return attribute(Attribute<[String]>.actionNames)
     }
 
     // domIdentifier - simplified to a single method, was previously a computed property and a method.

--- a/Sources/AXorcist/Core/Element+Properties.swift
+++ b/Sources/AXorcist/Core/Element+Properties.swift
@@ -115,9 +115,7 @@ extension Element {
     // Action-related - simplified
     @MainActor
     public func supportedActions() -> [String]? {
-        // AXActionNames is not reliably readable via AXUIElementCopyAttributeValue —
-        // SwiftUI apps return nothing there, which made every AXPress support check fail.
-        // Use the dedicated API first and keep the attribute read as a fallback.
+        // Action names have a dedicated Accessibility API; they are not a standard attribute.
         var names: CFArray?
         if AXUIElementCopyActionNames(underlyingElement, &names) == .success,
            let actions = names as? [String] {

--- a/Tests/AXorcistTests/ActionIntegrationTests.swift
+++ b/Tests/AXorcistTests/ActionIntegrationTests.swift
@@ -9,6 +9,21 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct ActionIntegrationTests {
+    @Test("Discover AXPress on a native window button", .tags(.automation))
+    func discoverPressActionOnWindowButton() async throws {
+        let (_, appElement) = try await setupTextEditAndGetInfo()
+        defer { Task { await closeTextEdit() } }
+
+        guard let appElement,
+              let button = Element(appElement).mainWindow()?.closeButton()
+        else {
+            throw TestError.generic("Could not find TextEdit's close button.")
+        }
+
+        #expect(button.supportedActions()?.contains(AXActionNames.kAXPressAction) == true)
+        #expect(button.isActionSupported(AXActionNames.kAXPressAction))
+    }
+
     @Test("Perform AXSetValue on TextEdit", .tags(.automation))
     func performActionSetTextEditTextAreaValue() async throws {
         let actionCommandId = "performaction-setvalue-\(UUID().uuidString)"


### PR DESCRIPTION
## Problem

`supportedActions()` read the nonstandard `AXActionNames` attribute through `AXUIElementCopyAttributeValue`. Real buttons can therefore report no actions, causing `isActionSupported("AXPress")` to reject an action that macOS actually supports.

## Fix

Use the dedicated `AXUIElementCopyActionNames` API first, retaining the previous attribute lookup only as a compatibility fallback. Add live automation regression coverage and an Unreleased changelog entry thanking @dalsoop.

## Verification

- Signed live AppKit fixture: AXorcist observed actions `["AXPress"]` on the real window close button.
- `isActionSupported("AXPress")` returned true.
- Performing `AXPress` closed the real window; the live validator passed in 0.039 seconds and exited 0.
- `swift build`
- `swift test --filter AXErrorExtensionsTests`
- `swift test --filter ActionIntegrationTests` (automation suite compiled and was correctly skipped without the automation opt-in)
- Structured autoreview: no actionable findings.
- Exact-head CI: [run 29659076451](https://github.com/openclaw/AXorcist/actions/runs/29659076451) passed build, safe tests, lint, and release packaging.
