### PR TITLE
fix: route AXSetValue through value attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Route the published `AXSetValue` compatibility command through the native value-attribute setter instead of treating it as a macOS accessibility action.
 - Execute accessibility actions directly through one system-call owner, preserving native AX failures without redundant action-discovery round trips.
 - Use the native macOS names for parameterized accessibility attributes instead of non-existent `Parameterized`-suffixed raw values.
 - Traverse menu bars during default searches so their items remain discoverable without `--scan-all`. Thanks @dalsoop.

--- a/Examples/UsingNewImprovements.swift
+++ b/Examples/UsingNewImprovements.swift
@@ -134,10 +134,13 @@ func exampleModernActions() {
         // All available actions:
         let availableActions: [AXAction] = [
             .press, .increment, .decrement, .confirm, .cancel,
-            .showMenu, .pick, .raise, .setValue,
+            .showMenu, .pick, .raise,
         ]
 
         print("Available actions: \(availableActions.map(\.rawValue).joined(separator: ", "))")
+
+        // AXValue is an attribute mutation rather than an action:
+        // try textField.setValue("New value")
 
     } catch {
         print("❌ Action failed: \(error)")

--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ let title = element.title()
 let role = element.role()
 let isEnabled = element.isEnabled()
 
-// Perform actions
+// Perform a native action
 try element.performAction(.press)
-_ = element.setValue("Hello World", forAttribute: "AXValue")
+
+// Set the native value attribute
+try element.setValue("Hello World")
 
 // Navigate hierarchy
 let children = element.children()
@@ -410,10 +412,9 @@ Execute multiple commands in sequence.
     },
     {
       "command_id": "fill-text-area",
-      "command": "performAction",
+      "command": "setFocusedValue",
       "application": "TextEdit",
       "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]},
-      "action_name": "AXSetValue",
       "action_value": "Hello, World!"
     }
   ]
@@ -460,20 +461,24 @@ Available actions to perform on elements:
 - **AXShowMenu** - Show context menu
 - **AXPick** - Pick/select element
 - **AXRaise** - Bring element to front
-- **AXSetValue** - Set value (for text fields)
 
 ### Setting Text Values
+
+Setting `AXValue` is an attribute mutation, not a native accessibility action. Use `setFocusedValue` when the target
+may need focus:
 
 ```json
 {
   "command_id": "replace-text",
-  "command": "performAction",
+  "command": "setFocusedValue",
   "application": "TextEdit",
   "locator": {"criteria": [{"attribute": "AXRole", "value": "AXTextArea"}]},
-  "action_name": "AXSetValue",
   "action_value": "New text content"
 }
 ```
+
+The published `performAction` spelling with `"action_name": "AXSetValue"` remains a compatibility alias. It requires
+a string `action_value` and writes `AXValue` directly without invoking an accessibility action or changing focus.
 
 ## Notifications and Observing
 
@@ -600,7 +605,7 @@ Existing invocations such as `axorc --stdin` and `axorc '{...}'` remain supporte
   "sub_commands": [
     {
       "command_id": "fill-email",
-      "command": "performAction",
+      "command": "setFocusedValue",
       "application": "Safari",
       "locator": {
         "criteria": [
@@ -608,12 +613,11 @@ Existing invocations such as `axorc --stdin` and `axorc '{...}'` remain supporte
           {"attribute": "AXPlaceholderValue", "value": "Email", "match_type": "contains"}
         ]
       },
-      "action_name": "AXSetValue",
       "action_value": "user@example.com"
     },
     {
       "command_id": "fill-password",
-      "command": "performAction",
+      "command": "setFocusedValue",
       "application": "Safari",
       "locator": {
         "criteria": [
@@ -621,7 +625,6 @@ Existing invocations such as `axorc --stdin` and `axorc '{...}'` remain supporte
           {"attribute": "AXPlaceholderValue", "value": "Password", "match_type": "contains"}
         ]
       },
-      "action_name": "AXSetValue",
       "action_value": "example-value"
     },
     {

--- a/Sources/AXorcist/Core/AXError+Extensions.swift
+++ b/Sources/AXorcist/Core/AXError+Extensions.swift
@@ -105,4 +105,19 @@ extension AXError {
             .actionFailed
         }
     }
+
+    var valueResponseCode: AXErrorCode {
+        switch self {
+        case .apiDisabled:
+            .permissionDenied
+        case .invalidUIElement:
+            .elementNotFound
+        case .attributeUnsupported:
+            .attributeNotFound
+        case .illegalArgument:
+            .invalidParameter
+        default:
+            .actionFailed
+        }
+    }
 }

