### PR TITLE
fix: generic criterion matching returned nil for CF-typed attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Match generic accessibility criteria such as `AXTitle` against their real Core Foundation values. Thanks @dalsoop.
+
 ## [0.1.6] - 2026-07-15
 
 ### Added

--- a/Sources/AXorcist/Search/SingleCriterionMatching.swift
+++ b/Sources/AXorcist/Search/SingleCriterionMatching.swift
@@ -196,10 +196,8 @@ private func performGenericAttributeMatch(
     matchType: JSONPathHintComponent.MatchType,
     elementDescriptionForLog: String) -> Bool
 {
-    // Reading through attribute(Attribute<Any>) returns nil for CF-typed values,
-    // which silently broke every generic criterion (AXTitle, AXValue, ...).
-    // Prefer the raw attribute read and keep the generic path as a fallback.
-    let fetched: Any? = element.rawAttributeValue(named: key).map { $0 as Any }
+    // Generic criteria need the same CF-to-Swift normalization as attribute extraction.
+    let fetched: Any? = ValueUnwrapper.unwrap(element.rawAttributeValue(named: key))
         ?? element.attribute(Attribute(key))
     guard let actualValueAny: Any = fetched else {
         GlobalAXLogger.shared.log(

--- a/Sources/AXorcist/Search/SingleCriterionMatching.swift
+++ b/Sources/AXorcist/Search/SingleCriterionMatching.swift
@@ -196,7 +196,12 @@ private func performGenericAttributeMatch(
     matchType: JSONPathHintComponent.MatchType,
     elementDescriptionForLog: String) -> Bool
 {
-    guard let actualValueAny: Any = element.attribute(Attribute(key)) else {
+    // Reading through attribute(Attribute<Any>) returns nil for CF-typed values,
+    // which silently broke every generic criterion (AXTitle, AXValue, ...).
+    // Prefer the raw attribute read and keep the generic path as a fallback.
+    let fetched: Any? = element.rawAttributeValue(named: key).map { $0 as Any }
+        ?? element.attribute(Attribute(key))
+    guard let actualValueAny: Any = fetched else {
         GlobalAXLogger.shared.log(
             AXLogEntry(
                 level: .debug,

--- a/Tests/AXorcistTests/ElementSearchTests.swift
+++ b/Tests/AXorcistTests/ElementSearchTests.swift
@@ -8,6 +8,31 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct ElementSearchTests {
+    @Test("Search a window by its generic AXTitle criterion", .tags(.automation))
+    func searchWindowByExactTitle() async throws {
+        let (_, appElement) = try await setupTextEditAndGetInfo()
+        defer { Task { await closeTextEdit() } }
+
+        guard let appElement,
+              let title = Element(appElement).mainWindow()?.title()
+        else {
+            throw TestError.generic("Could not read TextEdit's main window title.")
+        }
+
+        let command = CommandEnvelope(
+            commandId: "query-window-by-title",
+            command: .query,
+            application: "com.apple.TextEdit",
+            locator: Locator(criteria: [
+                Criterion(attribute: "AXRole", value: "AXWindow"),
+                Criterion(attribute: "AXTitle", value: title),
+            ]))
+
+        let response = try await self.runQuery(command: command, encoder: JSONEncoder())
+        #expect(response.success)
+        #expect(response.data?.attributes?["AXTitle"]?.stringValue == title)
+    }
+
     @Test("Search elements by role", .tags(.automation))
     func searchElementsByRole() async throws {
         await closeTextEdit()


### PR DESCRIPTION
## Problem

Generic criteria fetched values through `Attribute<Any>`, whose typed conversion could return nil for real Core Foundation-backed accessibility values. A window with a readable `AXTitle` therefore failed an exact `AXRole` + `AXTitle` lookup.

## Fix

Read the raw AX attribute and normalize it through AXorcist's existing `ValueUnwrapper`, retaining the typed accessor as a fallback. This preserves string, boolean, number, and AXValue semantics while fixing generic matching. Add focused automation regression coverage and an Unreleased changelog entry thanking @dalsoop.

The contributor branch is refreshed onto current `main` with a regular merge, preserving both contributor commits and credit without rewriting branch history.

## Live behavior proof

The refreshed head was built locally, then exercised against a newly built AppKit fixture signed with the repository maintainer's Developer ID. The fixture was live at bundle identifier `org.openclaw.AXorcistProbe` with a real window titled `AXorcist Probe`.

```text
$ codesign --verify --deep --strict --verbose=2 AXorcistProbe.app
AXorcistProbe.app: valid on disk
AXorcistProbe.app: satisfies its Designated Requirement

$ axorc find --app org.openclaw.AXorcistProbe --role AXWindow --title "AXorcist Probe"
Role: AXWindow, Title: 'AXorcist Probe'
exit=0

$ axorc find --app org.openclaw.AXorcistProbe --role AXWindow --title "Wrong Probe Title"
Error: FTE: Not found C=[AXRole:AXWindow, AXTitle:Wrong Probe Title] from application root Role: AXApplication, Title: 'AXorcistProbe', Max depth visited = 2 of 10, Nodes visited = 7
exit=1
```

This negative control changed only the requested title while keeping the live app and role fixed.

## Verification

- `swift build`
- `swift test --filter ElementSearchTests` (the automation suite compiled and was correctly skipped without the automation opt-in)
- Source-blind behavior contract: exact-title lookup passed; wrong-title control passed; no blockers
- Structured autoreview on the refreshed diff: no actionable findings
- Exact candidate head: `e5863f35e3326f0c1e284fe3cb19148cf4e5d176`
- Exact-head CI: [run 29660139857](https://github.com/openclaw/AXorcist/actions/runs/29660139857) passed build, safe tests, lint, and release packaging
