### PR TITLE
chore(ci): enforce pinned Swift validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ permissions:
 env:
   SWIFT_VERSION: "6.2.1"
   XCODE_VERSION: "16.4"
-  VALIDATION_TOOLS_DIR: ${{ runner.temp }}/axorcist-validation-tools
 
 jobs:
   build-and-lint:
@@ -55,8 +54,9 @@ jobs:
     - name: Install validation tools
       run: |
         brew install shellcheck
-        scripts/install-validation-tools.sh "$VALIDATION_TOOLS_DIR"
-        echo "$VALIDATION_TOOLS_DIR" >> "$GITHUB_PATH"
+        validation_tools_dir="${{ runner.temp }}/axorcist-validation-tools"
+        scripts/install-validation-tools.sh "$validation_tools_dir"
+        echo "$validation_tools_dir" >> "$GITHUB_PATH"
     
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ permissions:
 env:
   SWIFT_VERSION: "6.2.1"
   XCODE_VERSION: "16.4"
+  VALIDATION_TOOLS_DIR: ${{ runner.temp }}/axorcist-validation-tools
 
 jobs:
   build-and-lint:
@@ -53,29 +54,16 @@ jobs:
     
     - name: Install validation tools
       run: |
-        brew install shellcheck swiftlint swiftformat
+        brew install shellcheck
+        scripts/install-validation-tools.sh "$VALIDATION_TOOLS_DIR"
+        echo "$VALIDATION_TOOLS_DIR" >> "$GITHUB_PATH"
     
     - name: Build
       run: |
         swift build
     
-    - name: Run SwiftFormat (check only)
-      continue-on-error: true
-      run: |
-        echo "::group::SwiftFormat Check"
-        if ! swiftformat --lint .; then
-          echo "::warning::SwiftFormat found formatting issues"
-        fi
-        echo "::endgroup::"
-    
-    - name: Run SwiftLint
-      continue-on-error: true
-      run: |
-        echo "::group::SwiftLint Check"
-        if ! swiftlint lint; then
-          echo "::warning::SwiftLint found linting issues"
-        fi
-        echo "::endgroup::"
+    - name: Run formatting and linting checks
+      run: make check
     
     - name: Run safe tests
       run: swift test

--- a/Sources/AXorcist/Core/AXApp.swift
+++ b/Sources/AXorcist/Core/AXApp.swift
@@ -17,9 +17,17 @@ public struct AXApp: Sendable {
         self.init(app)
     }
 
-    public var pid: pid_t { self.application.processIdentifier }
-    public var bundleIdentifier: String? { self.application.bundleIdentifier }
-    public var localizedName: String? { self.application.localizedName }
+    public var pid: pid_t {
+        self.application.processIdentifier
+    }
+
+    public var bundleIdentifier: String? {
+        self.application.bundleIdentifier
+    }
+
+    public var localizedName: String? {
+        self.application.localizedName
+    }
 
     /// Windows exposed via AX for this application.
     public func windows() -> [Element]? {
@@ -42,9 +50,17 @@ public struct AXWindowHandle: Sendable {
         self.element = element
     }
 
-    public var title: String? { self.element.title() }
-    public var frame: CGRect? { self.element.frame() }
-    public var role: String? { self.element.role() }
+    public var title: String? {
+        self.element.title()
+    }
+
+    public var frame: CGRect? {
+        self.element.frame()
+    }
+
+    public var role: String? {
+        self.element.role()
+    }
 
     /// CGWindowID for this AX window, if resolvable.
     public var windowID: CGWindowID? {

--- a/Sources/AXorcist/Core/AXError+Extensions.swift
+++ b/Sources/AXorcist/Core/AXError+Extensions.swift
@@ -8,8 +8,8 @@
 import ApplicationServices
 import Foundation
 
-// Create a custom error type that wraps AXError
-nonisolated public struct AccessibilitySystemError: Error, LocalizedError {
+/// Create a custom error type that wraps AXError
+public nonisolated struct AccessibilitySystemError: Error, LocalizedError {
     public let axError: AXError
 
     public init(_ axError: AXError) {
@@ -87,7 +87,7 @@ extension AXError {
     }
 
     /// Provides a localized description for AXError
-    nonisolated public var localizedDescription: String {
+    public nonisolated var localizedDescription: String {
         AccessibilitySystemError(self).errorDescription ?? "Unknown AXError: \(self.rawValue)"
     }
 }

--- a/Sources/AXorcist/Core/AXWindowResolver.swift
+++ b/Sources/AXorcist/Core/AXWindowResolver.swift
@@ -20,7 +20,7 @@ public final class AXWindowResolver {
     @MainActor
     public func windowID(from axElement: AXUIElement) -> CGWindowID? {
         var windowID: CGWindowID = 0
-        let result = _AXUIElementGetWindow(axElement, &windowID)
+        let result = self._AXUIElementGetWindow(axElement, &windowID)
         guard result == .success else {
             self.logger.error("Failed to get window ID from AXUIElement, error: \(result.rawValue)")
             return nil

--- a/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
@@ -202,7 +202,9 @@ extension AXorcist {
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .debug,
             message: "HandleSetFocusedValue: Attempting to set kAXFocusedAttribute to true for \(elementDescription)"))
-        if element.setValue(true, forAttribute: AXAttributeNames.kAXFocusedAttribute) { return }
+        if element.setValue(true, forAttribute: AXAttributeNames.kAXFocusedAttribute) {
+            return
+        }
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .warning,
             message: [

--- a/Sources/AXorcist/Core/AccessibilityConstants.swift
+++ b/Sources/AXorcist/Core/AccessibilityConstants.swift
@@ -20,7 +20,7 @@ public enum AXActionNames {
     // public static let kAXShowDefaultUIAction = "AXShowDefaultUI"     // Shows the default UI for the element
     // public static let kAXDeleteAction = "AXDelete" // Action to delete content or an element
 
-    // Internal/Custom action name for setting a value via performAction handler
+    /// Internal/Custom action name for setting a value via performAction handler
     public static let kAXSetValueAction = "AXSetValue"
 }
 
@@ -101,7 +101,7 @@ public enum AXAttributeNames {
     public static let kAXHiddenAttribute = "AXHidden" // Bool (is app hidden?)
     // public static let kAXEnhancedUserInterfaceAttribute = "AXEnhancedUserInterface" // Bool (private)
 
-    // System-wide Attributes (available on SystemWide element)
+    /// System-wide Attributes (available on SystemWide element)
     public static let kAXFocusedApplicationAttribute =
         "AXFocusedApplication" // AXUIElement (the currently focused application)
 
@@ -182,7 +182,7 @@ public enum AXAttributeNames {
     public static let kAXColumnIndexRangeAttribute = "AXColumnIndexRange" // AXValue (CFRange)
     public static let kAXSelectedCellsAttribute = "AXSelectedCells" // [AXUIElement]
 
-    // Tabs
+    /// Tabs
     public static let kAXTabsAttribute = "AXTabs" // [AXUIElement]
 
     // Linking Attributes
@@ -230,17 +230,17 @@ public enum AXAttributeNames {
     public static let kAXLayoutAreaChildrenAttribute = "AXLayoutAreaChildren" // Children of AXLayoutArea
     public static let kAXGroupChildrenAttribute = "AXGroupChildren" // Often just kAXChildren on AXGroup
 
-    // Action related
+    /// Action related
     public static let kAXActionsAttribute = "AXActions" // Standard attribute for available actions.
 
-    // Hierarchy and Path related
+    /// Hierarchy and Path related
     public static let kAXPathHintAttribute = "AXPathHint" // Custom attribute for path hints, if used
 
     // Web content related
     // public static let kAXDOMIdentifierAttribute = "AXDOMIdentifier" // Used in web views for DOM element IDs.
 
-    // macOS 13 additions (example)
-    // public static let kAXCustomActionsAttribute = "AXCustomActions" // This is a guess, verify actual name
+    /// macOS 13 additions (example)
+    /// public static let kAXCustomActionsAttribute = "AXCustomActions" // This is a guess, verify actual name
     public static let kAXValueWrapsAttribute = "AXValueWraps" // Added based on error
 
     // Attributes related to windows and applications (These were duplicated, ensure only one set exists)
@@ -402,7 +402,7 @@ public enum AXNotification: String, Sendable {
 public enum AXMiscConstants {
     public static let axBinaryVersion = "0.8.0" // AXorcist version for this constants file
 
-    // Default attributes to fetch when none are specified
+    /// Default attributes to fetch when none are specified
     public static let defaultAttributesToFetch: [String] = [
         AXAttributeNames.kAXRoleAttribute,
         AXAttributeNames.kAXSubroleAttribute,
@@ -428,12 +428,12 @@ public enum AXMiscConstants {
     public static let defaultMaxElementsToCollect = 1000 // New constant for element collection limit
     public static let defaultTimeoutPerElementCollectAll: TimeInterval = 2.0 // seconds
 
-    // String Constants (for default/fallback values)
+    /// String Constants (for default/fallback values)
     public static let kAXNotAvailableString = "n/a" // Placeholder for unavailable attribute values
 
-    // Keys for userInfo dictionaries or internal use
+    /// Keys for userInfo dictionaries or internal use
     public static let focusedApplicationKey = "focusedApplication" // Key to signify the focused application
-    // focusedWindowKey was here, but seems unused, can be re-added if needed
+    /// focusedWindowKey was here, but seems unused, can be re-added if needed
     public static let focusedUIElementKey =
         "focusedUIElement" // Key for focused UI element in userInfo (used in AXObserverCenter)
 
@@ -443,7 +443,7 @@ public enum AXMiscConstants {
     public static let isClickableAttributeKey = "IsClickable" // Key for computed clickability
     public static let isIgnoredAttributeKey = "IsIgnored" // Key for computed ignored status
 
-    // Path generation constants
+    /// Path generation constants
     public static let maxPathSegments = 20 // Limit for path segment generation to avoid infinite loops
     // pathHintAttributeKey was for Element.swift's pathHint property, which is different from
     // AXAttributeNames.kAXPathHintAttribute

--- a/Sources/AXorcist/Core/AccessibilityError.swift
+++ b/Sources/AXorcist/Core/AccessibilityError.swift
@@ -3,7 +3,7 @@
 import ApplicationServices // Import to make AXError visible
 import Foundation
 
-// Main error enum for the accessibility tool, incorporating parsing and operational errors.
+/// Main error enum for the accessibility tool, incorporating parsing and operational errors.
 public enum AccessibilityError: Error, CustomStringConvertible {
     // Authorization & Setup Errors
     case apiDisabled // Accessibility API is disabled.
@@ -23,7 +23,7 @@ public enum AccessibilityError: Error, CustomStringConvertible {
     case observerSetupFailed(details: String) // Failed to setup AXObserver
     case tokenNotFound(tokenId: UUID) // Subscription token not found
 
-    // Attribute Errors
+    /// Attribute Errors
     case attributeUnsupported(
         attribute: String,
         elementDescription: String?) // Attribute is not supported by the element.
@@ -61,12 +61,16 @@ public enum AccessibilityError: Error, CustomStringConvertible {
         case .apiDisabled: return "Accessibility API is disabled. Please enable it in System Settings."
         case let .notAuthorized(axErr):
             let base = "Accessibility permissions are not granted for this process."
-            if let error = axErr { return "\(base) AXError: \(error)" }
+            if let error = axErr {
+                return "\(base) AXError: \(error)"
+            }
             return base
         // Command & Input
         case let .invalidCommand(msg):
             let base = "Invalid command specified."
-            if let message = msg { return "\(base) \(message)" }
+            if let message = msg {
+                return "\(base) \(message)"
+            }
             return base
         case let .missingArgument(name): return "Missing required argument: \(name)."
         case let .invalidArgument(details): return "Invalid argument: \(details)."
@@ -74,7 +78,9 @@ public enum AccessibilityError: Error, CustomStringConvertible {
         case let .appNotFound(app): return "Application '\(app)' not found or not running."
         case let .elementNotFound(msg):
             let base = "No element matches the locator criteria or path."
-            if let message = msg { return "\(base) \(message)" }
+            if let message = msg {
+                return "\(base) \(message)"
+            }
             return base
         case .invalidElement: return "The specified UI element is invalid (possibly stale)."
         // Observer Errors
@@ -83,54 +89,76 @@ public enum AccessibilityError: Error, CustomStringConvertible {
         // Attribute Errors
         case let .attributeUnsupported(attr, elDesc):
             let base = "Attribute '\(attr)' is not supported"
-            if let desc = elDesc { return "\(base) on element '\(desc)'." }
+            if let desc = elDesc {
+                return "\(base) on element '\(desc)'."
+            }
             return "\(base)."
         case let .attributeNotReadable(attr, elDesc):
             let base = "Attribute '\(attr)' is not readable"
-            if let desc = elDesc { return "\(base) on element '\(desc)'." }
+            if let desc = elDesc {
+                return "\(base) on element '\(desc)'."
+            }
             return "\(base)."
         case let .attributeNotSettable(attr, elDesc):
             let base = "Attribute '\(attr)' is not settable"
-            if let desc = elDesc { return "\(base) on element '\(desc)'." }
+            if let desc = elDesc {
+                return "\(base) on element '\(desc)'."
+            }
             return "\(base)."
         case let .typeMismatch(expected, actual, attribute):
             var msg = "Type mismatch: Expected '\(expected)', got '\(actual)'"
-            if let attr = attribute { msg += " for attribute '\(attr)'" }
+            if let attr = attribute {
+                msg += " for attribute '\(attr)'"
+            }
             return msg + "."
         case let .valueParsingFailed(details, attribute):
             var msg = "Value parsing failed: \(details)"
-            if let attr = attribute { msg += " for attribute '\(attr)'" }
+            if let attr = attribute {
+                msg += " for attribute '\(attr)'"
+            }
             return msg + "."
         case let .valueNotAXValue(attr, elDesc):
             let base = "Value for attribute '\(attr)' is not an AXValue type as expected"
-            if let desc = elDesc { return "\(base) on element '\(desc)'." }
+            if let desc = elDesc {
+                return "\(base) on element '\(desc)'."
+            }
             return "\(base)."
         // Action Errors
         case let .actionUnsupported(action, elDesc):
             let base = "Action '\(action)' is not supported"
-            if let desc = elDesc { return "\(base) on element '\(desc)'." }
+            if let desc = elDesc {
+                return "\(base) on element '\(desc)'."
+            }
             return "\(base)."
         case let .actionFailed(action, elDesc, axErr):
             var parts = ["Action '\(action)' failed."]
-            if let desc = elDesc { parts.append("On element: '\(desc)'.") }
-            if let error = axErr { parts.append("AXError: \(error).") }
+            if let desc = elDesc {
+                parts.append("On element: '\(desc)'.")
+            }
+            if let error = axErr {
+                parts.append("AXError: \(error).")
+            }
             return parts.joined(separator: " ")
         // Generic & System
         case let .unknownAXError(error): return "An unexpected Accessibility Framework error occurred: \(error)."
         case let .jsonEncodingFailed(err):
             let base = "Failed to encode the response to JSON."
-            if let error = err { return "\(base) Error: \(error.localizedDescription)" }
+            if let error = err {
+                return "\(base) Error: \(error.localizedDescription)"
+            }
             return base
         case let .jsonDecodingFailed(err):
             let base = "Failed to decode the JSON command input."
-            if let error = err { return "\(base) Error: \(error.localizedDescription)" }
+            if let error = err {
+                return "\(base) Error: \(error.localizedDescription)"
+            }
             return base
         case let .genericError(msg): return msg
         }
     }
 
-    // Helper to get a more specific exit code if needed, or a general one.
-    // This is just an example; actual exit codes might vary.
+    /// Helper to get a more specific exit code if needed, or a general one.
+    /// This is just an example; actual exit codes might vary.
     public var exitCode: Int32 {
         switch self {
         case .apiDisabled, .notAuthorized: 10

--- a/Sources/AXorcist/Core/AnyCodable.swift
+++ b/Sources/AXorcist/Core/AnyCodable.swift
@@ -117,12 +117,14 @@ public struct AnyCodable: Codable, @unchecked Sendable, Equatable {
     }
 }
 
-// Helper struct for AnyCodable to properly encode intermediate Encodable values
-// This might not be necessary if the direct (value as! Encodable).encode(to: encoder) works.
+/// Helper struct for AnyCodable to properly encode intermediate Encodable values
+/// This might not be necessary if the direct (value as! Encodable).encode(to: encoder) works.
 struct AnyCodablePośrednik<T: Encodable>: Encodable {
     // MARK: Lifecycle
 
-    init(_ value: T) { self.value = value }
+    init(_ value: T) {
+        self.value = value
+    }
 
     // MARK: Internal
 
@@ -133,7 +135,7 @@ struct AnyCodablePośrednik<T: Encodable>: Encodable {
     }
 }
 
-// Helper protocol to check if a type is Optional
+/// Helper protocol to check if a type is Optional
 private protocol OptionalProtocol {
     static func isOptional() -> Bool
 }

--- a/Sources/AXorcist/Core/Attribute.swift
+++ b/Sources/AXorcist/Core/Attribute.swift
@@ -62,27 +62,44 @@ public struct Attribute<T> {
 
     // MARK: - General Element Attributes
 
-    public static var role: Attribute<String> { Attribute<String>(AXAttributeNames.kAXRoleAttribute) }
-    public static var subrole: Attribute<String> { Attribute<String>(AXAttributeNames.kAXSubroleAttribute) }
+    public static var role: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXRoleAttribute)
+    }
+
+    public static var subrole: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXSubroleAttribute)
+    }
+
     public static var roleDescription: Attribute<String> {
         Attribute<String>(AXAttributeNames.kAXRoleDescriptionAttribute)
     }
 
-    public static var title: Attribute<String> { Attribute<String>(AXAttributeNames.kAXTitleAttribute) }
+    public static var title: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXTitleAttribute)
+    }
+
     public static var titleUIElement: Attribute<AXUIElement> {
         Attribute<AXUIElement>(AXAttributeNames.kAXTitleUIElementAttribute)
     }
 
-    public static var description: Attribute<String> { Attribute<String>(AXAttributeNames.kAXDescriptionAttribute) }
-    public static var help: Attribute<String> { Attribute<String>(AXAttributeNames.kAXHelpAttribute) }
-    public static var identifier: Attribute<String> { Attribute<String>(AXAttributeNames.kAXIdentifierAttribute) }
+    public static var description: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXDescriptionAttribute)
+    }
+
+    public static var help: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXHelpAttribute)
+    }
+
+    public static var identifier: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXIdentifierAttribute)
+    }
 
     // MARK: - Value Attributes
 
-    // kAXValueAttribute can be many types. For a generic getter, Any might be appropriate,
-    // or specific versions if the context knows the type.
-    // public static var value: Attribute<Any> { Attribute("AXValue") } // Generic Any can be problematic, prefer
-    // specific types
+    /// kAXValueAttribute can be many types. For a generic getter, Any might be appropriate,
+    /// or specific versions if the context knows the type.
+    /// public static var value: Attribute<Any> { Attribute("AXValue") } // Generic Any can be problematic, prefer
+    /// specific types
     public static var valueDescription: Attribute<String> {
         Attribute<String>(AXAttributeNames.kAXValueDescriptionAttribute)
     }
@@ -91,7 +108,10 @@ public struct Attribute<T> {
         Attribute<NSNumber>(AXAttributeNames.kAXValueIncrementAttribute)
     }
 
-    public static var valueWraps: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXValueWrapsAttribute) }
+    public static var valueWraps: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXValueWrapsAttribute)
+    }
+
     // Example of a more specific value if known:
     // static var stringValue: Attribute<String> { Attribute(AXAttributeNames.kAXValueAttribute) }
 
@@ -101,16 +121,30 @@ public struct Attribute<T> {
 
     // MARK: - State Attributes
 
-    public static var enabled: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXEnabledAttribute) }
-    public static var focused: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXFocusedAttribute) }
-    public static var busy: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXElementBusyAttribute) }
-    public static var hidden: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXHiddenAttribute) }
+    public static var enabled: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXEnabledAttribute)
+    }
+
+    public static var focused: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXFocusedAttribute)
+    }
+
+    public static var busy: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXElementBusyAttribute)
+    }
+
+    public static var hidden: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXHiddenAttribute)
+    }
 
     // MARK: - Hierarchy Attributes
 