--- a/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
@@ -33,7 +33,7 @@ extension AXorcist {
             return .errorResponse(message: message, code: .elementNotFound)
         }
 
-        return self.executeAction(action: command.action, on: element, value: command.value)
+        return self.executeResolvedAction(command: command, on: element)
     }
 
     // MARK: - Set Focused Value Handler
@@ -60,7 +60,7 @@ extension AXorcist {
         if self.ensureFocusCapability(for: element) {
             self.setFocus(on: element)
         }
-        return self.setValue(command.value, on: element)
+        return self.executeSetValue(value: command.value, on: element)
     }
 
     // MARK: - Extract Text Handler
@@ -125,6 +125,37 @@ extension AXorcist {
                 "Locator: \(command.locator), Value: '\(command.value)'"))
     }
 
+    func executeResolvedAction(
+        command: PerformActionCommand,
+        on element: Element,
+        performer: (Element, String) throws -> Void = { element, action in
+            try element.performAction(action)
+        },
+        valueSetter: (Element, String) throws -> Void = { element, value in
+            try element.setValue(value)
+        },
+        supportedActions: (Element) -> [String]? = { element in
+            element.supportedActions()
+        }) -> AXResponse
+    {
+        guard command.action == AXActionNames.kAXSetValueAction else {
+            return self.executeAction(
+                action: command.action,
+                on: element,
+                value: command.value,
+                performer: performer,
+                supportedActions: supportedActions)
+        }
+
+        guard let value = command.value?.value as? String else {
+            let message = "HandlePerformAction: AXSetValue requires a string action_value. No value was dispatched."
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
+            return .errorResponse(message: message, code: .invalidParameter)
+        }
+
+        return self.executeSetValue(value: value, on: element, setter: valueSetter)
+    }
+
     func executeAction(
         action: String,
         on element: Element,
@@ -160,6 +191,31 @@ extension AXorcist {
             let errorMessage = "HandlePerformAction: Failed to perform action '\(action)'. Error: \(error)"
             GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
             return .errorResponse(message: errorMessage, code: .actionFailed)
+        }
+    }
+
+    func executeSetValue(
+        value: String,
+        on element: Element,
+        setter: (Element, String) throws -> Void = { element, value in
+            try element.setValue(value)
+        }) -> AXResponse
+    {
+        do {
+            try setter(element, value)
+            GlobalAXLogger.shared.log(AXLogEntry(
+                level: .info,
+                message: "Successfully set the element's AXValue attribute."))
+            return .successResponse(payload: AnyCodable(["message": "Value set successfully."]))
+        } catch let error as AccessibilitySystemError {
+            let message = "Failed to set AXValue. Error: \(error.localizedDescription) " +
+                "(AXError \(error.axError.rawValue))."
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
+            return .errorResponse(message: message, code: error.axError.valueResponseCode)
+        } catch {
+            let message = "Failed to set AXValue. Error: \(error.localizedDescription)"
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
+            return .errorResponse(message: message, code: .actionFailed)
         }
     }
 
@@ -236,25 +292,6 @@ extension AXorcist {
                 "HandleSetFocusedValue: Failed to set kAXFocusedAttribute for \(elementDescription),",
                 "but proceeding to set value.",
             ].joined(separator: " ")))
