### PR TITLE
fix: remove Apple Events permission probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.
 - Route the published `AXSetValue` compatibility command through the native value-attribute setter instead of treating it as a macOS accessibility action.
 - Execute accessibility actions directly through one system-call owner, preserving native AX failures without redundant action-discovery round trips.
 - Use the native macOS names for parameterized accessibility attributes instead of non-existent `Parameterized`-suffixed raw values.

--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,11 @@ lint:
 	swiftlint lint --strict
 	@echo "Code linting complete."
 
-# Run both formatting and linting
-check: format-check lint
+native-only:
+	@bash scripts/test-native-ax-only.sh
+
+# Run formatting, linting, and native-only policy checks
+check: format-check lint native-only
 	@echo "All code checks complete."
 
 # Default target

--- a/Sources/AXorcist/Core/AccessibilityPermissions.swift
+++ b/Sources/AXorcist/Core/AccessibilityPermissions.swift
@@ -1,8 +1,6 @@
 // AccessibilityPermissions.swift - Utility for checking and managing accessibility permissions.
 
-import AppKit // For NSRunningApplication
 import ApplicationServices // For AXIsProcessTrusted(), AXUIElementCreateSystemWide(), etc.
-import Foundation
 
 // Removed private let kAXTrustedCheckOptionPromptKey = "AXTrustedCheckOptionPrompt"
 