-    public static var parent: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXParentAttribute) }
-    // For children, the direct attribute often returns [AXUIElement].
-    // Element.children getter then wraps these.
+    public static var parent: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXParentAttribute)
+    }
+
+    /// For children, the direct attribute often returns [AXUIElement].
+    /// Element.children getter then wraps these.
     public static var children: Attribute<[AXUIElement]> {
         Attribute<[AXUIElement]>(AXAttributeNames.kAXChildrenAttribute)
     }
@@ -131,7 +165,8 @@ public struct Attribute<T> {
         Attribute<[AXUIElement]>(AXAttributeNames.kAXSheetsAttribute)
     }
 
-    public static var window: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXWindowAttribute)
+    public static var window: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXWindowAttribute)
     } // Often the main/key window of an app element
     public static var mainWindow: Attribute<AXUIElement> {
         Attribute<AXUIElement>(AXAttributeNames.kAXMainWindowAttribute)
@@ -147,21 +182,33 @@ public struct Attribute<T> {
 
     // MARK: - Application Specific Attributes
 
-    // public static var enhancedUserInterface: Attribute<Bool> {
-    //     Attribute<Bool>(AXAttributeNames.kAXEnhancedUserInterfaceAttribute)
-    // } // Constant not found, commenting out
-    public static var frontmost: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXFrontmostAttribute) }
-    public static var mainMenu: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXMenuBarAttribute) }
-    // public static var hiddenApplication: Attribute<Bool> { Attribute(AXAttributeNames.kAXHiddenAttribute) } // Same
-    // as element hidden, but for app. Covered by .hidden
+    /// public static var enhancedUserInterface: Attribute<Bool> {
+    ///     Attribute<Bool>(AXAttributeNames.kAXEnhancedUserInterfaceAttribute)
+    /// } // Constant not found, commenting out
+    public static var frontmost: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXFrontmostAttribute)
+    }
+
+    public static var mainMenu: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXMenuBarAttribute)
+    }
+
+    /// public static var hiddenApplication: Attribute<Bool> { Attribute(AXAttributeNames.kAXHiddenAttribute) } // Same
+    /// as element hidden, but for app. Covered by .hidden
     public static var focusedApplication: Attribute<AXUIElement> {
         Attribute<AXUIElement>(AXAttributeNames.kAXFocusedApplicationAttribute)
     }
 
     // MARK: - Window Specific Attributes
 
-    public static var minimized: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXMinimizedAttribute) }
-    public static var modal: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXModalAttribute) }
+    public static var minimized: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXMinimizedAttribute)
+    }
+
+    public static var modal: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXModalAttribute)
+    }
+
     public static var defaultButton: Attribute<AXUIElement> {
         Attribute<AXUIElement>(AXAttributeNames.kAXDefaultButtonAttribute)
     }
@@ -190,14 +237,28 @@ public struct Attribute<T> {
         Attribute<AXUIElement>(AXAttributeNames.kAXFullScreenButtonAttribute)
     }
 
-    public static var proxy: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXProxyAttribute) }
-    public static var growArea: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXGrowAreaAttribute) }
-    public static var main: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXMainAttribute) }
-    public static var fullScreen: Attribute<Bool> { Attribute<Bool>(AXAttributeNames.kAXFullScreenAttribute) }
+    public static var proxy: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXProxyAttribute)
+    }
+
+    public static var growArea: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXGrowAreaAttribute)
+    }
+
+    public static var main: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXMainAttribute)
+    }
+
+    public static var fullScreen: Attribute<Bool> {
+        Attribute<Bool>(AXAttributeNames.kAXFullScreenAttribute)
+    }
 
     // MARK: - Table/List/Outline Attributes
 
-    public static var rows: Attribute<[AXUIElement]> { Attribute<[AXUIElement]>(AXAttributeNames.kAXRowsAttribute) }
+    public static var rows: Attribute<[AXUIElement]> {
+        Attribute<[AXUIElement]>(AXAttributeNames.kAXRowsAttribute)
+    }
+
     public static var columns: Attribute<[AXUIElement]> {
         Attribute<[AXUIElement]>(AXAttributeNames.kAXColumnsAttribute)
     }
@@ -222,12 +283,20 @@ public struct Attribute<T> {
         Attribute<[AXUIElement]>(AXAttributeNames.kAXVisibleColumnsAttribute)
     }
 
