### PR TITLE
fix: replace AppleScript permission probe

### DIFF
--- a/Sources/AXorcist/Core/AccessibilityPermissions.swift
+++ b/Sources/AXorcist/Core/AccessibilityPermissions.swift
@@ -1,6 +1,6 @@
 // AccessibilityPermissions.swift - Utility for checking and managing accessibility permissions.
 
-import AppKit // For NSRunningApplication, NSAppleScript
+import AppKit // For NSRunningApplication
 import ApplicationServices // For AXIsProcessTrusted(), AXUIElementCreateSystemWide(), etc.
 import Foundation
 
@@ -154,58 +154,58 @@ private func checkSingleBundleAutomation(_ bundleID: String) -> (status: Bool?, 
         return (nil, nil)
     }
 
-    let scriptSource = """
-    tell application id \"\(bundleID)\" to count windows
-    """
-
-    guard let script = NSAppleScript(source: scriptSource) else {
-        let errNoScript = "Could not initialize AppleScript for bundle ID '\(bundleID)'."
-        axErrorLog(
-            errNoScript,
-            file: #file,
-            function: #function,
-            line: #line)
-        return (nil, errNoScript)
+    guard var target = makeAutomationTarget(bundleID: bundleID) else {
+        let message = "Could not create an Apple Event target for bundle ID '\(bundleID)'."
+        axErrorLog(message, file: #file, function: #function, line: #line)
+        return (nil, message)
     }
+    defer { AEDisposeDesc(&target) }
 
-    return executeAppleScriptCheck(script, for: bundleID)
+    let nativeStatus = AEDeterminePermissionToAutomateTarget(
+        &target,
+        typeWildCard,
+        typeWildCard,
+        false)
+    return automationPermissionResult(for: nativeStatus, bundleID: bundleID)
 }
 
-private func executeAppleScriptCheck(
-    _ script: NSAppleScript,
-    for bundleID: String) -> (status: Bool?, errorMessage: String?)
+private func makeAutomationTarget(bundleID: String) -> AEDesc? {
+    let bundleIDData = Data(bundleID.utf8)
+    guard !bundleIDData.isEmpty else { return nil }
+
+    var target = AEDesc()
+    let status = bundleIDData.withUnsafeBytes { bytes in
+        AECreateDesc(
+            typeApplicationBundleID,
+            bytes.baseAddress,
+            bundleIDData.count,
+            &target)
+    }
+    guard status == noErr else { return nil }
+    return target
+}
+
+func automationPermissionResult(
+    for nativeStatus: OSStatus,
+    bundleID: String) -> (status: Bool?, errorMessage: String?)
 {
-    var errorDict: NSDictionary?
-
-    axDebugLog(
-        "Executing AppleScript against \(bundleID) to check automation status.",
-        file: #file,
-        function: #function,
-        line: #line)
-
-    let descriptor = script.executeAndReturnError(&errorDict)
-
-    if errorDict == nil, descriptor.descriptorType != typeNull {
-        axDebugLog(
-            "AppleScript execution against \(bundleID) succeeded " +
-                "(no errorDict, descriptor type: \(descriptor.descriptorType.description)). " +
-                "Automation permitted.",
-            file: #file,
-            function: #function,
-            line: #line)
+    switch nativeStatus {
+    case noErr:
+        axDebugLog("Native automation permission check for \(bundleID) succeeded.")
         return (true, nil)
-    } else {
-        let errorCode = errorDict?[NSAppleScript.errorNumber] as? Int ?? 0
-        let errorMessage = errorDict?[NSAppleScript.errorMessage] as? String ?? "Unknown AppleScript error"
-        let descriptorDetails = errorDict == nil ?
-            "Descriptor was typeNull (type: \(descriptor.descriptorType.description)) but no errorDict." : ""
-        let logMessage = "AppleScript execution against \(bundleID) failed. " +
-            "Automation likely denied. Code: \(errorCode), Msg: \(errorMessage). \(descriptorDetails)"
-        axWarningLog(
-            logMessage,
-            file: #file,
-            function: #function,
-            line: #line)
-        return (false, "Automation denied for \(bundleID): \(errorMessage) (Code: \(errorCode))")
+    case OSStatus(procNotFound):
+        return (nil, nil)
+    case OSStatus(errAEEventWouldRequireUserConsent):
+        let message = "Automation permission for \(bundleID) has not been determined."
+        axWarningLog(message)
+        return (false, message)
+    case OSStatus(errAEEventNotPermitted), OSStatus(errAETargetAddressNotPermitted):
+        let message = "Automation denied for \(bundleID) (Code: \(nativeStatus))."
+        axWarningLog(message)
+        return (false, message)
+    default:
+        let message = "Automation permission check failed for \(bundleID) (Code: \(nativeStatus))."
+        axWarningLog(message)
+        return (false, message)
     }
 }

--- a/Tests/AXorcistTests/AccessibilityPermissionsTests.swift
+++ b/Tests/AXorcistTests/AccessibilityPermissionsTests.swift
@@ -1,0 +1,29 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@MainActor
+struct AccessibilityPermissionsTests {
+    @Test
+    func `Native automation permission mapping is noninteractive and truthful`() {
+        let granted = automationPermissionResult(for: noErr, bundleID: "com.example.Test")
+        #expect(granted.status == true)
+        #expect(granted.errorMessage == nil)
+
+        let undecided = automationPermissionResult(
+            for: OSStatus(errAEEventWouldRequireUserConsent),
+            bundleID: "com.example.Test")
+        #expect(undecided.status == false)
+        #expect(undecided.errorMessage?.contains("not been determined") == true)
+
+        let denied = automationPermissionResult(
+            for: OSStatus(errAEEventNotPermitted),
+            bundleID: "com.example.Test")
+        #expect(denied.status == false)
+        #expect(denied.errorMessage?.contains("denied") == true)
+
+        let missing = automationPermissionResult(for: OSStatus(procNotFound), bundleID: "com.example.Test")
+        #expect(missing.status == nil)
+        #expect(missing.errorMessage == nil)
+    }
+}

--- a/Tests/AXorcistTests/CommonTestHelpers.swift
+++ b/Tests/AXorcistTests/CommonTestHelpers.swift
@@ -120,22 +120,12 @@ private func axWindowCount(for appElement: AXUIElement) async throws -> Int {
 
 @MainActor
 private func createNewDocument() async throws {
-    let appleScript = """
-    tell application "System Events"
-        tell process "TextEdit"
-            set frontmost to true
-            keystroke "n" using command down
-        end tell
-    end tell
-    """
-    var errorDict: NSDictionary?
-    if let scriptObject = NSAppleScript(source: appleScript) {
-        scriptObject.executeAndReturnError(&errorDict)
-        if let error = errorDict {
-            throw TestError.appleScriptError("Failed to create new document in TextEdit: \(error)")
-        }
-        try await Task.sleep(for: .seconds(2))
+    do {
+        try InputDriver.hotkey(keys: ["cmd", "n"])
+    } catch {
+        throw TestError.inputError("Failed to create a new TextEdit document: \(error)")
     }
+    try await Task.sleep(for: .seconds(2))
 }
 
 @MainActor
@@ -463,7 +453,7 @@ struct BatchOperationResponse: Codable {
 enum TestError: Error, CustomStringConvertible {
     case appNotRunning(String)
     case axError(String)
-    case appleScriptError(String)
+    case inputError(String)
     case generic(String)
 
     // MARK: Internal
@@ -472,7 +462,7 @@ enum TestError: Error, CustomStringConvertible {
         switch self {
         case let .appNotRunning(string): "AppNotRunning: \(string)"
         case let .axError(string): "AXError: \(string)"
-        case let .appleScriptError(string): "AppleScriptError: \(string)"
+        case let .inputError(string): "InputError: \(string)"
         case let .generic(string): "GenericTestError: \(string)"
         }
     }


### PR DESCRIPTION
## Summary

- replace the `NSAppleScript` automation-permission probe with the native, noninteractive `AEDeterminePermissionToAutomateTarget` API
- distinguish granted, undecided, denied, missing-target, and native-error results without launching an app or displaying a consent prompt
- remove the remaining System Events AppleScript from test helpers and use AXorcist's input driver instead

## Why

Permission inspection should not execute a script against another app. The native Apple Event permission API reports the TCC state directly with `askUserIfNeeded: false`, avoids side effects, and keeps downstream binaries free of dormant `NSAppleScript` code and script payloads.

## Proof

- full AXorcist suite: 58 tests
- strict SwiftLint: zero violations
- Release binary and source scan: no `NSAppleScript` symbol or script payload
- Autoreview and TruffleHog clean at 0.98