-    }
-
-    private func setValue(_ value: String, on element: Element) -> AXResponse {
-        let elementDescription = element.briefDescription(option: ValueFormatOption.smart)
-        GlobalAXLogger.shared.log(AXLogEntry(
-            level: .debug,
-            message: "HandleSetFocusedValue: Attempting to set kAXValueAttribute to '\(value)' " +
-                "for \(elementDescription)"))
-        if element.setValue(value, forAttribute: AXAttributeNames.kAXValueAttribute) {
-            GlobalAXLogger.shared.log(AXLogEntry(
-                level: .info,
-                message: "HandleSetFocusedValue: Successfully set value for \(elementDescription)."))
-            return .successResponse(
-                payload: AnyCodable(["message": "Value '\(value)' set successfully on focused element."]))
-        }
-
-        let setError = "HandleSetFocusedValue: Failed to set kAXValueAttribute for \(elementDescription)."
-        GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: setError))
-        return .errorResponse(message: setError, code: .actionFailed)
     }
 
     private func missingElementMessage(prefix: String, appIdentifier: String, locatorDescription: String) -> String {

--- a/Sources/AXorcist/Core/AccessibilityConstants.swift
+++ b/Sources/AXorcist/Core/AccessibilityConstants.swift
@@ -20,7 +20,7 @@ public enum AXActionNames {
     // public static let kAXShowDefaultUIAction = "AXShowDefaultUI"     // Shows the default UI for the element
     // public static let kAXDeleteAction = "AXDelete" // Action to delete content or an element
 
-    /// Internal/Custom action name for setting a value via performAction handler
+    /// Compatibility command and receipt token. This is not a native macOS accessibility action.
     public static let kAXSetValueAction = "AXSetValue"
 }
 
@@ -36,6 +36,7 @@ public enum AXAction {
     case showMenu
     case pick
     case raise
+    @available(*, deprecated, message: "AXSetValue is not a native action; use Element.setValue(_:) instead.")
     case setValue
 
     // MARK: Public

--- a/Sources/AXorcist/Core/Element+ValueSetting.swift
+++ b/Sources/AXorcist/Core/Element+ValueSetting.swift
@@ -1,0 +1,75 @@
+import ApplicationServices
+import Foundation
+
+extension Element {
+    /// Sets the native `AXValue` attribute and preserves the exact Accessibility framework error.
+    @MainActor
+    @discardableResult
+    public func setValue(_ value: String) throws -> Element {
+        try self.setAttributeValue(value, forAttribute: AXAttributeNames.kAXValueAttribute)
+    }
+
+    /// Sets an accessibility attribute and preserves the exact Accessibility framework error.
+    @MainActor
+    @discardableResult
+    public func setAttributeValue(_ value: Any, forAttribute attributeName: String) throws -> Element {
+        try self.setAttributeValue(value, forAttribute: attributeName, using: AXUIElementSetAttributeValue)
+    }
+
+    /// Compatibility wrapper for callers that still use the historical Boolean setter.
+    @MainActor
+    public func setValue(_ value: Any, forAttribute attributeName: String) -> Bool {
+        do {
+            try self.setAttributeValue(value, forAttribute: attributeName)
+            return true
+        } catch {
+            axErrorLog("Failed to set attribute '\(attributeName)': \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    @MainActor
+    @discardableResult
+    func setAttributeValue(
+        _ value: Any,
+        forAttribute attributeName: String,
+        using setter: (AXUIElement, CFString, CFTypeRef) -> AXError) throws -> Element
+    {
+        guard let cfValue = Self.bridgeAttributeValue(value) else {
+            throw AccessibilitySystemError(.illegalArgument)
+        }
+
+        let description = GlobalAXLogger.shared.isLoggingEnabled
+            ? self.briefDescription(option: .smart)
+            : nil
+        if let description {
+            axDebugLog("Setting attribute '\(attributeName)' on element: \(description)")
+        }
+
+        try setter(self.underlyingElement, attributeName as CFString, cfValue).throwIfError()
+
+        if let description {
+            axInfoLog("Successfully set attribute '\(attributeName)' on element: \(description)")
+        }
+        return self
+    }
+
+    private static func bridgeAttributeValue(_ value: Any) -> CFTypeRef? {
+        if let string = value as? String {
+            return string as CFString
+        }
+        if let bool = value as? Bool {
+            return CFConstants.cfBoolean(from: bool)
+        }
+        if let number = value as? NSNumber {
+            return number
+        }
+        if let element = value as? Element {
+            return element.underlyingElement
+        }
+        if let object = value as? NSObject {
+            return object
+        }
+        return nil
+    }
+}

--- a/Sources/AXorcist/Core/Element.swift
+++ b/Sources/AXorcist/Core/Element.swift
@@ -245,46 +245,6 @@ public struct Element: Equatable, Hashable, Sendable {
         }
     }
 
-    @MainActor
-    public func setValue(_ value: Any, forAttribute attributeName: String) -> Bool {
-        // Bridge the Swift value to CFTypeRef
-        // Note: This bridging is basic. For complex types or specific CF types, more handling may be needed.
-        let cfValue: CFTypeRef
-        if let strValue = value as? String {
-            cfValue = strValue as CFString
-        } else if let boolValue = value as? Bool {
-            cfValue = CFConstants.cfBoolean(from: boolValue) as CFBoolean
-        } else if let numValue = value as? NSNumber { // Handles Int, Double, etc. that bridge to NSNumber
-            cfValue = numValue
-        } else if let elementValue = value as? Element {
-            cfValue = elementValue.underlyingElement
-        } else {
-            // Attempt direct bridging for other types; may fail if not directly bridgable.
-            // Consider logging a warning or throwing an error for unhandled types.
-            let warningMsg = "Attempting to set attribute '\\(attributeName)' with potentially "
-            let warningDetail = "non-CF-bridgable Swift type: \\(type(of: value)). "
-            let warningEnd = "This might fail or lead to unexpected behavior."
-            GlobalAXLogger.shared.log(AXLogEntry(
-                level: .warning,
-                message: warningMsg + warningDetail + warningEnd))
-            cfValue = value as CFTypeRef // This can crash if 'value' is not CF-bridgable
-        }
-
-        let error = AXUIElementSetAttributeValue(self.underlyingElement, attributeName as CFString, cfValue)
-        if error == .success {
-            let msg = "Successfully set attribute '\\(attributeName)' to '\\(value)' on "
-            GlobalAXLogger.shared.log(AXLogEntry(
-                level: .debug,
-                message: msg + "\(self.briefDescription(option: .smart))"))
-            return true
-        } else {
-            axErrorLog(
-                "Failed to set attribute '\(attributeName)' to '\(value)' on " +
-                    "\(self.briefDescription(option: .smart)): \(error.stringValue)")
-            return false
-        }
-    }
-
     // MARK: Private
 
     @MainActor

--- a/Sources/AXorcist/Utils/AXUtilities.swift
+++ b/Sources/AXorcist/Utils/AXUtilities.swift
@@ -31,44 +31,24 @@ public enum AXUtilities {
         forElement element: Element,
         valueToSet: Any?) -> (error: AXError, errorMessage: String?)
     {
-        let description = element.briefDescription()
-        axDebugLog(
-            "AXUtilities: Attempting to set value for element: \(description) " +
-                "with value: \(String(describing: valueToSet))")
-
-        let attributeName = AXAttributeNames.kAXValueAttribute
-
-        var cfValue: CFTypeRef?
-        if let nsValue = valueToSet as? NSObject {
-            cfValue = nsValue
-        } else if let strValue = valueToSet as? String {
-            cfValue = strValue as CFString
-        } else if valueToSet == nil {
-            axDebugLog("AXUtilities: valueToSet is nil. Attempting to set attribute to nil/empty.")
-        } else {
-            let errorMsg =
-                "AXUtilities: Value type for attribute '\(attributeName)' is not directly " +
-                "convertible to CFTypeRef: \(String(describing: valueToSet)). " +
-                "Type: \(type(of: valueToSet))"
-            axErrorLog(errorMsg)
-            return (.apiDisabled, errorMsg)
+        guard let valueToSet else {
+            let message = "AXUtilities: AXValue requires a non-nil value."
+            axErrorLog(message)
+            return (.illegalArgument, message)
         }
 
-        let error = AXUIElementSetAttributeValue(
-            element.underlyingElement,
-            attributeName as CFString,
-            cfValue ?? CFConstants.cfBooleanFalse!)
-
-        if error == .success {
-            axDebugLog(
-                "AXUtilities: Successfully set attribute '\(attributeName)' on \(description)")
+        do {
+            try element.setAttributeValue(valueToSet, forAttribute: AXAttributeNames.kAXValueAttribute)
             return (.success, nil)
-        } else {
-            let errorMsg =
-                "AXUtilities: Failed to set attribute '\(attributeName)' on \(description). " +
-                "Error: \(error)"
-            axErrorLog(errorMsg)
-            return (error, errorMsg)
+        } catch let error as AccessibilitySystemError {
+            let message = "AXUtilities: Failed to set AXValue: \(error.localizedDescription) " +
+                "(AXError \(error.axError.rawValue))."
+            axErrorLog(message)
+            return (error.axError, message)
+        } catch {
+            let message = "AXUtilities: Failed to set AXValue: \(error.localizedDescription)"
+            axErrorLog(message)
+            return (.failure, message)
         }
     }
 }

--- a/Tests/AXorcistTests/SetValueExecutionTests.swift
+++ b/Tests/AXorcistTests/SetValueExecutionTests.swift
@@ -1,0 +1,157 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("AX value execution")
+@MainActor
+struct SetValueExecutionTests {
+    nonisolated enum InvalidValueFixture: CaseIterable, Sendable {
+        case missing
+        case integer
+        case boolean
+    }
+
+    @Test
+    func `canonical value owner invokes the native setter once`() throws {
+        let element = Element(AXUIElementCreateSystemWide())
+        var invocationCount = 0
+        var receivedAttribute: String?
+        var receivedValue: String?
+
+        let returnedElement = try element.setAttributeValue(
+            "hello",
+            forAttribute: AXAttributeNames.kAXValueAttribute)
+        { _, attribute, value in
+            invocationCount += 1
+            receivedAttribute = attribute as String
+            receivedValue = value as? String
+            return .success
+        }
+
+        #expect(invocationCount == 1)
+        #expect(receivedAttribute == AXAttributeNames.kAXValueAttribute)
+        #expect(receivedValue == "hello")
+        #expect(CFEqual(returnedElement.underlyingElement, element.underlyingElement))
+    }
+
+    @Test
+    func `canonical value owner preserves native AX errors`() {
+        let element = Element(AXUIElementCreateSystemWide())
+
+        do {
+            try element.setAttributeValue("hello", forAttribute: AXAttributeNames.kAXValueAttribute) { _, _, _ in
+                .attributeUnsupported
+            }
+            Issue.record("Expected AccessibilitySystemError")
+        } catch let error as AccessibilitySystemError {
+            #expect(error.axError == .attributeUnsupported)
+        } catch {
+            Issue.record("Unexpected error type: \(error)")
+        }
+    }
+
+    @Test
+    func `AXSetValue compatibility command uses only the value setter`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var actionCount = 0
+        var valueSetCount = 0
+        var discoveryCount = 0
+        var receivedValue: String?
+
+        let response = AXorcist().executeResolvedAction(
+            command: Self.command(value: AnyCodable("hello")),
+            on: element,
+            performer: { _, _ in actionCount += 1 },
+            valueSetter: { _, value in
+                valueSetCount += 1
+                receivedValue = value
+            },
+            supportedActions: { _ in
+                discoveryCount += 1
+                return [AXActionNames.kAXSetValueAction]
+            })
+
+        #expect(response.status == "success")
+        #expect(actionCount == 0)
+        #expect(valueSetCount == 1)
+        #expect(discoveryCount == 0)
+        #expect(receivedValue == "hello")
+    }
+
+    @Test(arguments: InvalidValueFixture.allCases)
+    func `AXSetValue rejects missing or non-string values before dispatch`(_ fixture: InvalidValueFixture) {
+        let element = Element(AXUIElementCreateSystemWide())
+        var actionCount = 0
+        var valueSetCount = 0
+        var discoveryCount = 0
+        let value: AnyCodable? = switch fixture {
+        case .missing: nil
+        case .integer: AnyCodable(42)
+        case .boolean: AnyCodable(true)
+        }
+
+        let response = AXorcist().executeResolvedAction(
+            command: Self.command(value: value),
+            on: element,
+            performer: { _, _ in actionCount += 1 },
+            valueSetter: { _, _ in valueSetCount += 1 },
+            supportedActions: { _ in
+                discoveryCount += 1
+                return nil
+            })
+
+        #expect(response.error?.code == .invalidParameter)
+        #expect(response.error?.message.contains("No value was dispatched") == true)
+        #expect(actionCount == 0)
+        #expect(valueSetCount == 0)
+        #expect(discoveryCount == 0)
+    }
+
+    @Test
+    func `AXSetValue preserves exact native setter failures`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var valueSetCount = 0
+
+        let response = AXorcist().executeResolvedAction(
+            command: Self.command(value: AnyCodable("hello")),
+            on: element,
+            valueSetter: { _, _ in
+                valueSetCount += 1
+                throw AccessibilitySystemError(.attributeUnsupported)
+            })
+
+        #expect(response.error?.code == .attributeNotFound)
+        #expect(response.error?.message.contains("Attribute is not supported") == true)
+        #expect(response.error?.message.contains("-25205") == true)
+        #expect(valueSetCount == 1)
+    }
+
+    @Test
+    func `legacy value utility rejects nil before dispatch`() {
+        let result = AXUtilities.performSetValueAction(
+            forElement: Element(AXUIElementCreateSystemWide()),
+            valueToSet: nil)
+
+        #expect(result.error == .illegalArgument)
+        #expect(result.errorMessage?.contains("non-nil value") == true)
+    }
+
+    @Test(arguments: [
+        (AXError.apiDisabled, AXErrorCode.permissionDenied),
+        (.invalidUIElement, .elementNotFound),
+        (.attributeUnsupported, .attributeNotFound),
+        (.illegalArgument, .invalidParameter),
+        (.cannotComplete, .actionFailed),
+    ])
+    func `native value failures map to precise response codes`(_ error: AXError, _ code: AXErrorCode) {
+        #expect(error.valueResponseCode == code)
+    }
+
+    private static func command(value: AnyCodable?) -> PerformActionCommand {
+        PerformActionCommand(
+            appIdentifier: "com.example.fixture",
+            locator: Locator(criteria: []),
+            action: AXActionNames.kAXSetValueAction,
+            value: value)
+    }
+}


### PR DESCRIPTION
## Summary

- keep the published `AXSetValue` command/receipt token as a compatibility alias while removing it from native action semantics
- route the alias and `setFocusedValue` through one exact-error `AXValue` attribute setter
- reject missing and non-string compatibility values with `invalid_parameter` before any mutation
- deprecate, but retain, the misleading `AXAction.setValue` enum case for source compatibility in the current minor line
- repair the README and examples so only real macOS accessibility actions are listed as actions

## Why

macOS does not define an `AXSetValue` action. AXorcist nevertheless documented it as one, ignored the provided action value, and sent the invented name to `AXUIElementPerformAction`. This keeps the published JSON spelling working while making its implementation truthful: it is a direct `kAXValueAttribute` mutation and never performs action discovery, action dispatch, focus preparation, activation, or retry.

The new setter preserves the exact native `AXError`; the existing Boolean setter and legacy utility now share that owner instead of duplicating the framework call.

## Proof

- `swift build`
- `swift test` — 73 safe tests passed; standard automation-gated suites remained skipped
- `make check` — pinned SwiftFormat and strict SwiftLint passed
- structured autoreview — clean, no accepted/actionable findings
- source-blind signed-binary validation against a signed nonactivating AppKit fixture:
  - single, batch, and repeated `AXSetValue` compatibility commands changed the independently queried `AXValue`
  - missing and integer values returned `error_code: "invalid_parameter"`, said no value was dispatched, and left state unchanged
  - every query reported `AXFocused: false`; the foreground ASN remained unchanged throughout
  - malformed JSON remained a structured non-mutating error
  - no AppleScript or Apple Events were used

Focused unit tests assert one native setter call, zero action calls and zero supported-action discovery, fail-before-mutation value validation, exact native error propagation, and stable error-code mapping.
