### PR TITLE
fix: traverse menu bars during default searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Traverse menu bars during default searches so their items remain discoverable without `--scan-all`. Thanks @dalsoop.
+
 ## [0.1.6] - 2026-07-15
 
 ### Added

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -531,11 +531,7 @@ private let containerRoles: Set<String> = [
     AXRoleNames.kAXOutlineRole,
     AXRoleNames.kAXUnknownRole,
     "AXGeneric", "AXSection", "AXArticle", "AXSplitter", "AXScrollBar", "AXPane",
-    // Menus, toolbars and sheets are containers too. Without these, traversal
-    // pruned the (second) AXMenuBar holding status items, so menu-bar extras
-    // and toolbar content were unreachable unless --scan-all was passed.
-    "AXMenuBar", "AXMenuBarItem", "AXMenu", "AXMenuItem",
-    "AXToolbar", "AXTabGroup", "AXRadioGroup", "AXSheet", "AXDrawer", "AXPopover",
+    AXRoleNames.kAXMenuBarRole,
 ]
 
 // MARK: - Search Timeout Handling

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -531,6 +531,11 @@ private let containerRoles: Set<String> = [
     AXRoleNames.kAXOutlineRole,
     AXRoleNames.kAXUnknownRole,
     "AXGeneric", "AXSection", "AXArticle", "AXSplitter", "AXScrollBar", "AXPane",
+    // Menus, toolbars and sheets are containers too. Without these, traversal
+    // pruned the (second) AXMenuBar holding status items, so menu-bar extras
+    // and toolbar content were unreachable unless --scan-all was passed.
+    "AXMenuBar", "AXMenuBarItem", "AXMenu", "AXMenuItem",
+    "AXToolbar", "AXTabGroup", "AXRadioGroup", "AXSheet", "AXDrawer", "AXPopover",
 ]
 
 // MARK: - Search Timeout Handling

--- a/Tests/AXorcistTests/ElementSearchTests.swift
+++ b/Tests/AXorcistTests/ElementSearchTests.swift
@@ -8,6 +8,24 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct ElementSearchTests {
+    @Test("Search through a menu bar container", .tags(.automation))
+    func searchMenuBarItem() async throws {
+        _ = try await setupTextEditAndGetInfo()
+        defer { Task { await closeTextEdit() } }
+
+        let command = CommandEnvelope(
+            commandId: "query-menu-bar-item",
+            command: .query,
+            application: "com.apple.TextEdit",
+            locator: Locator(criteria: [
+                Criterion(attribute: "AXRole", value: AXRoleNames.kAXMenuBarItemRole),
+            ]))
+
+        let response = try await self.runQuery(command: command, encoder: JSONEncoder())
+        #expect(response.success)
+        #expect(response.data?.attributes?["AXRole"]?.stringValue == AXRoleNames.kAXMenuBarItemRole)
+    }
+
     @Test("Search elements by role", .tags(.automation))
     func searchElementsByRole() async throws {
         await closeTextEdit()


### PR DESCRIPTION
## Problem

Default traversal visits an element but descends into its children only when its role belongs to `containerRoles`. `AXMenuBar` was absent, so a real menu-bar item could exist in macOS's accessibility tree while `axorc find` pruned the menu bar before reaching it.

## Fix

Treat only `AXMenuBar` as an additional traversal container. The original proposal also expanded through menu items, menus, toolbars, tab groups, radio groups, sheets, drawers, and popovers; those unproven roles remain leaves so default negative searches do not fan out through whole menu or system subtrees.

The contributor branch was refreshed onto current `main` with a regular merge, preserving the contributor's original commit and the maintainer repair's `Co-authored-by` credit. The user-visible changelog entry thanks @dalsoop.

## Signed live behavior proof

The exact repaired tree was built locally and exercised against a newly built AppKit fixture signed with the repository maintainer's Developer ID. The fixture exposed a real top-level item titled `Probe Menu`. A separately signed AX inspector confirmed the item independently before either `axorc` binary was run.

```text
$ ./ax-menu-inspector
Role: AXMenuBarItem, Title: 'Apple'
Role: AXMenuBarItem, Title: 'AXorcistMenuProbe'
Role: AXMenuBarItem, Title: 'Probe Menu'

$ ./axorc-main find --app org.openclaw.AXorcistMenuProbe --role AXMenuBarItem --title "Probe Menu"
Error: FTE: Not found C=[AXRole:AXMenuBarItem, AXTitle:Probe Menu] ... Nodes visited = 7
real 0.06
exit=1

$ ./axorc-pr20 find --app org.openclaw.AXorcistMenuProbe --role AXMenuBarItem --title "Probe Menu"
Role: AXMenuBarItem, Title: 'Probe Menu', ID: 'probe-menu'
real 0.11
exit=0

$ ./axorc-pr20 find --app org.openclaw.AXorcistMenuProbe --role AXMenuBarItem --title "Wrong Probe Menu"
Error: FTE: Not found C=[AXRole:AXMenuBarItem, AXTitle:Wrong Probe Menu] ... Nodes visited = 10
real 0.03
exit=1
```

The negative control changed only the requested title while keeping the same signed app and role fixed. It shows that the narrower container addition restores discovery without creating an unbounded menu traversal.

## Verification

- `swift build`
- `swift test --filter ElementSearchTests`: the six automation cases compiled and were correctly skipped without automation opt-in
- `swift test`: 54 tests across 16 suites passed; expected automation suites skipped
- Source-blind behavior-validator contract: four checks passed, three anti-cheat probes passed, no blockers
- AutoReview on the exact refreshed diff: no actionable findings
- Exact candidate head: `d0b05ef6fd2af033e3296abf25c91da5b99fc417`
- Exact-head CI: [run 29660658323](https://github.com/openclaw/AXorcist/actions/runs/29660658323) passed build, safe tests, lint, and release packaging
