### PR TITLE
fix: use native parameterized attribute names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Use the native macOS names for parameterized accessibility attributes instead of non-existent `Parameterized`-suffixed raw values.
 - Traverse menu bars during default searches so their items remain discoverable without `--scan-all`. Thanks @dalsoop.
 - Match generic accessibility criteria such as `AXTitle` against their real Core Foundation values. Thanks @dalsoop.
 - Discover element actions through the dedicated macOS Accessibility API so supported actions such as `AXPress` work in SwiftUI apps. Thanks @dalsoop.

--- a/Sources/AXorcist/Core/AccessibilityConstants.swift
+++ b/Sources/AXorcist/Core/AccessibilityConstants.swift
@@ -176,7 +176,7 @@ public enum AXAttributeNames {
     // Cell-specific Attributes
     // swiftlint:disable identifier_name
     public static let kAXCellForColumnAndRowParameterizedAttribute =
-        "AXCellForColumnAndRowParameterized" // AXUIElement (params: col, row)
+        "AXCellForColumnAndRow" // AXUIElement (params: col, row)
     // swiftlint:enable identifier_name
     public static let kAXRowIndexRangeAttribute = "AXRowIndexRange" // AXValue (CFRange)
     public static let kAXColumnIndexRangeAttribute = "AXColumnIndexRange" // AXValue (CFRange)
@@ -192,16 +192,26 @@ public enum AXAttributeNames {
 
     // Parameterized Attributes (Set for easy checking)
     // These require parameters when being accessed via AXUIElementCopyParameterizedAttributeValue
+    public static let kAXLineForIndexParameterizedAttribute = "AXLineForIndex"
+    public static let kAXRangeForLineParameterizedAttribute = "AXRangeForLine"
+    public static let kAXStringForRangeParameterizedAttribute = "AXStringForRange"
+    public static let kAXRangeForPositionParameterizedAttribute = "AXRangeForPosition"
+    public static let kAXRangeForIndexParameterizedAttribute = "AXRangeForIndex"
+    public static let kAXBoundsForRangeParameterizedAttribute = "AXBoundsForRange"
+    public static let kAXRTFForRangeParameterizedAttribute = "AXRTFForRange"
+    public static let kAXAttributedStringForRangeParameterizedAttribute = "AXAttributedStringForRange"
+    public static let kAXStyleRangeForIndexParameterizedAttribute = "AXStyleRangeForIndex"
+
     public static let parameterizedAttributes: Set<String> = [
-        "AXStringForRangeParameterized", // Param: AXValue (CFRange) -> String
-        "AXRangeForLineParameterized", // Param: Int (line number) -> AXValue (CFRange)
-        "AXRangeForPositionParameterized", // Param: AXValue (CGPoint) -> AXValue (CFRange)
-        "AXRangeForIndexParameterized", // Param: Int (char index) -> AXValue (CFRange)
-        "AXBoundsForRangeParameterized", // Param: AXValue (CFRange) -> AXValue (CGRect)
-        "AXRTFForRangeParameterized", // Param: AXValue (CFRange) -> Data
-        "AXAttributedStringForRangeParameterized", // Param: AXValue (CFRange) -> AttributedString
-        "AXStyleRangeForIndexParameterized", // Param: Int (char index) -> AXValue (CFRange)
-        "AXLineForIndexParameterized", // Param: Int (char index) -> Int (line number)
+        kAXStringForRangeParameterizedAttribute, // Param: AXValue (CFRange) -> String
+        kAXRangeForLineParameterizedAttribute, // Param: Int (line number) -> AXValue (CFRange)
+        kAXRangeForPositionParameterizedAttribute, // Param: AXValue (CGPoint) -> AXValue (CFRange)
+        kAXRangeForIndexParameterizedAttribute, // Param: Int (char index) -> AXValue (CFRange)
+        kAXBoundsForRangeParameterizedAttribute, // Param: AXValue (CFRange) -> AXValue (CGRect)
+        kAXRTFForRangeParameterizedAttribute, // Param: AXValue (CFRange) -> Data
+        kAXAttributedStringForRangeParameterizedAttribute, // Param: AXValue (CFRange) -> AttributedString
+        kAXStyleRangeForIndexParameterizedAttribute, // Param: Int (char index) -> AXValue (CFRange)
+        kAXLineForIndexParameterizedAttribute, // Param: Int (char index) -> Int (line number)
         kAXCellForColumnAndRowParameterizedAttribute, // Already defined above
         kAXActionDescriptionAttribute, // Param: String (action name) -> String
         // AXLayoutPointForScreenPointParameterized, AXLayoutSizeForScreenSizeParameterized, etc. for layout areas

--- a/Sources/AXorcist/Core/Attribute.swift
+++ b/Sources/AXorcist/Core/Attribute.swift
@@ -248,19 +248,22 @@ public struct Attribute<T> {
     // MARK: - Parameterized Text Attributes (Raw strings from AXAttributeConstants.h / common usage)
 
     public static var stringForRangeParameterized: Attribute<String> {
-        Attribute<String>("AXStringForRangeParameterized")
+        Attribute<String>(AXAttributeNames.kAXStringForRangeParameterizedAttribute)
     }
 
-    public static var rangeForLineParameterized: Attribute<CFRange> { Attribute<CFRange>("AXRangeForLineParameterized")
+    public static var rangeForLineParameterized: Attribute<CFRange> {
+        Attribute<CFRange>(AXAttributeNames.kAXRangeForLineParameterizedAttribute)
     }
 
     public static var boundsForRangeParameterized: Attribute<CGRect> {
-        Attribute<CGRect>("AXBoundsForRangeParameterized")
+        Attribute<CGRect>(AXAttributeNames.kAXBoundsForRangeParameterizedAttribute)
     }
 
-    public static var lineForIndexParameterized: Attribute<Int> { Attribute<Int>("AXLineForIndexParameterized") }
+    public static var lineForIndexParameterized: Attribute<Int> {
+        Attribute<Int>(AXAttributeNames.kAXLineForIndexParameterizedAttribute)
+    }
     public static var attributedStringForRangeParameterized: Attribute<NSAttributedString> {
-        Attribute<NSAttributedString>("AXAttributedStringForRangeParameterized")
+        Attribute<NSAttributedString>(AXAttributeNames.kAXAttributedStringForRangeParameterizedAttribute)
     }
 
     // MARK: - Parameterized Table/Cell Attributes

--- a/Tests/AXorcistTests/ParameterizedAttributeNameTests.swift
+++ b/Tests/AXorcistTests/ParameterizedAttributeNameTests.swift
@@ -1,0 +1,43 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("Parameterized Attribute Name Tests", .tags(.safe))
+struct ParameterizedAttributeNameTests {
+    @Test
+    func `typed attributes use the native macOS raw values`() {
+        #expect(Attribute<String>.stringForRangeParameterized.rawValue ==
+            kAXStringForRangeParameterizedAttribute as String)
+        #expect(Attribute<CFRange>.rangeForLineParameterized.rawValue ==
+            kAXRangeForLineParameterizedAttribute as String)
+        #expect(Attribute<CGRect>.boundsForRangeParameterized.rawValue ==
+            kAXBoundsForRangeParameterizedAttribute as String)
+        #expect(Attribute<Int>.lineForIndexParameterized.rawValue ==
+            kAXLineForIndexParameterizedAttribute as String)
+        #expect(Attribute<NSAttributedString>.attributedStringForRangeParameterized.rawValue ==
+            kAXAttributedStringForRangeParameterizedAttribute as String)
+    }
+
+    @Test
+    func `parameterized attribute catalog matches the system constants`() {
+        let expected: Set<String> = [
+            kAXLineForIndexParameterizedAttribute as String,
+            kAXRangeForLineParameterizedAttribute as String,
+            kAXStringForRangeParameterizedAttribute as String,
+            kAXRangeForPositionParameterizedAttribute as String,
+            kAXRangeForIndexParameterizedAttribute as String,
+            kAXBoundsForRangeParameterizedAttribute as String,
+            kAXRTFForRangeParameterizedAttribute as String,
+            kAXAttributedStringForRangeParameterizedAttribute as String,
+            kAXStyleRangeForIndexParameterizedAttribute as String,
+            AXAttributeNames.kAXCellForColumnAndRowParameterizedAttribute,
+            AXAttributeNames.kAXActionDescriptionAttribute,
+        ]
+
+        #expect(AXAttributeNames.parameterizedAttributes == expected)
+        let allNamesAreNative = AXAttributeNames.parameterizedAttributes.allSatisfy {
+            !$0.hasSuffix("Parameterized")
+        }
+        #expect(allNamesAreNative)
+    }
+}


### PR DESCRIPTION
## Summary

- replace non-existent `...Parameterized` raw accessibility names with Apple's native parameterized attribute values
- correct typed string/range/bounds/line helpers and the centralized parameterized-attribute catalog
- also correct table-cell lookup from `AXCellForColumnAndRowParameterized` to `AXCellForColumnAndRow`

This was discovered while adding verified selected-text-range readback: the old convenience helper asked macOS for `AXStringForRangeParameterized`, while the SDK-defined value is `AXStringForRange`.

## Proof

- focused native-name tests: 2/2
- full suite: 57/57 across 18 suites
- strict SwiftLint: 0 violations across 136 files
- changed-file formatting and diff checks clean
- structured Autoreview clean at 0.99 correctness

No public symbol is removed. The affected public constants now contain the values macOS actually accepts.