@@ -14,14 +12,22 @@ import Foundation
 public struct AXPermissionsStatus {
     public let isAccessibilityApiEnabled: Bool
     public let isProcessTrustedForAccessibility: Bool
-    public var automationStatus: [String: Bool] =
-        [:] // BundleID: Bool (true if permitted, false if denied, nil if not checked or app not running)
+
+    @available(
+        *,
+        deprecated,
+        message: "AXorcist no longer probes Apple Events automation permission; this status remains empty.")
+    public var automationStatus: [String: Bool] = [:]
     public var overallErrorMessages: [String] = []
 
     public var canUseAccessibility: Bool {
         self.isAccessibilityApiEnabled && self.isProcessTrustedForAccessibility
     }
 
+    @available(
+        *,
+        deprecated,
+        message: "AXorcist no longer probes Apple Events automation permission; this result is unknown.")
     public func canAutomate(bundleID: String) -> Bool? {
         self.automationStatus[bundleID]
     }
@@ -53,11 +59,9 @@ public func checkAccessibilityPermissions(promptIfNeeded: Bool = true) throws {
 }
 
 @MainActor
-public func getPermissionsStatus(
-    checkAutomationFor bundleIDs: [String] = []) -> AXPermissionsStatus
-{
+public func getPermissionsStatus() -> AXPermissionsStatus {
     axDebugLog(
-        "Starting full permission status check.",
+        "Starting Accessibility permission status check.",
         file: #file,
         function: #function,
         line: #line)
@@ -71,27 +75,11 @@ public func getPermissionsStatus(
 
     logProcessTrustStatus(isProcessTrusted)
 
-    var automationStatus: [String: Bool] = [:]
-    var collectedErrorMessages: [String] = []
-
-    if !bundleIDs.isEmpty, isProcessTrusted {
-        let results = checkAutomationPermissions(for: bundleIDs)
-        automationStatus = results.automationStatus
-        collectedErrorMessages = results.errorMessages
-    } else if !bundleIDs.isEmpty {
-        axDebugLog(
-            "Skipping automation permission checks because basic accessibility " +
-                "(isProcessTrusted: \(isProcessTrusted)) is not met.",
-            file: #file,
-            function: #function,
-            line: #line)
-    }
-
     let finalStatus = AXPermissionsStatus(
         isAccessibilityApiEnabled: isProcessTrusted,
         isProcessTrustedForAccessibility: isProcessTrusted,
-        automationStatus: automationStatus,
-        overallErrorMessages: collectedErrorMessages)
+        automationStatus: [:],
+        overallErrorMessages: [])
     axDebugLog(
         "Finished permission status check. isAccessibilityApiEnabled: \(finalStatus.isAccessibilityApiEnabled), " +
             "isProcessTrusted: \(finalStatus.isProcessTrustedForAccessibility)",
@@ -99,6 +87,20 @@ public func getPermissionsStatus(
         function: #function,
         line: #line)
     return finalStatus
+}
+
+/// Returns Accessibility permission status without probing Apple Events automation permission.
+///
+/// The bundle identifiers are ignored and ``AXPermissionsStatus/automationStatus`` remains empty.
+/// This overload is retained only so existing source continues to compile while callers migrate to
+/// ``getPermissionsStatus()``.
+@available(
+    *,
+    deprecated,
+    message: "Apple Events automation permission probing was removed; call getPermissionsStatus() instead.")
+@MainActor
+public func getPermissionsStatus(checkAutomationFor _: [String]) -> AXPermissionsStatus {
+    getPermissionsStatus()
 }
 
 private func logProcessTrustStatus(_ isProcessTrusted: Bool) {
@@ -116,96 +118,5 @@ private func logProcessTrustStatus(_ isProcessTrusted: Bool) {
             file: #file,
             function: #function,
             line: #line)
-    }
-}
-
-private func checkAutomationPermissions(
-    for bundleIDs: [String]) -> (automationStatus: [String: Bool], errorMessages: [String])
-{
-    var automationStatus: [String: Bool] = [:]
-    var collectedErrorMessages: [String] = []
-
-    axDebugLog(
-        "Checking automation permissions for bundle IDs: \(bundleIDs.joined(separator: ", "))",
-        file: #file,
-        function: #function,
-        line: #line)
-
-    for bundleID in bundleIDs {
-        let result = checkSingleBundleAutomation(bundleID)
-        if let status = result.status {
-            automationStatus[bundleID] = status
-        }
-        if let error = result.errorMessage {
-            collectedErrorMessages.append(error)
-        }
-    }
-
-    return (automationStatus, collectedErrorMessages)
-}
-
-private func checkSingleBundleAutomation(_ bundleID: String) -> (status: Bool?, errorMessage: String?) {
-    guard NSRunningApplication.runningApplications(withBundleIdentifier: bundleID).first != nil else {
-        axDebugLog(
-            "Application with bundle ID '\(bundleID)' is not running. Cannot check automation status.",
-            file: #file,
-            function: #function,
-            line: #line)
-        return (nil, nil)
-    }
-
-    guard var target = makeAutomationTarget(bundleID: bundleID) else {
-        let message = "Could not create an Apple Event target for bundle ID '\(bundleID)'."
-        axErrorLog(message, file: #file, function: #function, line: #line)
-        return (nil, message)
-    }
-    defer { AEDisposeDesc(&target) }
-
-    let nativeStatus = AEDeterminePermissionToAutomateTarget(
-        &target,
-        typeWildCard,
-        typeWildCard,
-        false)
-    return automationPermissionResult(for: nativeStatus, bundleID: bundleID)
-}
-
-private func makeAutomationTarget(bundleID: String) -> AEDesc? {
-    let bundleIDData = Data(bundleID.utf8)
-    guard !bundleIDData.isEmpty else { return nil }
-
-    var target = AEDesc()
-    let status = bundleIDData.withUnsafeBytes { bytes in
-        AECreateDesc(
-            typeApplicationBundleID,
-            bytes.baseAddress,
-            bundleIDData.count,
-            &target)
-    }
-    guard status == noErr else { return nil }
-    return target
-}
-
-func automationPermissionResult(
-    for nativeStatus: OSStatus,
-    bundleID: String) -> (status: Bool?, errorMessage: String?)
-{
-    switch nativeStatus {
-    case noErr:
-        axDebugLog("Native automation permission check for \(bundleID) succeeded.")
-        return (true, nil)
-    case OSStatus(procNotFound):
-        return (nil, nil)
-    case OSStatus(errAEEventWouldRequireUserConsent):
-        let message = "Automation permission for \(bundleID) has not been determined."
-        axWarningLog(message)
-        return (false, message)
-    case OSStatus(errAEEventNotPermitted), OSStatus(errAETargetAddressNotPermitted):
-        let message = "Automation denied for \(bundleID) (Code: \(nativeStatus))."
-        axWarningLog(message)
-        return (false, message)
-    default:
-        let message = "Automation permission check failed for \(bundleID) (Code: \(nativeStatus))."
-        axWarningLog(message)
-        return (false, message)
     }
 }

--- a/Tests/AXorcistTests/AccessibilityPermissionsTests.swift
+++ b/Tests/AXorcistTests/AccessibilityPermissionsTests.swift
@@ -1,29 +1,24 @@
-import ApplicationServices
 import Testing
 @testable import AXorcist
 
 @MainActor
 struct AccessibilityPermissionsTests {
     @Test
-    func `Native automation permission mapping is noninteractive and truthful`() {
-        let granted = automationPermissionResult(for: noErr, bundleID: "com.example.Test")
-        #expect(granted.status == true)
-        #expect(granted.errorMessage == nil)
+    func `Permission status reports Accessibility without legacy automation probes`() {
+        let status = getPermissionsStatus()
 
-        let undecided = automationPermissionResult(
-            for: OSStatus(errAEEventWouldRequireUserConsent),
-            bundleID: "com.example.Test")
-        #expect(undecided.status == false)
-        #expect(undecided.errorMessage?.contains("not been determined") == true)
+        #expect(status.canUseAccessibility == (
+            status.isAccessibilityApiEnabled && status.isProcessTrustedForAccessibility))
+        #expect(status.overallErrorMessages.isEmpty)
+    }
 
-        let denied = automationPermissionResult(
-            for: OSStatus(errAEEventNotPermitted),
-            bundleID: "com.example.Test")
-        #expect(denied.status == false)
-        #expect(denied.errorMessage?.contains("denied") == true)
+    @available(*, deprecated, message: "Exercises the retained legacy compatibility surface.")
+    @Test
+    func `Legacy automation targets remain source compatible but unknown`() {
+        let status = getPermissionsStatus(checkAutomationFor: ["com.example.Test"])
 
-        let missing = automationPermissionResult(for: OSStatus(procNotFound), bundleID: "com.example.Test")
-        #expect(missing.status == nil)
-        #expect(missing.errorMessage == nil)
+        #expect(status.automationStatus.isEmpty)
+        #expect(status.canAutomate(bundleID: "com.example.Test") == nil)
+        #expect(status.overallErrorMessages.isEmpty)
     }
 }

--- a/scripts/test-native-ax-only.sh
+++ b/scripts/test-native-ax-only.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+cd "$repo_root"
+
+source_pattern='NSAppleScript|AEDeterminePermissionToAutomateTarget|AECreateDesc|AEDisposeDesc|AESend(Message)?|OSA(Compile|Execute|Load|Store|DoScript)|NSAppleEventsUsageDescription|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)'
+if source_matches="$(grep -REn "$source_pattern" Sources 2>/dev/null)" && [[ -n "$source_matches" ]]; then
+    echo "Production source retains an Apple Events execution surface:" >&2
+    echo "$source_matches" >&2
+    exit 1
+fi
+
+resource_matches="$(find Sources -type f \( -name '*.scpt' -o -name '*.applescript' -o -name '*.osa' \) -print)"
+if [[ -n "$resource_matches" ]]; then
+    echo "Production source contains an Apple Events script resource:" >&2
+    echo "$resource_matches" >&2
+    exit 1
+fi
+
+if [[ $# -gt 1 ]]; then
+    echo "Usage: scripts/test-native-ax-only.sh [axorc-binary]" >&2
+    exit 2
+fi
+
+binary="${1:-}"
+if [[ -z "$binary" ]]; then
+    swift build --product axorc >/dev/null
+    binary="$(swift build --show-bin-path)/axorc"
+elif [[ "$binary" != /* ]]; then
+    binary="$repo_root/$binary"
+fi
+
+if [[ ! -x "$binary" ]]; then
+    echo "axorc binary is missing or not executable: $binary" >&2
+    exit 1
+fi
+
+symbol_pattern='(^|[[:space:]])_(AE[A-Z][[:alnum:]_]*|OSA[A-Z][[:alnum:]_]*|OBJC_(CLASS|METACLASS)_[^[:space:]]*NSAppleScript)'
+if symbol_matches="$(nm -u "$binary" | grep -E "$symbol_pattern")" && [[ -n "$symbol_matches" ]]; then
+    echo "axorc imports an Apple Events execution API:" >&2
+    echo "$symbol_matches" >&2
+    exit 1
+fi
+
+if string_matches="$(strings -a "$binary" | grep -E 'NSAppleEventsUsageDescription|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)')" &&
+    [[ -n "$string_matches" ]]
+then
+    echo "axorc embeds an Apple Events execution surface:" >&2
+    echo "$string_matches" >&2
+    exit 1
+fi
+
+echo "test-native-ax-only: ok"


### PR DESCRIPTION
## Summary

- remove the legacy Apple Events automation-permission probe and all direct `AE*` result/target helpers
- retain source compatibility through a deprecated inert `checkAutomationFor` overload and deprecated status accessors that report unknown
- enforce native AX-only production source and linked-binary policy through the existing validation gate

Accessibility permission checks remain native and unchanged. No Apple Events request is created, sent, or linked by AXorcist.

## Verification

- `swift test --no-parallel` (74 tests; automation-tagged UI suites skipped as intended)
- `swift test --filter AccessibilityPermissionsTests --no-parallel` (2 tests)
- `make check` (SwiftFormat, strict SwiftLint, and native-only policy)
- `shellcheck scripts/*.sh`
- `bash scripts/test-native-ax-only.sh` against the debug CLI
- isolated arm64 and x86_64 release builds combined into a verified universal binary; native-only scan passed, SHA-256 `2b85ce3d1fa7546ab998977782880d98aea3fdd8542aa1de9e1b33cea869e459`
- structured autoreview: clean, no findings
