### PR TITLE
perf: streamline AX action execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Execute accessibility actions directly through one system-call owner, preserving native AX failures without redundant action-discovery round trips.
 - Use the native macOS names for parameterized accessibility attributes instead of non-existent `Parameterized`-suffixed raw values.
 - Traverse menu bars during default searches so their items remain discoverable without `--scan-all`. Thanks @dalsoop.
 - Match generic accessibility criteria such as `AXTitle` against their real Core Foundation values. Thanks @dalsoop.

--- a/Sources/AXorcist/Core/AXError+Extensions.swift
+++ b/Sources/AXorcist/Core/AXError+Extensions.swift
@@ -90,4 +90,19 @@ extension AXError {
     public nonisolated var localizedDescription: String {
         AccessibilitySystemError(self).errorDescription ?? "Unknown AXError: \(self.rawValue)"
     }
+
+    var actionResponseCode: AXErrorCode {
+        switch self {
+        case .apiDisabled:
+            .permissionDenied
+        case .invalidUIElement:
+            .elementNotFound
+        case .actionUnsupported:
+            .actionNotSupported
+        case .illegalArgument:
+            .invalidParameter
+        default:
+            .actionFailed
+        }
+    }
 }

--- a/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 /// This extension handles:
 /// - Performing accessibility actions on UI elements
-/// - Action validation and error handling
+/// - Action error handling
 /// - Setting element values (text, numeric, selection)
 /// - Complex action coordination and validation
 /// - Integration with element discovery and targeting
@@ -33,10 +33,7 @@ extension AXorcist {
             return .errorResponse(message: message, code: .elementNotFound)
         }
 
-        if let errorResponse = self.validateActionSupport(command.action, for: element) {
-            return errorResponse
-        }
-        return self.execute(action: command.action, on: element, value: command.value)
+        return self.executeAction(action: command.action, on: element, value: command.value)
     }
 
     // MARK: - Set Focused Value Handler
@@ -128,19 +125,17 @@ extension AXorcist {
                 "Locator: \(command.locator), Value: '\(command.value)'"))
     }
 