-    public static var header: Attribute<AXUIElement> { Attribute<AXUIElement>(AXAttributeNames.kAXHeaderAttribute) }
-    public static var orientation: Attribute<String> { Attribute<String>(AXAttributeNames.kAXOrientationAttribute) }
+    public static var header: Attribute<AXUIElement> {
+        Attribute<AXUIElement>(AXAttributeNames.kAXHeaderAttribute)
+    }
+
+    public static var orientation: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXOrientationAttribute)
+    }
 
     // MARK: - Text Attributes
 
-    public static var selectedText: Attribute<String> { Attribute<String>(AXAttributeNames.kAXSelectedTextAttribute) }
+    public static var selectedText: Attribute<String> {
+        Attribute<String>(AXAttributeNames.kAXSelectedTextAttribute)
+    }
+
     public static var selectedTextRange: Attribute<CFRange> {
         Attribute<CFRange>(AXAttributeNames.kAXSelectedTextRangeAttribute)
     }
@@ -262,6 +331,7 @@ public struct Attribute<T> {
     public static var lineForIndexParameterized: Attribute<Int> {
         Attribute<Int>(AXAttributeNames.kAXLineForIndexParameterizedAttribute)
     }
+
     public static var attributedStringForRangeParameterized: Attribute<NSAttributedString> {
         Attribute<NSAttributedString>(AXAttributeNames.kAXAttributedStringForRangeParameterizedAttribute)
     }
@@ -284,20 +354,28 @@ public struct Attribute<T> {
 
     // MARK: - Action Related
 
-    // Action names are typically an array of strings.
-    public static var actionNames: Attribute<[String]> { Attribute<[String]>(AXAttributeNames.kAXActionNamesAttribute) }
-    // Action description is parameterized by the action name, so a simple Attribute<String> isn't quite right.
-    // It would be kAXActionDescriptionAttribute, and you pass a parameter.
-    // For now, we will represent it as taking a string, and the usage site will need to handle parameterization.
+    /// Action names are typically an array of strings.
+    public static var actionNames: Attribute<[String]> {
+        Attribute<[String]>(AXAttributeNames.kAXActionNamesAttribute)
+    }
+
+    /// Action description is parameterized by the action name, so a simple Attribute<String> isn't quite right.
+    /// It would be kAXActionDescriptionAttribute, and you pass a parameter.
+    /// For now, we will represent it as taking a string, and the usage site will need to handle parameterization.
     public static var actionDescription: Attribute<String> {
         Attribute<String>(AXAttributeNames.kAXActionDescriptionAttribute)
     }
 
     // MARK: - AXValue holding attributes (expect these to return AXValueRef)
 
-    // These will typically be unwrapped by a helper function (like ValueParser or similar) into their Swift types.
-    public static var position: Attribute<CGPoint> { Attribute<CGPoint>(AXAttributeNames.kAXPositionAttribute) }
-    public static var size: Attribute<CGSize> { Attribute<CGSize>(AXAttributeNames.kAXSizeAttribute) }
+    /// These will typically be unwrapped by a helper function (like ValueParser or similar) into their Swift types.
+    public static var position: Attribute<CGPoint> {
+        Attribute<CGPoint>(AXAttributeNames.kAXPositionAttribute)
+    }
+
+    public static var size: Attribute<CGSize> {
+        Attribute<CGSize>(AXAttributeNames.kAXSizeAttribute)
+    }
 
     // Note: CGRect for kAXBoundsAttribute is also common if available.
     // For now, relying on position and size.

--- a/Sources/AXorcist/Core/AttributeValue.swift
+++ b/Sources/AXorcist/Core/AttributeValue.swift
@@ -78,43 +78,57 @@ public enum AttributeValue: Codable, Sendable, Equatable {
 extension AttributeValue {
     /// Extracts the string value if this is a string, otherwise returns nil
     public var stringValue: String? {
-        if case let .string(value) = self { return value }
+        if case let .string(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Extracts the boolean value if this is a bool, otherwise returns nil
     public var boolValue: Bool? {
-        if case let .bool(value) = self { return value }
+        if case let .bool(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Extracts the integer value if this is an int, otherwise returns nil
     public var intValue: Int? {
-        if case let .int(value) = self { return value }
+        if case let .int(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Extracts the double value if this is a double, otherwise returns nil
     public var doubleValue: Double? {
-        if case let .double(value) = self { return value }
+        if case let .double(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Extracts the array value if this is an array, otherwise returns nil
     public var arrayValue: [AttributeValue]? {
-        if case let .array(value) = self { return value }
+        if case let .array(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Extracts the dictionary value if this is a dictionary, otherwise returns nil
     public var dictionaryValue: [String: AttributeValue]? {
-        if case let .dictionary(value) = self { return value }
+        if case let .dictionary(value) = self {
+            return value
+        }
         return nil
     }
 
     /// Returns true if this is a null value
     public var isNull: Bool {
-        if case .null = self { return true }
+        if case .null = self {
+            return true
+        }
         return false
     }
 }

--- a/Sources/AXorcist/Core/CommandEnvelope.swift
+++ b/Sources/AXorcist/Core/CommandEnvelope.swift
@@ -222,7 +222,7 @@ public struct CommandEnvelope: Codable {
     /// When true, notifications from child elements will also be captured.
     public let watchChildren: Bool?
 
-    // New field for collectAll filtering
+    /// New field for collectAll filtering
     public let filterCriteria: [String: String]?
 
     // Additional fields for various commands

--- a/Sources/AXorcist/Core/DataModels.swift
+++ b/Sources/AXorcist/Core/DataModels.swift
@@ -56,13 +56,13 @@ public struct AXValueWrapper: Codable, Sendable, Equatable {
 
     // MARK: Private
 
-    // Static helper to sanitize individual items, called recursively by init for collections
+    /// Static helper to sanitize individual items, called recursively by init for collections
     @MainActor
     private static func recursivelySanitize(_ item: Any?) -> Any {
         self.recursivelySanitizeWithDepth(item, depth: 0, visited: Set<ObjectIdentifier>())
     }
 
-    // Convert sanitized Any value to AttributeValue
+    /// Convert sanitized Any value to AttributeValue
     private static func convertToAttributeValue(_ value: Any) -> AttributeValue? {
         switch value {
         case let string as String:
@@ -106,9 +106,15 @@ public struct AXValueWrapper: Codable, Sendable, Equatable {
         }
 
         let cfItem = anItem as CFTypeRef
-        if CFGetTypeID(cfItem) == CFNullGetTypeID() { return () } // NSNull to null marker
-        if CFGetTypeID(cfItem) == AXUIElementGetTypeID() { return "<AXUIElement_RS>" }
-        if let element = anItem as? Element { return "<Element_RS: \(element.briefDescription(option: .raw))>" }
+        if CFGetTypeID(cfItem) == CFNullGetTypeID() {
+            return ()
+        } // NSNull to null marker
+        if CFGetTypeID(cfItem) == AXUIElementGetTypeID() {
+            return "<AXUIElement_RS>"
+        }
+        if let element = anItem as? Element {
+            return "<Element_RS: \(element.briefDescription(option: .raw))>"
+        }
 
         // If it's a collection, recurse with cycle detection
         if let array = anItem as? [Any?] {
@@ -147,7 +153,7 @@ public nonisolated struct AXElement: Codable, HandlerDataRepresentable {
 public struct SearchLogEntry: Codable {
     // MARK: Lifecycle
 
-    // Public initializer
+    /// Public initializer
     public init(
         depth: Int,
         elementRole: String?,

--- a/Sources/AXorcist/Core/Element+Actions.swift
+++ b/Sources/AXorcist/Core/Element+Actions.swift
@@ -5,7 +5,7 @@ import Foundation
 
 // GlobalAXLogger should be available
 
-// Action-related extension for Element
+/// Action-related extension for Element
 extension Element {
     // MARK: - Actions
 

--- a/Sources/AXorcist/Core/Element+ApplicationActions.swift
+++ b/Sources/AXorcist/Core/Element+ApplicationActions.swift
@@ -4,8 +4,8 @@ import ApplicationServices
 import Foundation
 
 extension Element {
-    // Helper to set a boolean attribute value.
-    // Returns true on success, false on failure.
+    /// Helper to set a boolean attribute value.
+    /// Returns true on success, false on failure.
     @MainActor
     private func setBooleanAttribute(_ attributeName: String, value: Bool) -> Bool {
         let cfValue: CFBoolean = CFConstants.cfBoolean(from: value)

--- a/Sources/AXorcist/Core/Element+Hierarchy.swift
+++ b/Sources/AXorcist/Core/Element+Hierarchy.swift
@@ -170,7 +170,7 @@ private let maxChildrenPerElement = 50000
 private struct ChildCollector {
     // MARK: Public
 
-    // New public method to get the count of unique children
+    /// New public method to get the count of unique children
     func collectedChildrenCount() -> Int {
         self.uniqueChildrenSet.count
     }
@@ -178,7 +178,9 @@ private struct ChildCollector {
     // MARK: Internal
 
     mutating func addChildren(from childrenUI: [AXUIElement]) { // Removed dLog param
-        if self.limitReached { return }
+        if self.limitReached {
+            return
+        }
 
         for childUI in childrenUI {
             if self.collectedChildren.count >= maxChildrenPerElement {

--- a/Sources/AXorcist/Core/Element+ParameterizedAttributes.swift
+++ b/Sources/AXorcist/Core/Element+ParameterizedAttributes.swift
@@ -76,8 +76,12 @@ extension Element {
     @MainActor
     private func castValueToType<T>(_ finalValue: Any, attribute: Attribute<T>) -> T? {
         if T.self == String.self {
-            if let str = finalValue as? String { return str as? T }
-            if let attrStr = finalValue as? NSAttributedString { return attrStr.string as? T }
+            if let str = finalValue as? String {
+                return str as? T
+            }
+            if let attrStr = finalValue as? NSAttributedString {
+                return attrStr.string as? T
+            }
             axDebugLog(
                 "Failed to cast unwrapped value for String attribute \(attribute.rawValue). " +
                     "Value: \(finalValue)")

--- a/Sources/AXorcist/Core/Element+PathGeneration.swift
+++ b/Sources/AXorcist/Core/Element+PathGeneration.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // GlobalAXLogger should be available
 
-// Extension to generate a descriptive path string
+/// Extension to generate a descriptive path string
 extension Element {
     @MainActor
     public func generatePathString(upTo ancestor: Element? = nil) -> String { // Removed logging params
@@ -66,7 +66,7 @@ extension Element {
         return finalPath
     }
 
-    // New function to return path components as an array
+    /// New function to return path components as an array
     @MainActor
     public func generatePathArray(upTo ancestor: Element? = nil) -> [String] { // Removed logging params
         var pathComponents: [String] = []

--- a/Sources/AXorcist/Core/Element+Properties.swift
+++ b/Sources/AXorcist/Core/Element+Properties.swift
@@ -6,7 +6,7 @@ import Foundation
 // MARK: - Element Common Attribute Getters & Status Properties
 
 extension Element {
-    // Common Attribute Getters - now simplified
+    /// Common Attribute Getters - now simplified
     @MainActor public func role() -> String? {
         attribute(Attribute<String>.role)
     }
@@ -19,7 +19,7 @@ extension Element {
         attribute(Attribute<String>.title)
     }
 
-    // Renamed from 'description' to 'descriptionText'
+    /// Renamed from 'description' to 'descriptionText'
     @MainActor public func descriptionText() -> String? {
         attribute(Attribute<String>.description)
     }
@@ -44,7 +44,7 @@ extension Element {
         attribute(Attribute<String>.identifier)
     }
 
-    // Status Properties - simplified
+    /// Status Properties - simplified
     @MainActor public func isFocused() -> Bool? {
         attribute(Attribute<Bool>.focused)
     }
@@ -78,7 +78,7 @@ extension Element {
         return nil
     }
 
-    // Hierarchy and Relationship Getters - simplified
+    /// Hierarchy and Relationship Getters - simplified
     @MainActor public func parent() -> Element? {
         guard let parentElementUI: AXUIElement = attribute(.parent) else { return nil }
         return Element(parentElementUI)
@@ -104,7 +104,7 @@ extension Element {
         return Element(windowElementUI)
     }
 
-    // Attempts to get the focused UI element within this element (e.g., a focused text field in a window).
+    /// Attempts to get the focused UI element within this element (e.g., a focused text field in a window).
     @MainActor
     public func focusedUIElement() -> Element? {
         // Use the specific type for the attribute, non-optional generic
@@ -112,19 +112,20 @@ extension Element {
         return Element(elementUI)
     }
 
-    // Action-related - simplified
+    /// Action-related - simplified
     @MainActor
     public func supportedActions() -> [String]? {
         // Action names have a dedicated Accessibility API; they are not a standard attribute.
         var names: CFArray?
         if AXUIElementCopyActionNames(underlyingElement, &names) == .success,
-           let actions = names as? [String] {
+           let actions = names as? [String]
+        {
             return actions
         }
         return attribute(Attribute<[String]>.actionNames)
     }
 
-    // domIdentifier - simplified to a single method, was previously a computed property and a method.
+    /// domIdentifier - simplified to a single method, was previously a computed property and a method.
     @MainActor public func domIdentifier() -> String? {
         attribute(Attribute<String>(AXAttributeNames.kAXDOMIdentifierAttribute))
     }
@@ -139,7 +140,7 @@ extension Element {
         return Element(buttonAXUIElement)
     }
 
-    // Specific UI Buttons in a Window
+    /// Specific UI Buttons in a Window
     @MainActor public func closeButton() -> Element? {
         guard let buttonAXUIElement = attribute(.closeButton) else { return nil }
         return Element(buttonAXUIElement)
@@ -165,13 +166,13 @@ extension Element {
         return Element(buttonAXUIElement)
     }
 
-    // Proxy (e.g. for web content)
+    /// Proxy (e.g. for web content)
     @MainActor public func proxy() -> Element? {
         guard let proxyAXUIElement = attribute(.proxy) else { return nil }
         return Element(proxyAXUIElement)
     }
 
-    // Grow Area (e.g. for resizing window)
+    /// Grow Area (e.g. for resizing window)
     @MainActor public func growArea() -> Element? {
         guard let growAreaAXUIElement = attribute(.growArea) else { return nil }
         return Element(growAreaAXUIElement)
@@ -182,7 +183,7 @@ extension Element {
         return Element(headerAXUIElement)
     }
 
-    // Scroll Area properties
+    /// Scroll Area properties
     @MainActor public func horizontalScrollBar() -> Element? {
         guard let scrollBarAXUIElement = attribute(.horizontalScrollBar) else { return nil }
         return Element(scrollBarAXUIElement)

--- a/Sources/AXorcist/Core/Element+TypeChecking.swift
+++ b/Sources/AXorcist/Core/Element+TypeChecking.swift
@@ -309,7 +309,9 @@ extension Element {
     /// Check if element is scrollable (has scroll bars or is a scroll area)
     @MainActor
     public func isScrollable() -> Bool {
-        if self.isScrollArea() { return true }
+        if self.isScrollArea() {
+            return true
+        }
 
         // Check if it has scroll bars
         if horizontalScrollBar() != nil || verticalScrollBar() != nil {

--- a/Sources/AXorcist/Core/Element+WindowOperations.swift
+++ b/Sources/AXorcist/Core/Element+WindowOperations.swift
@@ -2,7 +2,7 @@ import AppKit
 import ApplicationServices
 import os.log
 
-// Create a logger for window operations
+/// Create a logger for window operations
 private let windowLogger = Logger(subsystem: "boo.peekaboo.axorcist", category: "WindowOperations")
 
 /// Window-specific accessibility operations

--- a/Sources/AXorcist/Core/ElementFactories.swift
+++ b/Sources/AXorcist/Core/ElementFactories.swift
@@ -3,7 +3,7 @@
 import ApplicationServices // For AXUIElement and other C APIs
 import Foundation
 
-// Convenience factory for the application element - already @MainActor
+/// Convenience factory for the application element - already @MainActor
 @MainActor
 public func applicationElement(for bundleIdOrName: String) -> Element? {
     // pid() is assumed to be refactored to use GlobalAXLogger or handle its own logging.
@@ -24,7 +24,7 @@ public func applicationElement(for bundleIdOrName: String) -> Element? {
     return Element(appElement)
 }
 
-// Convenience factory for application element from PID - already @MainActor
+/// Convenience factory for application element from PID - already @MainActor
 @MainActor
 public func applicationElement(forProcessID pid: pid_t) -> Element? {
     guard pid > 0 else {
@@ -44,7 +44,7 @@ public func applicationElement(forProcessID pid: pid_t) -> Element? {
     return Element(appElement)
 }
 
-// Convenience factory for the system-wide element - already @MainActor
+/// Convenience factory for the system-wide element - already @MainActor
 @MainActor
 public func systemWideElement() -> Element {
     axDebugLog(
@@ -55,7 +55,7 @@ public func systemWideElement() -> Element {
     return Element(AXUIElement.systemWide)
 }
 
-// Additional convenience factories using new static helpers
+/// Additional convenience factories using new static helpers
 /**
  Returns the accessibility element for the currently focused application.
  */

--- a/Sources/AXorcist/Core/InputDriver.swift
+++ b/Sources/AXorcist/Core/InputDriver.swift
@@ -39,7 +39,9 @@ public enum InputDriver {
 
     /// Cached current location provider to avoid repeated CGEvent creation in tight loops.
     public static func cachedLocation(using cache: inout CGPoint?) -> CGPoint? {
-        if let cached = cache { return cached }
+        if let cached = cache {
+            return cached
+        }
         let loc = self.currentLocation()
         cache = loc
         return loc
@@ -110,7 +112,9 @@ public enum InputDriver {
                 mouseButton: buttonType)
             else { continue }
             move.post(tap: .cghidEventTap)
-            if interStepDelay > 0 { Thread.sleep(forTimeInterval: interStepDelay) }
+            if interStepDelay > 0 {
+                Thread.sleep(forTimeInterval: interStepDelay)
+            }
         }
 
         guard let up = CGEvent(

--- a/Sources/AXorcist/Core/MatchingTypes.swift
+++ b/Sources/AXorcist/Core/MatchingTypes.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// Represents a single criterion for element matching
+/// Represents a single criterion for element matching
 public struct Criterion: Codable, Sendable {
     // MARK: Lifecycle
 
@@ -34,12 +34,12 @@ public struct Criterion: Codable, Sendable {
 
     // MARK: Internal
 
-    // With `JSONDecoder.keyDecodingStrategy = .convertFromSnakeCase`,
-    // we can simply rely on automatic snake-case → camel-case conversion.
-    // Using a custom raw value here would *break* that feature because the
-    // strategy is applied **after** the raw value is resolved, resulting in
-    // the decoder searching for a non-existent key ("matchType").
-    // Therefore we keep the raw key identical to the Swift property name.
+    /// With `JSONDecoder.keyDecodingStrategy = .convertFromSnakeCase`,
+    /// we can simply rely on automatic snake-case → camel-case conversion.
+    /// Using a custom raw value here would *break* that feature because the
+    /// strategy is applied **after** the raw value is resolved, resulting in
+    /// the decoder searching for a non-existent key ("matchType").
+    /// Therefore we keep the raw key identical to the Swift property name.
     enum CodingKeys: String, CodingKey {
         case attribute, value, matchType
     }
@@ -49,7 +49,7 @@ public struct Criterion: Codable, Sendable {
 public struct PathStep: Codable, Sendable {
     // MARK: Lifecycle
 
-    // Default initializer
+    /// Default initializer
     public init(
         criteria: [Criterion],
         matchType: JSONPathHintComponent.MatchType? = .exact,
@@ -90,7 +90,7 @@ public struct PathStep: Codable, Sendable {
 
     // MARK: Internal
 
-    // CodingKeys to map JSON keys to Swift properties
+    /// CodingKeys to map JSON keys to Swift properties
     enum CodingKeys: String, CodingKey {
         case criteria
         case matchType
@@ -99,7 +99,7 @@ public struct PathStep: Codable, Sendable {
     }
 }
 
-// Locator for finding elements
+/// Locator for finding elements
 public struct Locator: Codable, Sendable {
     // MARK: Lifecycle
 

--- a/Sources/AXorcist/Core/NotificationTypes.swift
+++ b/Sources/AXorcist/Core/NotificationTypes.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // MARK: - AXNotificationName enum
 
-// Define AXNotificationName as a String-based enum for notification names
+/// Define AXNotificationName as a String-based enum for notification names
 public enum AXNotificationName: String, Codable, Sendable {
     case focusedUIElementChanged = "AXFocusedUIElementChanged"
     case valueChanged = "AXValueChanged"

--- a/Sources/AXorcist/Core/PathUtils.swift
+++ b/Sources/AXorcist/Core/PathUtils.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public enum PathUtils {
-    // Mapping of common attribute shortcuts to their full AX attribute names
+    /// Mapping of common attribute shortcuts to their full AX attribute names
     public static let attributeKeyMappings: [String: String] = [
         "role": AXAttributeNames.kAXRoleAttribute,
         "subrole": AXAttributeNames.kAXSubroleAttribute,

--- a/Sources/AXorcist/Core/ResponseModels.swift
+++ b/Sources/AXorcist/Core/ResponseModels.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // MARK: - AXErrorCode
 
-// Error codes for AXorcist operations
+/// Error codes for AXorcist operations
 public enum AXErrorCode: String, Codable, Sendable {
     case elementNotFound = "element_not_found"
     case actionFailed = "action_failed"
@@ -23,14 +23,14 @@ public enum AXErrorCode: String, Codable, Sendable {
 
 // MARK: - AXResponse
 
-// Main response enum for AXorcist operations
+/// Main response enum for AXorcist operations
 public enum AXResponse: Sendable {
     case success(payload: AnyCodable?, logs: [String]?)
     case error(message: String, code: AXErrorCode, logs: [String]?)
 
     // MARK: Public
 
-    // Computed property for status
+    /// Computed property for status
     public var status: String {
         switch self {
         case .success: "success"
@@ -38,7 +38,7 @@ public enum AXResponse: Sendable {
         }
     }
 
-    // Computed property for payload
+    /// Computed property for payload
     public var payload: AnyCodable? {
         switch self {
         case let .success(payload, _): payload
@@ -46,7 +46,7 @@ public enum AXResponse: Sendable {
         }
     }
 
-    // Computed property for error
+    /// Computed property for error
     public var error: (message: String, code: AXErrorCode)? {
         switch self {
         case .success: nil
@@ -54,7 +54,7 @@ public enum AXResponse: Sendable {
         }
     }
 
-    // Computed property for logs
+    /// Computed property for logs
     public var logs: [String]? {
         switch self {
         case let .success(_, logs): logs
@@ -62,7 +62,7 @@ public enum AXResponse: Sendable {
         }
     }
 
-    // Static factory methods
+    /// Static factory methods
     public static func successResponse(payload: AnyCodable?, logs: [String]? = nil) -> AXResponse {
         .success(payload: payload, logs: logs)
     }
@@ -72,10 +72,10 @@ public enum AXResponse: Sendable {
     }
 }
 
-// New protocol for generic data in HandlerResponse
+/// New protocol for generic data in HandlerResponse
 public protocol HandlerDataRepresentable: Codable {}
 
-// Definition for AXElementData based on usage in AXorcist+QueryHandlers.swift
+/// Definition for AXElementData based on usage in AXorcist+QueryHandlers.swift
 public nonisolated struct AXElementData: Codable, HandlerDataRepresentable, Equatable {
     // MARK: Lifecycle
 
@@ -108,7 +108,7 @@ public nonisolated struct AXElementData: Codable, HandlerDataRepresentable, Equa
     public var textualContent: String?
     public var childrenBriefDescriptions: [String]?
     public var fullAXDescription: String?
-    // Add path here as it's often part of element data
+    /// Add path here as it's often part of element data
     public var path: [String]?
 }
 
@@ -116,7 +116,7 @@ public nonisolated struct AXElementData: Codable, HandlerDataRepresentable, Equa
 // AXElement is defined in DataModels.swift, so we'll make it conform there later.
 // For now, assume it will.
 
-// Response for query command (single element)
+/// Response for query command (single element)
 public struct QueryResponse: Codable {
     // MARK: Lifecycle
 
@@ -138,7 +138,7 @@ public struct QueryResponse: Codable {
         self.debugLogs = debugLogs
     }
 
-    // Custom init for HandlerResponse integration
+    /// Custom init for HandlerResponse integration
     public init(
         commandId: String,
         success: Bool,
@@ -186,7 +186,7 @@ public struct QueryResponse: Codable {
     }
 }
 
-// Extension to add JSON encoding functionality to QueryResponse
+/// Extension to add JSON encoding functionality to QueryResponse
 extension QueryResponse {
     public func jsonString() throws -> String {
         let encoder = JSONEncoder()
@@ -196,7 +196,7 @@ extension QueryResponse {
     }
 }
 
-// Response for collect_all command (multiple elements)
+/// Response for collect_all command (multiple elements)
 public struct MultiQueryResponse: Codable {
     // MARK: Lifecycle
 
@@ -233,7 +233,7 @@ public struct MultiQueryResponse: Codable {
     }
 }
 
-// Response for perform_action command
+/// Response for perform_action command
 public nonisolated struct PerformResponse: Codable, HandlerDataRepresentable {
     // MARK: Lifecycle
 
@@ -261,7 +261,7 @@ public nonisolated struct PerformResponse: Codable, HandlerDataRepresentable {
     }
 }
 
-// New response for extract_text command
+/// New response for extract_text command
 public nonisolated struct TextExtractionResponse: Codable, HandlerDataRepresentable {
     // MARK: Lifecycle
 
@@ -300,7 +300,7 @@ public nonisolated struct TextExtractionResponse: Codable, HandlerDataRepresenta
  }
  */
 
-// Generic error response
+/// Generic error response
 public struct ErrorResponse: Codable {
     // MARK: Lifecycle
 
@@ -340,7 +340,7 @@ public struct ErrorDetail: Codable, Equatable {
     public var message: String
 }
 
-// Simple success response, e.g. for ping
+/// Simple success response, e.g. for ping
 public struct SimpleSuccessResponse: Codable, Equatable {
     // MARK: Lifecycle
 
@@ -420,7 +420,7 @@ public struct BatchResponse: Codable {
 
 // MARK: - Additional Payload Structs
 
-// NoFocusPayload for when no focused element is found
+/// NoFocusPayload for when no focused element is found
 public nonisolated struct NoFocusPayload: Codable, HandlerDataRepresentable {
     // MARK: Lifecycle
 
@@ -433,7 +433,7 @@ public nonisolated struct NoFocusPayload: Codable, HandlerDataRepresentable {
     public let message: String
 }
 
-// TextPayload for text extraction
+/// TextPayload for text extraction
 public nonisolated struct TextPayload: Codable, HandlerDataRepresentable {
     // MARK: Lifecycle
 
@@ -446,7 +446,7 @@ public nonisolated struct TextPayload: Codable, HandlerDataRepresentable {
     public let text: String
 }
 
-// BatchResponsePayload for batch operations
+/// BatchResponsePayload for batch operations
 public nonisolated struct BatchResponsePayload: Codable, HandlerDataRepresentable {
     // MARK: Lifecycle
 
@@ -463,7 +463,7 @@ public nonisolated struct BatchResponsePayload: Codable, HandlerDataRepresentabl
 
 // MARK: - AXElementDescription
 
-// Structure for element tree descriptions
+/// Structure for element tree descriptions
 public struct AXElementDescription: Codable, Sendable {
     // MARK: Lifecycle
 
@@ -487,14 +487,14 @@ public struct AXElementDescription: Codable, Sendable {
     public let children: [AXElementDescription]?
 }
 
-// Structure for custom JSON output of handleCollectAll
+/// Structure for custom JSON output of handleCollectAll
 public struct CollectAllOutput: Codable {
     // MARK: Lifecycle
 
-    // Add a new initializer or ensure the existing one matches these fields.
-    // Assuming the default memberwise initializer will now work with these changes,
-    // or one will be synthesized. If a custom one exists, it will need updating.
-    // For safety, let's add one that matches the typical usage pattern.
+    /// Add a new initializer or ensure the existing one matches these fields.
+    /// Assuming the default memberwise initializer will now work with these changes,
+    /// or one will be synthesized. If a custom one exists, it will need updating.
+    /// For safety, let's add one that matches the typical usage pattern.
     public init(
         commandId: String,
         success: Bool,

--- a/Sources/AXorcist/Core/ValueFormatOption.swift
+++ b/Sources/AXorcist/Core/ValueFormatOption.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// Enum for specifying how values, especially for descriptions, should be formatted.
+/// Enum for specifying how values, especially for descriptions, should be formatted.
 public enum ValueFormatOption: String, Codable, Sendable {
     case smart // Tries to provide the most useful, possibly summarized, representation.
     case raw // Provides the raw or complete value, potentially verbose.

--- a/Sources/AXorcist/Logging/AXLogEntry.swift
+++ b/Sources/AXorcist/Logging/AXLogEntry.swift
@@ -8,14 +8,14 @@ public enum AXLogLevel: String, Codable, Sendable, CaseIterable {
     case critical // For errors that might lead to a crash or critical malfunction
 }
 
-// Added AXLogDetailLevel
+/// Added AXLogDetailLevel
 public enum AXLogDetailLevel: String, Codable, Sendable, CaseIterable {
     case minimal // Only critical/error messages
     case normal // Info, warning, error, critical
     case verbose // Debug, info, warning, error, critical (all messages)
 }
 
-// Added AXLogOutputFormat
+/// Added AXLogOutputFormat
 public enum AXLogOutputFormat: String, Codable, Sendable, CaseIterable {
     case text
     case json
@@ -56,14 +56,14 @@ public struct AXLogEntry: Codable, Sendable, Identifiable {
     public let details: [String: AnyCodable]? // Changed to AnyCodable
 }
 
-// Add Equatable conformance
+/// Add Equatable conformance
 extension AXLogEntry: Equatable {
     public static func == (lhs: AXLogEntry, rhs: AXLogEntry) -> Bool {
         lhs.id == rhs.id
     }
 }
 
-// Example of how it might be formatted for text output
+/// Example of how it might be formatted for text output
 extension AXLogEntry {
     public func formattedForTextLog() -> String {
         let dateFormatter = ISO8601DateFormatter()

--- a/Sources/AXorcist/Logging/GlobalAXLogger.swift
+++ b/Sources/AXorcist/Logging/GlobalAXLogger.swift
@@ -31,12 +31,14 @@ public class GlobalAXLogger {
 
     // MARK: - Logging Core
 
-    // Assumes this method is always called on the main thread.
+    /// Assumes this method is always called on the main thread.
     public func log(_ entry: AXLogEntry) {
         guard self.shouldLog(entry) else { return }
 
         let condensedMessage = self.condensedMessage(for: entry.message)
-        if self.shouldSkipDueToDuplicate(message: condensedMessage, entry: entry) { return }
+        if self.shouldSkipDueToDuplicate(message: condensedMessage, entry: entry) {
+            return
+        }
 
         let processedEntry = entry.withMessage(condensedMessage)
         self.logEntries.append(processedEntry)
@@ -45,7 +47,7 @@ public class GlobalAXLogger {
 
     // MARK: - Log Retrieval
 
-    // Assumes these methods are always called on the main thread.
+    /// Assumes these methods are always called on the main thread.
     public func getEntries() -> [AXLogEntry] {
         self.logEntries
     }

--- a/Sources/AXorcist/Models/JSONPathHintComponent.swift
+++ b/Sources/AXorcist/Models/JSONPathHintComponent.swift
@@ -14,8 +14,8 @@ public struct JSONPathHintComponent: Codable, Sendable {
         self.matchType = matchType
     }
 
-    // If you need custom Codable implementation because of the new optional field
-    // and want to maintain existing JSON compatibility (if matchType is often absent):
+    /// If you need custom Codable implementation because of the new optional field
+    /// and want to maintain existing JSON compatibility (if matchType is often absent):
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.attribute = try container.decode(String.self, forKey: .attribute)
@@ -86,7 +86,7 @@ public struct JSONPathHintComponent: Codable, Sendable {
 
     // MARK: Internal
 
-    // Default depth if not specified in JSON
+    /// Default depth if not specified in JSON
     static let defaultDepthForSegment = 3
 
     // MARK: Private

--- a/Sources/AXorcist/Search/AttributeExtractors.swift
+++ b/Sources/AXorcist/Search/AttributeExtractors.swift
@@ -5,7 +5,7 @@ import Foundation
 
 // MARK: - Internal Fetch Logic Helpers
 
-// Approach using direct property access within a switch statement
+/// Approach using direct property access within a switch statement
 @MainActor
 func extractDirectPropertyValue(
     for attributeName: String,
@@ -25,7 +25,9 @@ func determineAttributesToFetch(
     targetRole: String?,
     element: Element) -> [String]
 {
-    if forMultiDefault { return defaultMultiAttributes(for: targetRole) }
+    if forMultiDefault {
+        return defaultMultiAttributes(for: targetRole)
+    }
 
     if let requested = requestedAttributes, !requested.isEmpty {
         return requested
@@ -72,7 +74,7 @@ private struct AttributeDefaultSet {
     }
 }
 
-// Function to get specifically computed attributes for an element
+/// Function to get specifically computed attributes for an element
 @MainActor
 func getComputedAttributes(for element: Element) async -> [String: AttributeData] {
     var computedAttrs: [String: AttributeData] = [:]

--- a/Sources/AXorcist/Search/AttributeFormatter.swift
+++ b/Sources/AXorcist/Search/AttributeFormatter.swift
@@ -3,7 +3,7 @@
 import ApplicationServices
 import Foundation
 
-// Helper function to format the parent attribute
+/// Helper function to format the parent attribute
 @MainActor
 func formatParentAttribute(
     _ parent: Element?,
@@ -18,7 +18,7 @@ func formatParentAttribute(
     }
 }
 
-// Helper function to format the children attribute
+/// Helper function to format the children attribute
 @MainActor
 func formatChildrenAttribute(
     _ children: [Element]?,
@@ -41,7 +41,7 @@ func formatChildrenAttribute(
     }
 }
 
-// Helper function to format the focused UI element attribute
+/// Helper function to format the focused UI element attribute
 @MainActor
 func formatFocusedUIElementAttribute(
     _ focusedElement: Element?,

--- a/Sources/AXorcist/Search/AttributeFormatters.swift
+++ b/Sources/AXorcist/Search/AttributeFormatters.swift
@@ -4,7 +4,7 @@ import ApplicationServices
 import CoreGraphics
 import Foundation
 
-// Helper for formatting raw CFTypeRef values for .textContent output
+/// Helper for formatting raw CFTypeRef values for .textContent output
 @MainActor
 func formatRawCFValueForTextContent(_ rawValue: CFTypeRef?) async -> String {
     guard let value = rawValue else { return AXMiscConstants.kAXNotAvailableString }

--- a/Sources/AXorcist/Search/AttributeTypes.swift
+++ b/Sources/AXorcist/Search/AttributeTypes.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// ElementDetails struct for AXpector
+/// ElementDetails struct for AXpector
 public struct ElementDetails {
     // MARK: Lifecycle
 
@@ -24,14 +24,14 @@ public struct ElementDetails {
     public var computedName: String?
 }
 
-// Enum to specify the source of an attribute
+/// Enum to specify the source of an attribute
 public enum AttributeSource: String, Codable {
     case direct // Directly from AXUIElement
     case computed // Computed by AXorcist (e.g., path, name heuristic)
     case prefetched // From element's stored attributes dictionary
 }
 
-// Struct to hold attribute data along with its source
+/// Struct to hold attribute data along with its source
 public struct AttributeData: Codable {
     public let value: AttributeValue
     public let source: AttributeSource

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -269,11 +269,11 @@ public func collectAllElements(
 
 // MARK: - Generic Tree Traversal with Visitor
 
-// Protocol for visitors used in tree traversal
+/// Protocol for visitors used in tree traversal
 @MainActor
 public protocol ElementVisitor {
-    // If visit returns .stop, traversal stops. If .skipChildren, children of current element are not visited.
-    // Otherwise, traversal continues (.continue).
+    /// If visit returns .stop, traversal stops. If .skipChildren, children of current element are not visited.
+    /// Otherwise, traversal continues (.continue).
     func visit(element: Element, depth: Int) -> TreeVisitorResult
 }
 
@@ -384,7 +384,9 @@ public class SearchVisitor: ElementVisitor {
     private var currentMaxDepthReachedByVisitor: Int = 0
     private let matchType: JSONPathHintComponent.MatchType
     private let matchAllCriteriaBool: Bool
-    public var deepestDepthReached: Int { self.currentMaxDepthReachedByVisitor }
+    public var deepestDepthReached: Int {
+        self.currentMaxDepthReachedByVisitor
+    }
 
     init(
         criteria: [Criterion],
@@ -451,7 +453,7 @@ public class SearchVisitor: ElementVisitor {
         return .continue
     }
 
-    // Resets the visitor state for reuse, e.g., when searching different branches of a tree.
+    /// Resets the visitor state for reuse, e.g., when searching different branches of a tree.
     public func reset() {
         self.foundElement = nil
         self.allFoundElements.removeAll()
@@ -517,7 +519,7 @@ private func describeCriteria(_ criteria: [Criterion]) -> String {
     return description.isEmpty ? "none" : description
 }
 
-// Container roles that can have meaningful descendants. Non-container roles are treated as leaves.
+/// Container roles that can have meaningful descendants. Non-container roles are treated as leaves.
 private let containerRoles: Set<String> = [
     AXRoleNames.kAXApplicationRole,
     AXRoleNames.kAXWindowRole,

--- a/Sources/AXorcist/Search/GeometryHelpers.swift
+++ b/Sources/AXorcist/Search/GeometryHelpers.swift
@@ -3,8 +3,8 @@
 import CoreGraphics
 import Foundation
 
-// Helper functions to convert CoreGraphics types to dictionaries for JSON serialization
-// These are needed because AnyCodable might not handle them directly as dictionaries.
+/// Helper functions to convert CoreGraphics types to dictionaries for JSON serialization
+/// These are needed because AnyCodable might not handle them directly as dictionaries.
 func NSPointToDictionary(_ point: CGPoint) -> [String: CGFloat] {
     ["x": point.x, "y": point.y]
 }

--- a/Sources/AXorcist/Search/NavigationUtils.swift
+++ b/Sources/AXorcist/Search/NavigationUtils.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-// This function demonstrates the requested pattern for trimming whitespace before splitting
+/// This function demonstrates the requested pattern for trimming whitespace before splitting
 @MainActor
 public func navigateToElementWithTrimming(
     pathComponents: [String]) -> [(String, String)]

--- a/Sources/AXorcist/Search/PathHintComponent.swift
+++ b/Sources/AXorcist/Search/PathHintComponent.swift
@@ -4,8 +4,8 @@ import Foundation
 
 // MARK: - PathHintComponent Definition
 
-// This PathHintComponent is simpler and used for basic string path hints if ever needed again.
-// For new functionality, JSONPathHintComponent is preferred.
+/// This PathHintComponent is simpler and used for basic string path hints if ever needed again.
+/// For new functionality, JSONPathHintComponent is preferred.
 @MainActor
 public struct PathHintComponent {
     // MARK: Lifecycle
@@ -56,7 +56,7 @@ public struct PathHintComponent {
 
     // MARK: Internal
 
-    // PathHintComponent uses exact matching by default when calling elementMatchesCriteria
+    /// PathHintComponent uses exact matching by default when calling elementMatchesCriteria
     func matches(element: Element) -> Bool {
         elementMatchesCriteria(
             element,

--- a/Sources/AXorcist/Search/PathNavigationJSON.swift
+++ b/Sources/AXorcist/Search/PathNavigationJSON.swift
@@ -4,7 +4,7 @@ import ApplicationServices
 import Foundation
 import Logging
 
-// Define logger for this file
+/// Define logger for this file
 private let logger = Logger(label: "AXorcist.PathNavigationJSON")
 
 // MARK: - JSON PathHint Navigation

--- a/Sources/AXorcist/Search/PathNavigationMatching.swift
+++ b/Sources/AXorcist/Search/PathNavigationMatching.swift
@@ -11,7 +11,7 @@ private func logPathNavigation(_ level: AXLogLevel, _ message: String) {
 
 // MARK: - Element Matching
 
-// New helper to check if an element matches all given criteria
+/// New helper to check if an element matches all given criteria
 @MainActor
 func elementMatchesAllCriteria(
     _ element: Element,

--- a/Sources/AXorcist/Utils/AXObserverManager.swift
+++ b/Sources/AXorcist/Utils/AXObserverManager.swift
@@ -42,20 +42,20 @@ public class AXObserverManager {
 
     // MARK: Public
 
-    // Typealias for notification callback - matches AXObserverCallbackWithInfo but without refcon
+    /// Typealias for notification callback - matches AXObserverCallbackWithInfo but without refcon
     public typealias AXNotificationCallback = (AXObserver, AXUIElement, CFString, CFDictionary?) -> Void
 
-    // Error types
+    /// Error types
     public enum ObserverError: Error {
         case couldNotCreateObserver
         case addNotificationFailed(AXError)
         case other(String)
     }
 
-    // Singleton instance
+    /// Singleton instance
     public static let shared = AXObserverManager()
 
-    // Add observer for an element and notification
+    /// Add observer for an element and notification
     public func addObserver(
         for element: Element,
         notification: AXNotification,
@@ -82,7 +82,7 @@ public class AXObserverManager {
             callback: callback)
     }
 
-    // Remove observer for an element and notification
+    /// Remove observer for an element and notification
     public func removeObserver(for element: Element, notification: AXNotification) throws {
         let elementId = ObjectIdentifier(element.underlyingElement as AnyObject)
 
@@ -125,7 +125,7 @@ public class AXObserverManager {
         }
     }
 
-    // Remove all observers
+    /// Remove all observers
     public func removeAllObservers() {
         self.observerLock.lock()
         defer { observerLock.unlock() }
@@ -144,7 +144,7 @@ public class AXObserverManager {
 
     // MARK: Private
 
-    // Private storage for observers and callbacks
+    /// Private storage for observers and callbacks
     private struct ObserverInfo {
         let observer: AXObserver
         let runLoopSource: CFRunLoopSource
@@ -158,7 +158,7 @@ public class AXObserverManager {
     private var observers: [ObjectIdentifier: ObserverInfo] = [:]
     private let observerLock = NSLock()
 
-    // Handle incoming notifications
+    /// Handle incoming notifications
     private func handleNotification(
         observer: AXObserver,
         element: AXUIElement,

--- a/Sources/AXorcist/Utils/CustomCharacterSet.swift
+++ b/Sources/AXorcist/Utils/CustomCharacterSet.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// CustomCharacterSet struct from Scanner
+/// CustomCharacterSet struct from Scanner
 public struct CustomCharacterSet {
     // MARK: Lifecycle
 
@@ -14,7 +14,7 @@ public struct CustomCharacterSet {
 
     // MARK: Public
 
-    // Add some common character sets that might be useful, similar to Foundation.CharacterSet
+    /// Add some common character sets that might be useful, similar to Foundation.CharacterSet
     public static var whitespacesAndNewlines: CustomCharacterSet {
         CustomCharacterSet(charactersInString: " \t\n\r")
     }

--- a/Sources/AXorcist/Utils/RunningApplicationHelper.swift
+++ b/Sources/AXorcist/Utils/RunningApplicationHelper.swift
@@ -5,8 +5,8 @@
 //  Helper utilities for discovering and working with running applications
 //
 
-import ApplicationServices
 import AppKit
+import ApplicationServices
 import Foundation
 #if canImport(CoreGraphics)
 import CoreGraphics // Added for CGWindowListCopyWindowInfo

--- a/Sources/AXorcist/Utils/Scanner.swift
+++ b/Sources/AXorcist/Utils/Scanner.swift
@@ -73,23 +73,27 @@ class Scanner {
         self.location >= self.string.count
     }
 
-    // Helper to get the remaining string
+    /// Helper to get the remaining string
     var remainingString: String {
-        if self.isAtEnd { return "" }
+        if self.isAtEnd {
+            return ""
+        }
         let startIndex = self.string.index(self.string.startIndex, offsetBy: self.location)
         return String(self.string[startIndex...])
     }
 
     // MARK: - Character Set Scanning
 
-    // A more conventional scanUpTo (scans until a character in the set is found)
+    /// A more conventional scanUpTo (scans until a character in the set is found)
     @discardableResult func scanUpToCharacters(in charSet: CustomCharacterSet) -> String? {
         let initialLocation = self.location
         var scannedCharacters = String()
 
         while self.location < self.string.count {
             let currentChar = self.string[self.location]
-            if charSet.contains(currentChar) { break }
+            if charSet.contains(currentChar) {
+                break
+            }
             scannedCharacters.append(currentChar)
             self.location += 1
         }
@@ -97,7 +101,7 @@ class Scanner {
         return scannedCharacters.isEmpty && self.location == initialLocation ? nil : scannedCharacters
     }
 
-    // Scans characters that ARE in the provided set (like original Scanner's scanUpTo/scan(characterSet:))
+    /// Scans characters that ARE in the provided set (like original Scanner's scanUpTo/scan(characterSet:))
     @discardableResult func scanCharacters(in charSet: CustomCharacterSet) -> String? {
         let initialLocation = self.location
         var characters = String()
@@ -214,7 +218,7 @@ class Scanner {
 
     // MARK: - Floating Point Scanning
 
-    // Attempt to parse Double with a compact implementation
+    /// Attempt to parse Double with a compact implementation
     func scanDouble() -> Double? {
         self.scanWhitespaces()
         let initialLocation = self.location
@@ -340,7 +344,7 @@ class Scanner {
 
     // MARK: Private
 
-    // Mapping hex characters to their integer values
+    /// Mapping hex characters to their integer values
     private static let hexValues: [Character: Int] = [
         "0": 0, "1": 1, "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "8": 8, "9": 9,
         "a": 10, "b": 11, "c": 12, "d": 13, "e": 14, "f": 15,
@@ -349,29 +353,33 @@ class Scanner {
 
     // MARK: - Identifier Scanning
 
-    // Character sets for identifier scanning
+    /// Character sets for identifier scanning
     private static let characterSets = (
         lowercaseLetters: "abcdefghijklmnopqrstuvwxyz",
         uppercaseLetters: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
         digits: "0123456789",
         hexDigits: "0123456789abcdefABCDEF")
 
-    // Private helper that scans and returns a string of digits
+    /// Private helper that scans and returns a string of digits
     private func scanDigits() -> String? {
         self.scanCharacters(in: .decimalDigits)
     }
 
-    // Calculate integer value from digit string with given base
+    /// Calculate integer value from digit string with given base
     private func integerValue<T: BinaryInteger>(from digitString: String, base: T = 10) -> T {
         digitString.reduce(T(0)) { result, char in
             result * base + T(Int(String(char))!)
         }
     }
 
-    // Helper function for power calculation with FloatingPoint types
+    /// Helper function for power calculation with FloatingPoint types
     private func scannerPower<T: FloatingPoint>(base: T, exponent: Int) -> T {
-        if exponent == 0 { return T(1) }
-        if exponent < 0 { return T(1) / self.scannerPower(base: base, exponent: -exponent) }
+        if exponent == 0 {
+            return T(1)
+        }
+        if exponent < 0 {
+            return T(1) / self.scannerPower(base: base, exponent: -exponent)
+        }
         var result = T(1)
         for _ in 0..<exponent {
             result *= base

--- a/Sources/AXorcist/Utils/SerializationUtils.swift
+++ b/Sources/AXorcist/Utils/SerializationUtils.swift
@@ -5,7 +5,7 @@ import Foundation
 // Consider if AXNotification needs to be accessible here, or if its rawValue is sufficient.
 // If AXorcist/Models/DataModels.swift defines AXNotification, that might be a better import.
 
-// Recursively sanitize value into JSON-encodable form
+/// Recursively sanitize value into JSON-encodable form
 func sanitizeValue(_ val: Any) -> Any {
     if let specialValue = sanitizeSpecialValue(val) {
         return specialValue
@@ -54,8 +54,8 @@ private func isPrimitiveJSONValue(_ value: Any) -> Bool {
     value is String || value is Int || value is Double || value is Bool || value is NSNull
 }
 
-// Ensure all nested values are JSON-serialisable (NSString/NSNumber/NSNull/Array/Dict)
-// This function is crucial for preparing the payload for JSONSerialization.
+/// Ensure all nested values are JSON-serialisable (NSString/NSNumber/NSNull/Array/Dict)
+/// This function is crucial for preparing the payload for JSONSerialization.
 func makeJSONCompatible(_ value: Any) -> Any {
     switch value {
     case let str as String:

--- a/Sources/AXorcist/Utils/String+HelperExtensions.swift
+++ b/Sources/AXorcist/Utils/String+HelperExtensions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// String extension from Scanner
+/// String extension from Scanner
 extension String {
     subscript(offset: Int) -> Character {
         self[index(startIndex, offsetBy: offset)]

--- a/Sources/AXorcist/Utils/TextExtraction.swift
+++ b/Sources/AXorcist/Utils/TextExtraction.swift
@@ -14,10 +14,18 @@ public func extractTextFromElement(_ element: Element, maxDepth: Int = 5, curren
     }
 
     // Attempt to get text from common attributes
-    if let title = element.title(), !title.isEmpty { return title }
-    if let value = element.value() as? String, !value.isEmpty { return value }
-    if let description = element.descriptionText(), !description.isEmpty { return description }
-    if let help = element.help(), !help.isEmpty { return help }
+    if let title = element.title(), !title.isEmpty {
+        return title
+    }
+    if let value = element.value() as? String, !value.isEmpty {
+        return value
+    }
+    if let description = element.descriptionText(), !description.isEmpty {
+        return description
+    }
+    if let help = element.help(), !help.isEmpty {
+        return help
+    }
 
     // If no direct text, try children
     var childrenText: [String] = []
@@ -44,13 +52,23 @@ public func extractTextFromElement(_ element: Element, maxDepth: Int = 5, curren
 @MainActor
 public func extractTextFromElementNonRecursive(_ element: Element) -> String? {
     // Try attributes that often hold primary text
-    if let title = element.title(), !title.isEmpty { return title }
-    if let value = element.value() as? String, !value.isEmpty { return value }
-    if let description = element.descriptionText(), !description.isEmpty { return description }
+    if let title = element.title(), !title.isEmpty {
+        return title
+    }
+    if let value = element.value() as? String, !value.isEmpty {
+        return value
+    }
+    if let description = element.descriptionText(), !description.isEmpty {
+        return description
+    }
 
     // Fallback to a broader set if primary ones fail
-    if let placeholder = element.placeholderValue(), !placeholder.isEmpty { return placeholder }
-    if let help = element.help(), !help.isEmpty { return help }
+    if let placeholder = element.placeholderValue(), !placeholder.isEmpty {
+        return placeholder
+    }
+    if let help = element.help(), !help.isEmpty {
+        return help
+    }
 
     // Consider role description as a last resort if it's textual and meaningful
     // This might be too generic in many cases, so it's lower priority.
@@ -64,7 +82,7 @@ public func extractTextFromElementNonRecursive(_ element: Element) -> String? {
     return nil
 }
 
-// More focused text extraction, typically used by handlers.
+/// More focused text extraction, typically used by handlers.
 @MainActor
 func getElementTextualContent(
     element: Element,
@@ -91,7 +109,9 @@ func getElementTextualContent(
 @MainActor
 private func collectDirectText(from element: Element) -> [String] {
     var pieces: [String] = []
-    if let title: String = element.attribute(Attribute<String>.title), !title.isEmpty { pieces.append(title) }
+    if let title: String = element.attribute(Attribute<String>.title), !title.isEmpty {
+        pieces.append(title)
+    }
     if let value: String = element.attribute(Attribute<String>(AXAttributeNames.kAXValueAttribute)), !value.isEmpty {
         pieces.append(value)
     }
@@ -132,8 +152,12 @@ private func joinedText(from pieces: [String]) -> String? {
 private func mergeText(directText: String?, childText: String?) -> String? {
     switch (directText, childText) {
     case let (direct?, child?):
-        if direct.isEmpty { return child }
-        if child.isEmpty { return direct }
+        if direct.isEmpty {
+            return child
+        }
+        if child.isEmpty {
+            return direct
+        }
         return "\(direct) \(child)"
     case let (direct?, nil):
         return direct

--- a/Sources/AXorcist/Values/Scannable.swift
+++ b/Sources/AXorcist/Values/Scannable.swift
@@ -10,26 +10,42 @@ protocol Scannable {
 
 extension Int: Scannable {
     init?(_ scanner: Scanner) {
-        if let value: Int = scanner.scanInteger() { self = value } else { return nil }
+        if let value: Int = scanner.scanInteger() {
+            self = value
+        } else {
+            return nil
+        }
     }
 }
 
 extension UInt: Scannable {
     init?(_ scanner: Scanner) {
-        if let value: UInt = scanner.scanUnsignedInteger() { self = value } else { return nil }
+        if let value: UInt = scanner.scanUnsignedInteger() {
+            self = value
+        } else {
+            return nil
+        }
     }
 }
 
 extension Float: Scannable {
     init?(_ scanner: Scanner) {
         // Using the custom scanDouble and casting
-        if let value = scanner.scanDouble() { self = Float(value) } else { return nil }
+        if let value = scanner.scanDouble() {
+            self = Float(value)
+        } else {
+            return nil
+        }
     }
 }
 
 extension Double: Scannable {
     init?(_ scanner: Scanner) {
-        if let value = scanner.scanDouble() { self = value } else { return nil }
+        if let value = scanner.scanDouble() {
+            self = value
+        } else {
+            return nil
+        }
     }
 }
 

--- a/Sources/AXorcist/Values/ValueCasters.swift
+++ b/Sources/AXorcist/Values/ValueCasters.swift
@@ -134,14 +134,13 @@ func castToArrayType<T>(_ value: Any, expectedType: T.Type, attr: String) -> T? 
 @MainActor
 func castToAXUIElementArray(_ value: Any, attr: String) -> [AXUIElement]? {
     if let anyArray = value as? [Any?] {
-        let result = anyArray.compactMap { item -> AXUIElement? in
+        return anyArray.compactMap { item -> AXUIElement? in
             guard let cfItem = item else { return nil }
             if CFGetTypeID(cfItem as CFTypeRef) == AXUIElementGetTypeID() {
                 return unsafeDowncast(cfItem as AnyObject, to: AXUIElement.self)
             }
             return nil
         }
-        return result
     }
     axDebugLog(
         "axValue: Expected [AXUIElement] for attribute '\(attr)', but got \(type(of: value)): \(value)",
@@ -154,7 +153,7 @@ func castToAXUIElementArray(_ value: Any, attr: String) -> [AXUIElement]? {
 @MainActor
 func castToElementArray(_ value: Any, attr: String) -> [Element]? {
     if let anyArray = value as? [Any?] {
-        let result = anyArray.compactMap { item -> Element? in
+        return anyArray.compactMap { item -> Element? in
             guard let cfItem = item else { return nil }
             if CFGetTypeID(cfItem as CFTypeRef) == AXUIElementGetTypeID() {
                 let axElement = unsafeDowncast(cfItem as AnyObject, to: AXUIElement.self)
@@ -162,7 +161,6 @@ func castToElementArray(_ value: Any, attr: String) -> [Element]? {
             }
             return nil
         }
-        return result
     }
     axDebugLog(
         "axValue: Expected [Element] for attribute '\(attr)', but got \(type(of: value)): \(value)",

--- a/Sources/axorc/CommandExecutor.swift
+++ b/Sources/axorc/CommandExecutor.swift
@@ -31,14 +31,12 @@ struct CommandExecutor {
             "Executing command: \(command.command) (ID: \(command.commandId)), "
                 + "cmdDebug: \(command.debugLogging), cliDebug: \(debugCLI)")
 
-        let responseString = self.processCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
-
-        return responseString
+        return self.processCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
     }
 
     // MARK: Private
 
-    // Simplified to only adjust detail level based on command specific flag, if CLI debug is on.
+    /// Simplified to only adjust detail level based on command specific flag, if CLI debug is on.
     private static func setupDetailLevelForCommand(commandDebugLogging: Bool, cliDebug: Bool) -> AXLogDetailLevel? {
         var previousDetailLevel: AXLogDetailLevel?
         if cliDebug { // Only adjust if CLI debugging is already enabled

--- a/Sources/axorc/CommandHandlers.swift
+++ b/Sources/axorc/CommandHandlers.swift
@@ -4,7 +4,7 @@ import AppKit
 import AXorcist
 import Foundation
 
-// Global variable to track input source for ping responses
+/// Global variable to track input source for ping responses
 @MainActor var axorcInputSource: String = "STDIN"
 
 // MARK: - Command Handlers

--- a/Tests/AXorcistTests/AXErrorExtensionsTests.swift
+++ b/Tests/AXorcistTests/AXErrorExtensionsTests.swift
@@ -4,12 +4,12 @@ import Testing
 
 @Suite("AXError extensions")
 struct AXErrorExtensionsTests {
-    @Test("localized descriptions are available outside the main actor")
-    func localizedDescriptionIsNonisolated() {
+    @Test
+    func `localized descriptions are available outside the main actor`() {
         #expect(Self.describe(.actionUnsupported) == "Action is not supported")
     }
 
-    nonisolated private static func describe(_ error: AXError) -> String {
+    private nonisolated static func describe(_ error: AXError) -> String {
         error.localizedDescription
     }
 }

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -5,8 +5,8 @@ import Testing
 @Suite("AXTimeoutHelper")
 struct AXTimeoutHelperTests {
     @MainActor
-    @Test("completes before timeout")
-    func completesBeforeTimeout() async throws {
+    @Test
+    func `completes before timeout`() async throws {
         let value: Int = try await AXTimeoutHelper.withTimeout(seconds: 0.2) {
             try await Task.sleep(nanoseconds: 50_000_000)
             return 7
@@ -15,8 +15,8 @@ struct AXTimeoutHelperTests {
     }
 
     @MainActor
-    @Test("throws on timeout")
-    func throwsOnTimeout() async {
+    @Test
+    func `throws on timeout`() async {
         do {
             _ = try await AXTimeoutHelper.withTimeout(seconds: 0.05) {
                 try await Task.sleep(nanoseconds: 200_000_000)

--- a/Tests/AXorcistTests/AXWindowResolverTests.swift
+++ b/Tests/AXorcistTests/AXWindowResolverTests.swift
@@ -7,16 +7,16 @@ import Testing
 struct AXWindowResolverTests {
     private let resolver = AXWindowResolver()
 
-    @Test("windowID returns nil for non-window element")
+    @Test
     @MainActor
-    func windowIdNilForNonWindow() async {
+    func `windowID returns nil for non-window element`() {
         let systemWide = AXUIElementCreateSystemWide()
         let element = Element(systemWide)
         #expect(self.resolver.windowID(from: element) == nil)
     }
 
-    @Test("windowExists false for random ID")
-    func windowExistsFalse() {
+    @Test
+    func `windowExists false for random ID`() {
         #expect(self.resolver.windowExists(windowID: 999_999_999) == false)
     }
 }

--- a/Tests/AXorcistTests/ActionIntegrationTests.swift
+++ b/Tests/AXorcistTests/ActionIntegrationTests.swift
@@ -9,8 +9,8 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct ActionIntegrationTests {
-    @Test("Discover AXPress on a native window button", .tags(.automation))
-    func discoverPressActionOnWindowButton() async throws {
+    @Test(.tags(.automation))
+    func `Discover AXPress on a native window button`() async throws {
         let (_, appElement) = try await setupTextEditAndGetInfo()
         defer { Task { await closeTextEdit() } }
 
@@ -24,8 +24,8 @@ struct ActionIntegrationTests {
         #expect(button.isActionSupported(AXActionNames.kAXPressAction))
     }
 
-    @Test("Perform AXSetValue on TextEdit", .tags(.automation))
-    func performActionSetTextEditTextAreaValue() async throws {
+    @Test(.tags(.automation))
+    func `Perform AXSetValue on TextEdit`() async throws {
         let actionCommandId = "performaction-setvalue-\(UUID().uuidString)"
         let queryCommandId = "query-verify-setvalue-\(UUID().uuidString)"
         let textEditBundleId = "com.apple.TextEdit"
@@ -50,8 +50,8 @@ struct ActionIntegrationTests {
             expectedText: textToSet)
     }
 
-    @Test("Extract text after setting value", .tags(.automation))
-    func extractTextFromTextEditTextArea() async throws {
+    @Test(.tags(.automation))
+    func `Extract text after setting value`() async throws {
         let setValueCommandId = "setvalue-for-extract-\(UUID().uuidString)"
         let extractTextCommandId = "extracttext-textedit-textarea-\(UUID().uuidString)"
         let textEditBundleId = "com.apple.TextEdit"

--- a/Tests/AXorcistTests/AppLocatorTests.swift
+++ b/Tests/AXorcistTests/AppLocatorTests.swift
@@ -5,9 +5,9 @@ import Testing
 
 @Suite("AppLocator")
 struct AppLocatorTests {
-    @Test("returns frontmost when point is nil and front app has window under mouse")
+    @Test
     @MainActor
-    func frontmostPreferred() async throws {
+    func `returns frontmost when point is nil and front app has window under mouse`() {
         // Skip on headless CI where NSEvent.mouseLocation is (0,0) and no frontmost app.
         guard NSWorkspace.shared.frontmostApplication != nil else { return }
 
@@ -18,9 +18,9 @@ struct AppLocatorTests {
         // above is sufficient coverage and avoids flaking on PID mismatches.
     }
 
-    @Test("falls back to frontmost when no window matches point")
+    @Test
     @MainActor
-    func fallbackToFrontmost() async throws {
+    func `falls back to frontmost when no window matches point`() {
         guard let front = NSWorkspace.shared.frontmostApplication else { return }
         // Pick an off-screen point unlikely to hit a window.
         let offscreen = CGPoint(x: -10000, y: -10000)

--- a/Tests/AXorcistTests/BatchIntegrationTests.swift
+++ b/Tests/AXorcistTests/BatchIntegrationTests.swift
@@ -9,8 +9,8 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct BatchIntegrationTests {
-    @Test("Get focused element and query textarea", .tags(.automation))
-    func batchCommandGetFocusedElementAndQuery() async throws {
+    @Test(.tags(.automation))
+    func `Get focused element and query textarea`() async throws {
         let batchCommandId = "batch-textedit-\(UUID().uuidString)"
         let focusedElementSubCmdId = "batch-sub-getfocused-\(UUID().uuidString)"
         let querySubCmdId = "batch-sub-querytextarea-\(UUID().uuidString)"

--- a/Tests/AXorcistTests/ClickEventGenerationTests.swift
+++ b/Tests/AXorcistTests/ClickEventGenerationTests.swift
@@ -4,9 +4,9 @@ import Testing
 
 @Suite("Click event generation")
 struct ClickEventGenerationTests {
-    @Test("Single click uses clickState=1")
+    @Test
     @MainActor
-    func singleClickUsesClickStateOne() throws {
+    func `Single click uses clickState=1`() throws {
         let pairs = try Element.buildClickEventPairs(
             at: CGPoint(x: 10, y: 20),
             button: .left,
@@ -19,9 +19,9 @@ struct ClickEventGenerationTests {
         #expect(pairs[0].up.getIntegerValueField(.mouseEventClickState) == 1)
     }
 
-    @Test("Double click emits clickState sequence 1 then 2")
+    @Test
     @MainActor
-    func doubleClickUsesSequentialClickStates() throws {
+    func `Double click emits clickState sequence 1 then 2`() throws {
         let pairs = try Element.buildClickEventPairs(
             at: CGPoint(x: 10, y: 20),
             button: .left,

--- a/Tests/AXorcistTests/CommonTestHelpers.swift
+++ b/Tests/AXorcistTests/CommonTestHelpers.swift
@@ -25,7 +25,7 @@ enum AXTestEnvironment {
     }
 }
 
-// Result struct for AXORC commands
+/// Result struct for AXORC commands
 struct CommandResult {
     let output: String?
     let errorOutput: String?
@@ -151,7 +151,9 @@ func closeTextEdit() async {
 
     textEdit.terminate()
     for _ in 0..<5 {
-        if textEdit.isTerminated { break }
+        if textEdit.isTerminated {
+            break
+        }
         try? await Task.sleep(for: .milliseconds(500))
     }
 

--- a/Tests/AXorcistTests/ElementSearchTests.swift
+++ b/Tests/AXorcistTests/ElementSearchTests.swift
@@ -8,8 +8,8 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct ElementSearchTests {
-    @Test("Search through a menu bar container", .tags(.automation))
-    func searchMenuBarItem() async throws {
+    @Test(.tags(.automation))
+    func `Search through a menu bar container`() async throws {
         _ = try await setupTextEditAndGetInfo()
         defer { Task { await closeTextEdit() } }
 
@@ -26,8 +26,8 @@ struct ElementSearchTests {
         #expect(response.data?.attributes?["AXRole"]?.stringValue == AXRoleNames.kAXMenuBarItemRole)
     }
 
-    @Test("Search a window by its generic AXTitle criterion", .tags(.automation))
-    func searchWindowByExactTitle() async throws {
+    @Test(.tags(.automation))
+    func `Search a window by its generic AXTitle criterion`() async throws {
         let (_, appElement) = try await setupTextEditAndGetInfo()
         defer { Task { await closeTextEdit() } }
 
@@ -51,8 +51,8 @@ struct ElementSearchTests {
         #expect(response.data?.attributes?["AXTitle"]?.stringValue == title)
     }
 
-    @Test("Search elements by role", .tags(.automation))
-    func searchElementsByRole() async throws {
+    @Test(.tags(.automation))
+    func `Search elements by role`() async throws {
         await closeTextEdit()
         try await Task.sleep(for: .milliseconds(500))
 
@@ -99,8 +99,8 @@ struct ElementSearchTests {
         }
     }
 
-    @Test("Describe element hierarchy", .tags(.automation))
-    func describeElementHierarchy() async throws {
+    @Test(.tags(.automation))
+    func `Describe element hierarchy`() async throws {
         await closeTextEdit()
         try await Task.sleep(for: .milliseconds(500))
 
@@ -149,8 +149,8 @@ struct ElementSearchTests {
         }
     }
 
-    @Test("Set and verify text in TextEdit", .tags(.automation))
-    func setAndVerifyText() async throws {
+    @Test(.tags(.automation))
+    func `Set and verify text in TextEdit`() async throws {
         try await withFreshTextEdit { encoder in
             try await self.setText("Hello from AXorcist tests!", encoder: encoder)
             let response = try await self.queryTextArea(encoder: encoder)
@@ -163,8 +163,8 @@ struct ElementSearchTests {
         }
     }
 
-    @Test("Extract text from TextEdit window", .tags(.automation))
-    func extractText() async throws {
+    @Test(.tags(.automation))
+    func `Extract text from TextEdit window`() async throws {
         try await withFreshTextEdit { encoder in
             try await self.setText(
                 "This is test content.\nIt has multiple lines.\nExtract this text.",

--- a/Tests/AXorcistTests/LoggerIsolationTests.swift
+++ b/Tests/AXorcistTests/LoggerIsolationTests.swift
@@ -4,13 +4,13 @@ import Testing
 
 @Suite("Logger isolation")
 struct LoggerIsolationTests {
-    @Test("convenience overloads are callable outside the main actor")
-    func convenienceOverloadsAreNonisolated() {
+    @Test
+    func `convenience overloads are callable outside the main actor`() {
         let logger = Logger(label: "AXorcistTests.LoggerIsolation")
         Self.logAllLevels(logger)
     }
 
-    nonisolated private static func logAllLevels(_ logger: Logger) {
+    private nonisolated static func logAllLevels(_ logger: Logger) {
         logger.debug("debug")
         logger.info("info")
         logger.warning("warning")

--- a/Tests/AXorcistTests/QueryIntegrationTests.swift
+++ b/Tests/AXorcistTests/QueryIntegrationTests.swift
@@ -9,8 +9,8 @@ import Testing
     .enabled(if: AXTestEnvironment.runAutomationScenarios))
 @MainActor
 struct QueryIntegrationTests {
-    @Test("Launch TextEdit and get focused element", .tags(.automation))
-    func launchAndQueryTextEdit() async throws {
+    @Test(.tags(.automation))
+    func `Launch TextEdit and get focused element`() async throws {
         await closeTextEdit()
         try await Task.sleep(for: .milliseconds(500))
 
@@ -44,8 +44,8 @@ struct QueryIntegrationTests {
         await closeTextEdit()
     }
 
-    @Test("Get application attributes", .tags(.automation))
-    func getAttributesForTextEditApplication() async throws {
+    @Test(.tags(.automation))
+    func `Get application attributes`() async throws {
         let commandId = "getattributes-textedit-app-\(UUID().uuidString)"
         let textEditBundleId = "com.apple.TextEdit"
         let requestedAttributes = ["AXRole", "AXTitle", "AXWindows", "AXFocusedWindow", "AXMainWindow", "AXIdentifier"]
@@ -68,8 +68,8 @@ struct QueryIntegrationTests {
         }
     }
 
-    @Test("Query TextEdit text area", .tags(.automation))
-    func queryForTextEditTextArea() async throws {
+    @Test(.tags(.automation))
+    func `Query TextEdit text area`() async throws {
         let commandId = "query-textedit-textarea-\(UUID().uuidString)"
         let textEditBundleId = "com.apple.TextEdit"
         let textAreaRole = ApplicationServices.kAXTextAreaRole as String
@@ -95,8 +95,8 @@ struct QueryIntegrationTests {
         }
     }
 
-    @Test("Describe TextEdit text area", .tags(.automation))
-    func describeTextEditTextArea() async throws {
+    @Test(.tags(.automation))
+    func `Describe TextEdit text area`() async throws {
         let commandId = "describe-textedit-textarea-\(UUID().uuidString)"
         let textEditBundleId = "com.apple.TextEdit"
         let textAreaRole = ApplicationServices.kAXTextAreaRole as String

--- a/Tests/AXorcistTests/SpecialKeyDigitTests.swift
+++ b/Tests/AXorcistTests/SpecialKeyDigitTests.swift
@@ -4,8 +4,8 @@ import Testing
 
 @Suite("Hotkey digit keys")
 struct SpecialKeyDigitTests {
-    @Test("SpecialKey parses digit keys 0-9")
-    func digitKeysParse() {
+    @Test
+    func `SpecialKey parses digit keys 0-9`() {
         let cases: [(String, CGKeyCode)] = [
             ("0", 29),
             ("1", 18),

--- a/Tests/AXorcistTests/Support/PipeStreaming.swift
+++ b/Tests/AXorcistTests/Support/PipeStreaming.swift
@@ -4,7 +4,7 @@ private final class PipeStreamBuffer: @unchecked Sendable {
     private let queue = DispatchQueue(
         label: "axorcist.tests.pipe-stream.\(UUID().uuidString)",
         qos: .userInitiated)
-    nonisolated(unsafe) private var data = Data()
+    private nonisolated(unsafe) var data = Data()
 
     nonisolated func append(_ chunk: Data) {
         self.queue.async {

--- a/scripts/install-validation-tools.sh
+++ b/scripts/install-validation-tools.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+swiftformat_version="0.62.1"
+swiftformat_sha256="7cb1cb1fae04932047c7015441c543848e8e60e1572d808d080e0a1f1661114a"
+swiftlint_version="0.65.0"
+swiftlint_sha256="d6cb0aa7a2f5f1ef306fc9e37bcb54dc9a26facc8f7784ac0c3dd3eccf5c6ba6"
+
+if [[ $# -gt 1 || "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  echo "Usage: scripts/install-validation-tools.sh [destination]"
+  exit 0
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+destination="${1:-$repo_root/.build/validation-tools}"
+temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/axorcist-validation-tools.XXXXXX")"
+
+cleanup() {
+  rm -rf "$temporary_directory"
+}
+trap cleanup EXIT
+
+mkdir -p "$destination"
+
+install_tool() {
+  local name="$1"
+  local version="$2"
+  local sha256="$3"
+  local owner="$4"
+  local repository="$5"
+  local archive_name="$6"
+  local archive_path="$temporary_directory/$name.zip"
+  local extract_path="$temporary_directory/$name"
+
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://github.com/$owner/$repository/releases/download/$version/$archive_name" \
+    --output "$archive_path"
+  printf '%s  %s\n' "$sha256" "$archive_path" | shasum -a 256 --check
+  mkdir -p "$extract_path"
+  unzip -q "$archive_path" -d "$extract_path"
+  install -m 0755 "$extract_path/$name" "$destination/$name"
+}
+
+install_tool \
+  swiftformat \
+  "$swiftformat_version" \
+  "$swiftformat_sha256" \
+  nicklockwood \
+  SwiftFormat \
+  swiftformat.zip
+install_tool \
+  swiftlint \
+  "$swiftlint_version" \
+  "$swiftlint_sha256" \
+  realm \
+  SwiftLint \
+  portable_swiftlint.zip
+
+"$destination/swiftformat" --version | grep -Fx "$swiftformat_version"
+"$destination/swiftlint" version | grep -Fx "$swiftlint_version"
+echo "Installed validation tools in $destination"


### PR DESCRIPTION
## Summary

- pin SwiftFormat 0.62.1 and SwiftLint 0.65.0 to their official universal release archives with SHA-256 verification
- replace warning-only formatting and linting steps with the blocking repo-native `make check` gate
- apply the pinned SwiftFormat baseline so all 137 checked Swift files are clean

## Validation

- `scripts/install-validation-tools.sh /tmp/axorcist-validation-install.wBviui`
- `PATH=/tmp/axorcist-validation-install.wBviui:$PATH make check`
- `swift build`
- `swift test` (58 tests in 19 suites)
- `shellcheck scripts/*.sh`
- autoreview: clean, no accepted or actionable findings

## Documentation

- No user-facing behavior changed; no documentation or changelog update is needed.
