### PR TITLE
feat: add selected text range setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AXorcist will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- Add a typed native setter for accessibility selected-text ranges.
+
 ### Fixed
 - Traverse menu bars during default searches so their items remain discoverable without `--scan-all`. Thanks @dalsoop.
 - Match generic accessibility criteria such as `AXTitle` against their real Core Foundation values. Thanks @dalsoop.

--- a/Sources/AXorcist/Core/Element+ConvenienceAttributes.swift
+++ b/Sources/AXorcist/Core/Element+ConvenienceAttributes.swift
@@ -116,6 +116,18 @@ extension Element {
         attribute(Attribute<CFRange>.selectedTextRange)
     }
 
+    /// Set the selected text range
+    @MainActor
+    public func setSelectedTextRange(_ range: CFRange) -> AXError {
+        guard let axValue = AXValue.create(range: range) else {
+            return .failure
+        }
+        return AXUIElementSetAttributeValue(
+            underlyingElement,
+            AXAttributeNames.kAXSelectedTextRangeAttribute as CFString,
+            axValue)
+    }
+
     /// Get visible character range
     @MainActor
     public func visibleCharacterRange() -> CFRange? {

--- a/Tests/AXorcistTests/ElementConvenienceAttributesTests.swift
+++ b/Tests/AXorcistTests/ElementConvenienceAttributesTests.swift
@@ -1,0 +1,23 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("Element Convenience Attribute Tests", .tags(.safe))
+struct ElementConvenienceAttributesTests {
+    @MainActor
+    @Test(.tags(.safe))
+    func `Selected text range setter returns the native AX error`() throws {
+        let element = Element(AXUIElementCreateSystemWide())
+        let range = CFRange(location: 1, length: 2)
+        let axValue = try #require(AXValue.create(range: range))
+        let nativeError = AXUIElementSetAttributeValue(
+            element.underlyingElement,
+            AXAttributeNames.kAXSelectedTextRangeAttribute as CFString,
+            axValue)
+
+        let wrapperError = element.setSelectedTextRange(range)
+
+        #expect(nativeError != .success)
+        #expect(wrapperError == nativeError)
+    }
+}

--- a/Tests/AXorcistTests/ValueUnwrapperTests.swift
+++ b/Tests/AXorcistTests/ValueUnwrapperTests.swift
@@ -5,13 +5,17 @@ import Testing
 @Suite("ValueUnwrapper Tests", .tags(.safe))
 struct ValueUnwrapperTests {
     @MainActor
-    @Test("unwrap preserves CFRange AXValue", .tags(.safe))
-    func unwrapPreservesCFRangeAXValue() {
+    @Test(.tags(.safe))
+    func `unwrap preserves CFRange AXValue`() {
         let expected = CFRange(location: 12, length: 34)
         guard let axValue = AXValue.create(range: expected) else {
             Issue.record("Failed to create AXValue from CFRange")
             return
         }
+
+        #expect(axValue.valueType == .cfRange)
+        #expect(axValue.cfRange()?.location == expected.location)
+        #expect(axValue.cfRange()?.length == expected.length)
 
         guard let actual = ValueUnwrapper.unwrap(axValue) as? CFRange else {
             Issue.record("Expected ValueUnwrapper to return a CFRange")


### PR DESCRIPTION
## Summary

- add a typed `Element.setSelectedTextRange(_:)` convenience API
- construct the native range with AXorcist's existing `AXValue.create(range:)` helper
- return the native `AXError` without a lossy Boolean conversion or racy preflight
- retain the existing getter and generic attribute-settable API instead of adding duplicate surface

This is the native AX foundation for verified background text selection in Peekaboo. Matching, snapshot identity, policy, and verification intentionally remain outside AXorcist.

## Proof

- focused selected-range tests: 2/2
- full default/safe suite: 55/55 across 17 suites
- strict SwiftLint: 0 violations across 135 files
- changed-file SwiftFormat: clean
- structured Autoreview: clean at 0.99 correctness

No AppleScript or new dependency is introduced.