-    private func validateActionSupport(_ action: String, for element: Element) -> AXResponse? {
-        guard element.isActionSupported(action) else {
-            let description = element.briefDescription(option: ValueFormatOption.smart)
-            let errorMessage = "HandlePerformAction: Action '\(action)' is NOT supported by element \(description)."
-            GlobalAXLogger.shared.log(AXLogEntry(level: .warning, message: errorMessage))
-            let availableActions = element.supportedActions() ?? []
-            let message = "\(errorMessage) Available actions: [\(availableActions.joined(separator: ", "))]"
-            return .errorResponse(message: message, code: .actionNotSupported)
-        }
-        return nil
-    }
-
-    private func execute(action: String, on element: Element, value: AnyCodable?) -> AXResponse {
+    func executeAction(
+        action: String,
+        on element: Element,
+        value: AnyCodable?,
+        performer: (Element, String) throws -> Void = { element, action in
+            try element.performAction(action)
+        },
+        supportedActions: (Element) -> [String]? = { element in
+            element.supportedActions()
+        }) -> AXResponse
+    {
         if let actionValue = value?.value {
             GlobalAXLogger.shared.log(AXLogEntry(
                 level: .warning,
@@ -148,19 +143,43 @@ extension AXorcist {
         }
 
         do {
-            try element.performAction(action)
+            try performer(element, action)
             GlobalAXLogger.shared.log(AXLogEntry(
                 level: .info,
-                message: "HandlePerformAction: Successfully performed action '\(action)' on " +
-                    "\(element.briefDescription(option: ValueFormatOption.smart))."))
+                message: "HandlePerformAction: Successfully performed action '\(action)'."))
             return .successResponse(
                 payload: AnyCodable(["message": "Action '\(action)' performed successfully."]))
+        } catch let error as AccessibilitySystemError {
+            // The platform can return cannotComplete after dispatch, so classify once and never retry here.
+            return self.actionFailureResponse(
+                action: action,
+                element: element,
+                error: error,
+                supportedActions: supportedActions)
         } catch {
-            let errorMessage = "HandlePerformAction: Failed to perform action '\(action)' on " +
-                "\(element.briefDescription(option: ValueFormatOption.smart)). Error: \(error)"
+            let errorMessage = "HandlePerformAction: Failed to perform action '\(action)'. Error: \(error)"
             GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
             return .errorResponse(message: errorMessage, code: .actionFailed)
         }
+    }
+
+    private func actionFailureResponse(
+        action: String,
+        element: Element,
+        error: AccessibilitySystemError,
+        supportedActions: (Element) -> [String]?) -> AXResponse
+    {
+        let summary = error.axError == .actionUnsupported
+            ? "Action '\(action)' is not supported."
+            : "Failed to perform action '\(action)'."
+        var errorMessage = "HandlePerformAction: \(summary) " +
+            "Error: \(error.localizedDescription) (AXError \(error.axError.rawValue))."
+        if error.axError == .actionUnsupported {
+            let availableActions = supportedActions(element) ?? []
+            errorMessage += " Available actions: [\(availableActions.joined(separator: ", "))]"
+        }
+        GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
+        return .errorResponse(message: errorMessage, code: error.axError.actionResponseCode)
     }
 
     private func ensureFocusCapability(for element: Element) -> Bool {
@@ -168,29 +187,35 @@ extension AXorcist {
             return true
         }
 
-        let elementDescription = element.briefDescription(option: ValueFormatOption.smart)
-        guard element.isActionSupported(AXActionNames.kAXPressAction) else {
-            let focusError = [
-                "HandleSetFocusedValue: Element \(elementDescription) is not focusable",
-                "(kAXFocusedAttribute not settable and kAXPressAction not supported).",
-            ].joined(separator: " ")
-            GlobalAXLogger.shared.log(AXLogEntry(level: .warning, message: focusError))
-            return false
-        }
-
+        let elementDescription = GlobalAXLogger.shared.isLoggingEnabled
+            ? element.briefDescription(option: .smart)
+            : nil
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .debug,
             message: "HandleSetFocusedValue: Element not directly focusable by kAXFocusedAttribute, " +
-                "but supports kAXPressAction. Attempting press."))
+                "attempting kAXPressAction."))
         do {
             try element.performAction(.press)
             GlobalAXLogger.shared.log(AXLogEntry(
                 level: .debug,
                 message: "HandleSetFocusedValue: Successfully pressed element to potentially gain focus."))
+        } catch let error as AccessibilitySystemError where error.axError == .actionUnsupported {
+            let focusError = [
+                "HandleSetFocusedValue: Element \(elementDescription ?? "target") is not focusable",
+                "(kAXFocusedAttribute not settable and kAXPressAction not supported).",
+            ].joined(separator: " ")
+            GlobalAXLogger.shared.log(AXLogEntry(level: .warning, message: focusError))
+        } catch let error as AccessibilitySystemError {
+            let pressError = [
+                "HandleSetFocusedValue: Element \(elementDescription ?? "target") could not be pressed",
+                "to potentially gain focus. Error: \(error.localizedDescription)",
+                "(AXError \(error.axError.rawValue)).",
+            ].joined(separator: " ")
+            GlobalAXLogger.shared.log(AXLogEntry(level: .warning, message: pressError))
         } catch {
             let pressError = [
-                "HandleSetFocusedValue: Element \(elementDescription) could not be pressed",
-                "to potentially gain focus.",
+                "HandleSetFocusedValue: Element \(elementDescription ?? "target") could not be pressed",
+                "to potentially gain focus. Error: \(error)",
             ].joined(separator: " ")
             GlobalAXLogger.shared.log(AXLogEntry(level: .warning, message: pressError))
         }

--- a/Sources/AXorcist/Core/Element+Actions.swift
+++ b/Sources/AXorcist/Core/Element+Actions.swift
@@ -10,44 +10,40 @@ extension Element {
     // MARK: - Actions
 
     @MainActor
-    public func isActionSupported(_ actionName: String) -> Bool { // Removed logging params
-        // self.supportedActions() is refactored and uses GlobalAXLogger internally
-        // Assumes self.supportedActions() is refactored in Element+Properties.swift
-        if let actions = self.supportedActions() {
-            return actions.contains(actionName)
+    public func isActionSupported(_ actionName: String) -> Bool {
+        self.supportedActions()?.contains(actionName) ?? false
+    }
+
+    @MainActor
+    @discardableResult
+    public func performAction(_ actionName: Attribute<String>) throws -> Element {
+        try self.performAction(actionName.rawValue)
+    }
+
+    @MainActor
+    @discardableResult
+    public func performAction(_ actionName: String) throws -> Element {
+        try self.performAction(actionName, using: AXUIElementPerformAction)
+    }
+
+    @MainActor
+    @discardableResult
+    func performAction(
+        _ actionName: String,
+        using performer: (AXUIElement, CFString) -> AXError) throws -> Element
+    {
+        let description = GlobalAXLogger.shared.isLoggingEnabled
+            ? self.briefDescription(option: .smart)
+            : nil
+        if let description {
+            axDebugLog("Attempting to perform action '\(actionName)' on element: \(description)")
         }
-        return false
-    }
 
-    @MainActor
-    @discardableResult
-    public func performAction(_ actionName: Attribute<String>) throws -> Element { // Removed logging params
-        // self.briefDescription() is refactored and uses GlobalAXLogger internally
-        // Assumes self.briefDescription() is refactored in Element+Description.swift
-        let descForLog = self.briefDescription(option: .smart)
-        axDebugLog("Attempting to perform action '\(actionName.rawValue)' on element: \(descForLog)")
+        try performer(self.underlyingElement, actionName as CFString).throwIfError()
 
-        let error = AXUIElementPerformAction(self.underlyingElement, actionName.rawValue as CFString)
-
-        // Use new error extension
-        try error.throwIfError()
-
-        axInfoLog("Successfully performed action '\(actionName.rawValue)' on element: \(descForLog)")
-        return self
-    }
-
-    @MainActor
-    @discardableResult
-    public func performAction(_ actionName: String) throws -> Element { // Removed logging params
-        let descForLog = self.briefDescription(option: .smart)
-        axDebugLog("Attempting to perform action '\(actionName)' on element: \(descForLog)")
-
-        let error = AXUIElementPerformAction(self.underlyingElement, actionName as CFString)
-
-        // Use new error extension
-        try error.throwIfError()
-
-        axInfoLog("Successfully performed action '\(actionName)' on element: \(descForLog)")
+        if let description {
+            axInfoLog("Successfully performed action '\(actionName)' on element: \(description)")
+        }
         return self
     }
 

--- a/Sources/AXorcist/Models/HandlerResponse.swift
+++ b/Sources/AXorcist/Models/HandlerResponse.swift
@@ -10,9 +10,11 @@ public struct HandlerResponse: Codable, Sendable {
     /// - Parameters:
     ///   - data: The data payload.
     ///   - error: An optional error message.
-    public init(data: AnyCodable? = nil, error: String? = nil) {
+    ///   - errorCode: An optional machine-readable error code.
+    public init(data: AnyCodable? = nil, error: String? = nil, errorCode: AXErrorCode? = nil) {
         self.data = data
         self.error = error
+        self.errorCode = errorCode
     }
 
     // MARK: Public
@@ -23,6 +25,9 @@ public struct HandlerResponse: Codable, Sendable {
 
     /// An optional error message. If present, indicates that the handler encountered an issue.
     public var error: String?
+
+    /// A stable error category when the underlying handler provides one.
+    public var errorCode: AXErrorCode?
 }
 
 // MARK: - Convenience Initializers & Properties
@@ -61,8 +66,8 @@ extension HandlerResponse {
         switch axResponse {
         case let .success(payload, _):
             self.init(data: payload, error: nil)
-        case let .error(message, _, _):
-            self.init(data: nil, error: message)
+        case let .error(message, code, _):
+            self.init(data: nil, error: message, errorCode: code)
         }
     }
 }

--- a/Sources/AXorcist/Utils/AXUtilities.swift
+++ b/Sources/AXorcist/Utils/AXUtilities.swift
@@ -8,33 +8,23 @@ import Foundation
 @MainActor
 public enum AXUtilities {
     public static func performAXAction(_ actionName: String, on element: Element) -> AXError {
-        let description = element.briefDescription()
-        axDebugLog(
-            "AXUtilities: Attempting to perform action '\(actionName)' " +
-                "on element: \(description)")
-        if element.isActionSupported(actionName) {
-            do {
-                // Assuming actionName is a raw string for a known AXAction
-                try element.performAction(Attribute<String>(actionName))
-                axDebugLog(
-                    "AXUtilities: Action '\(actionName)' performed successfully on \(description)")
-                return .success
-            } catch let error as AccessibilityError {
+        do {
+            try element.performAction(actionName)
+            return .success
+        } catch {
+            if let systemError = error as? AccessibilitySystemError {
                 axErrorLog(
-                    "AXUtilities: Action failed for '\(actionName)' on \(description). " +
-                        "Error: \(error)")
-                return .failure
-            } catch {
-                axErrorLog(
-                    "AXUtilities: Unexpected error performing action '\(actionName)' on \(description). " +
-                        "Error: \(error)")
-                return .failure // Generic failure for unexpected errors
+                    "AXUtilities: Action '\(actionName)' failed: \(systemError.localizedDescription) " +
+                        "(AXError \(systemError.axError.rawValue))")
+            } else {
+                axErrorLog("AXUtilities: Action '\(actionName)' failed with an unexpected error: \(error)")
             }
-        } else {
-            axWarningLog(
-                "AXUtilities: Action '\(actionName)' is not supported by element \(description)")
-            return .actionUnsupported
+            return Self.axError(forActionError: error)
         }
+    }
+
+    static func axError(forActionError error: any Error) -> AXError {
+        (error as? AccessibilitySystemError)?.axError ?? .failure
     }
 
     public static func performSetValueAction(

--- a/Sources/axorc/CommandExecutor.swift
+++ b/Sources/axorc/CommandExecutor.swift
@@ -189,6 +189,7 @@ struct CommandExecutor {
             status: "success",
             data: AnyCodable("All observations stopped"),
             error: nil,
+            errorCode: nil,
             debugLogs: debugCLI || command.debugLogging ? axGetLogsAsStrings() : nil)
         return encodeToJson(stopResponse) ??
             "{\"error\": \"Encoding stopObservation response failed\", \"commandId\": \"\(command.commandId)\"}"

--- a/Sources/axorc/CommandResponseHelpers.swift
+++ b/Sources/axorc/CommandResponseHelpers.swift
@@ -11,6 +11,7 @@ struct FinalResponse: Codable {
     let status: String
     let data: AnyCodable?
     let error: String?
+    let errorCode: AXErrorCode?
     var debugLogs: [String]?
 }
 
@@ -42,7 +43,8 @@ func finalizeAndEncodeResponse(
         commandType: commandType,
         status: responseStatus,
         data: handlerResponse.data,
-        error: handlerResponse.error)
+        error: handlerResponse.error,
+        errorCode: handlerResponse.errorCode)
 
     if debugCLI || commandDebugLogging {
         let logsForResponse = axGetLogsAsStrings()

--- a/Tests/AXorcistTests/ActionExecutionTests.swift
+++ b/Tests/AXorcistTests/ActionExecutionTests.swift
@@ -1,0 +1,130 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("AX action execution")
+@MainActor
+struct ActionExecutionTests {
+    private struct UnexpectedActionError: Error {}
+
+    @Test
+    func `canonical action owner invokes the system boundary once`() throws {
+        let element = Element(AXUIElementCreateSystemWide())
+        var invocationCount = 0
+        var receivedAction: String?
+
+        let returnedElement = try element.performAction("AXPress") { _, action in
+            invocationCount += 1
+            receivedAction = action as String
+            return .success
+        }
+
+        #expect(invocationCount == 1)
+        #expect(receivedAction == "AXPress")
+        #expect(CFEqual(returnedElement.underlyingElement, element.underlyingElement))
+    }
+
+    @Test
+    func `canonical action owner preserves native AX errors`() {
+        let element = Element(AXUIElementCreateSystemWide())
+
+        #expect(throws: AccessibilitySystemError.self) {
+            try element.performAction("AXPress") { _, _ in .cannotComplete }
+        }
+
+        do {
+            try element.performAction("AXPress") { _, _ in .cannotComplete }
+            Issue.record("Expected AccessibilitySystemError")
+        } catch let error as AccessibilitySystemError {
+            #expect(error.axError == .cannotComplete)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
+    func `utility preserves native AX errors and only generalizes unknown failures`() {
+        #expect(
+            AXUtilities.axError(forActionError: AccessibilitySystemError(.cannotComplete)) == .cannotComplete)
+        #expect(AXUtilities.axError(forActionError: UnexpectedActionError()) == .failure)
+    }
+
+    @Test
+    func `successful command action skips supported action discovery`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var invocationCount = 0
+        var discoveryCount = 0
+
+        let response = AXorcist().executeAction(
+            action: "AXPress",
+            on: element,
+            value: nil,
+            performer: { _, _ in invocationCount += 1 },
+            supportedActions: { _ in
+                discoveryCount += 1
+                return ["AXPress"]
+            })
+
+        #expect(response.status == "success")
+        #expect(invocationCount == 1)
+        #expect(discoveryCount == 0)
+    }
+
+    @Test
+    func `unsupported command action discovers diagnostics once after failure`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var discoveryCount = 0
+
+        let response = AXorcist().executeAction(
+            action: "AXPress",
+            on: element,
+            value: nil,
+            performer: { _, _ in throw AccessibilitySystemError(.actionUnsupported) },
+            supportedActions: { _ in
+                discoveryCount += 1
+                return ["AXRaise"]
+            })
+
+        #expect(response.error?.code == .actionNotSupported)
+        #expect(response.error?.message.contains("Action is not supported") == true)
+        #expect(response.error?.message.contains("Available actions: [AXRaise]") == true)
+        #expect(discoveryCount == 1)
+    }
+
+    @Test
+    func `cannot complete is preserved without retry or discovery`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var invocationCount = 0
+        var discoveryCount = 0
+
+        let response = AXorcist().executeAction(
+            action: "AXPress",
+            on: element,
+            value: nil,
+            performer: { _, _ in
+                invocationCount += 1
+                throw AccessibilitySystemError(.cannotComplete)
+            },
+            supportedActions: { _ in
+                discoveryCount += 1
+                return nil
+            })
+
+        #expect(response.error?.code == .actionFailed)
+        #expect(response.error?.message.contains("Cannot complete operation") == true)
+        #expect(response.error?.message.contains("-25204") == true)
+        #expect(invocationCount == 1)
+        #expect(discoveryCount == 0)
+    }
+
+    @Test(arguments: [
+        (AXError.apiDisabled, AXErrorCode.permissionDenied),
+        (.invalidUIElement, .elementNotFound),
+        (.actionUnsupported, .actionNotSupported),
+        (.illegalArgument, .invalidParameter),
+        (.cannotComplete, .actionFailed),
+    ])
+    func `native action failures map to precise response codes`(_ error: AXError, _ code: AXErrorCode) {
+        #expect(error.actionResponseCode == code)
+    }
+}

--- a/Tests/AXorcistTests/CLIFrontendTests.swift
+++ b/Tests/AXorcistTests/CLIFrontendTests.swift
@@ -103,6 +103,25 @@ struct CLIFrontendTests {
     }
 
     @Test
+    func `raw responses preserve machine readable AX error codes`() throws {
+        let handlerResponse = HandlerResponse(from: .errorResponse(
+            message: "Action is not supported",
+            code: .actionNotSupported))
+        let json = finalizeAndEncodeResponse(
+            commandId: "unsupported-action",
+            commandType: "performAction",
+            handlerResponse: handlerResponse,
+            debugCLI: false,
+            commandDebugLogging: false)
+
+        let data = try #require(json.data(using: .utf8))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["status"] as? String == "error")
+        #expect(object["error"] as? String == "Action is not supported")
+        #expect(object["error_code"] as? String == "action_not_supported")
+    }
+
+    @Test
     func `Raw argument failures remain structured JSON`() throws {
         let result = try runAXORCCommand(arguments: ["raw", "--file"])
 


### PR DESCRIPTION
## Summary

- make the string `Element.performAction` path the single owner of `AXUIElementPerformAction`
- remove advisory supported-action preflights from command, utility, and focus execution paths
- avoid eager multi-attribute element descriptions when logging is disabled
- preserve native `AccessibilitySystemError` values through `AXUtilities`, AXorcist responses, and the CLI's additive `error_code`
- keep `cannotComplete` single-dispatch and non-retrying because the platform may have already delivered the action

## Why

The previous action path could enumerate supported actions before dispatch, enumerate them again for diagnostics, and perform several descriptive AX reads even with logging off. Those checks were both slower and less authoritative than the native action result. The legacy utility also caught a different error type, collapsing every native failure to `.failure`, while the CLI adapter discarded AXorcist's machine-readable error category.

This keeps outcome semantics at AXorcist's existing boundary: no Peekaboo-specific result type or dispatched/unverified policy is introduced upstream.

## Proof

- `swift build`
- `swift test` — 66 safe tests passed; standard automation-gated suites remained skipped
- `make check` — pinned SwiftFormat and strict SwiftLint passed
- structured autoreview — clean, no accepted/actionable findings
- source-blind signed-binary validation against the already-running Finder application:
  - unsupported action exited 1 with `error_code: "action_not_supported"` and native AX error `-25206`
  - changing and repeating the bogus action name changed/preserved the response as expected
  - Finder never became foreground; no retry, AppleScript, or Apple Events were used

Focused regression tests assert one native call through the canonical owner, zero supported-action discovery calls on success, one diagnostic discovery only after `actionUnsupported`, exact raw error preservation/mapping, and no retry for `cannotComplete`.
