### PR TITLE
fix: make native-only policy fail closed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ lint:
 
 native-only:
 	@bash scripts/test-native-ax-only.sh
+	@bash scripts/test-native-ax-only-policy.sh
 
 # Run formatting, linting, and native-only policy checks
 check: format-check lint native-only

--- a/scripts/test-native-ax-only-policy.sh
+++ b/scripts/test-native-ax-only-policy.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+gate="$script_dir/test-native-ax-only.sh"
+fixture_root="$(mktemp -d "${TMPDIR:-/tmp}/axorcist-native-policy.XXXXXX")"
+trap 'rm -rf "$fixture_root"' EXIT
+
+mock_bin="$fixture_root/bin"
+binary="$fixture_root/axorc"
+mkdir -p "$mock_bin"
+touch "$binary"
+chmod +x "$binary"
+
+cat >"$mock_bin/nm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${AXORCIST_TEST_NM_MODE:-clean}" in
+    clean) ;;
+    fail) exit 86 ;;
+    apple-event) printf '%s\n' '                 U _AEGetParamPtr' ;;
+    osa) printf '%s\n' '                 U _OSAGetScriptInfo' ;;
+    user-script-task) printf '%s\n' '                 U _OBJC_CLASS_$_NSUserAppleScriptTask' ;;
+    *) exit 2 ;;
+esac
+EOF
+
+cat >"$mock_bin/strings" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${AXORCIST_TEST_STRINGS_MODE:-clean}" in
+    clean) printf '%s\n' 'native accessibility only' ;;
+    fail) exit 87 ;;
+    osakit) printf '%s\n' 'OSAKit.framework' ;;
+    osascript) printf '%s\n' '/usr/bin/osascript' ;;
+    *) exit 2 ;;
+esac
+EOF
+
+cat >"$mock_bin/grep" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${AXORCIST_TEST_GREP_MODE:-clean}" in
+    clean) exec /usr/bin/grep "$@" ;;
+    fail) exit 88 ;;
+    *) exit 2 ;;
+esac
+EOF
+
+chmod +x "$mock_bin/nm" "$mock_bin/strings" "$mock_bin/grep"
+
+run_gate() {
+    env \
+        PATH="$mock_bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+        AXORCIST_TEST_NM_MODE="${1:-clean}" \
+        AXORCIST_TEST_STRINGS_MODE="${2:-clean}" \
+        AXORCIST_TEST_GREP_MODE="${3:-clean}" \
+        bash "$gate" "$binary" 2>&1
+}
+
+expect_success() {
+    local label="$1"
+    local nm_mode="$2"
+    local strings_mode="$3"
+    local grep_mode="${4:-clean}"
+    local output
+
+    if ! output="$(run_gate "$nm_mode" "$strings_mode" "$grep_mode")"; then
+        printf 'FAIL: %s unexpectedly failed\n%s\n' "$label" "$output" >&2
+        exit 1
+    fi
+    [[ "$output" == *'test-native-ax-only: ok'* ]] || {
+        printf 'FAIL: %s did not report success\n%s\n' "$label" "$output" >&2
+        exit 1
+    }
+}
+
+expect_failure() {
+    local label="$1"
+    local nm_mode="$2"
+    local strings_mode="$3"
+    local expected="$4"
+    local grep_mode="${5:-clean}"
+    local output
+
+    if output="$(run_gate "$nm_mode" "$strings_mode" "$grep_mode")"; then
+        printf 'FAIL: %s unexpectedly passed\n%s\n' "$label" "$output" >&2
+        exit 1
+    fi
+    [[ "$output" == *"$expected"* ]] || {
+        printf 'FAIL: %s did not report %q\n%s\n' "$label" "$expected" "$output" >&2
+        exit 1
+    }
+}
+
+expect_success 'clean executable' clean clean
+expect_failure 'source inspection failure' clean clean 'Could not inspect production source' fail
+expect_failure 'nm inspection failure' fail clean 'Could not inspect axorc imports'
+expect_failure 'strings inspection failure' clean fail 'Could not inspect axorc embedded strings'
+expect_failure 'generic Apple Events import' apple-event clean 'imports an Apple Events execution API'
+expect_failure 'generic OSA import' osa clean 'imports an Apple Events execution API'
+expect_failure 'NSUserAppleScriptTask import' user-script-task clean 'imports an Apple Events execution API'
+expect_failure 'OSAKit framework string' clean osakit 'embeds an Apple Events execution surface'
+expect_failure 'osascript path string' clean osascript 'embeds an Apple Events execution surface'
+
+echo 'test-native-ax-only-policy: ok'

--- a/scripts/test-native-ax-only.sh
+++ b/scripts/test-native-ax-only.sh
@@ -5,8 +5,14 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 cd "$repo_root"
 
-source_pattern='NSAppleScript|AEDeterminePermissionToAutomateTarget|AECreateDesc|AEDisposeDesc|AESend(Message)?|OSA(Compile|Execute|Load|Store|DoScript)|NSAppleEventsUsageDescription|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)'
-if source_matches="$(grep -REn "$source_pattern" Sources 2>/dev/null)" && [[ -n "$source_matches" ]]; then
+source_pattern='NSAppleScript|NSUserAppleScriptTask|OSAKit|OSAScript|AEDeterminePermissionToAutomateTarget|AECreateDesc|AEDisposeDesc|AESend(Message)?|OSA(Compile|Execute|Load|Store|DoScript)|kOSAComponentType|NSAppleEventsUsageDescription|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)'
+source_scan_exit=0
+source_matches="$(grep -REn "$source_pattern" Sources)" || source_scan_exit=$?
+if ((source_scan_exit > 1)); then
+    echo "Could not inspect production source for Apple Events surfaces" >&2
+    exit 1
+fi
+if [[ -n "$source_matches" ]]; then
     echo "Production source retains an Apple Events execution surface:" >&2
     echo "$source_matches" >&2
     exit 1
@@ -37,18 +43,27 @@ if [[ ! -x "$binary" ]]; then
     exit 1
 fi
 
-symbol_pattern='(^|[[:space:]])_(AE[A-Z][[:alnum:]_]*|OSA[A-Z][[:alnum:]_]*|OBJC_(CLASS|METACLASS)_[^[:space:]]*NSAppleScript)'
-if symbol_matches="$(nm -u "$binary" | grep -E "$symbol_pattern")" && [[ -n "$symbol_matches" ]]; then
-    echo "axorc imports an Apple Events execution API:" >&2
-    echo "$symbol_matches" >&2
+symbol_pattern='(^|[[:space:]])_(AE[A-Z][[:alnum:]_]*|OSA[A-Z][[:alnum:]_]*|kOSAComponentType|OBJC_(CLASS|METACLASS)_[^[:space:]]*(NSAppleScript|NSUserAppleScriptTask|OSAScript))'
+if ! undefined_symbols="$(nm -u "$binary")"; then
+    echo "Could not inspect axorc imports: $binary" >&2
     exit 1
 fi
 
-if string_matches="$(strings -a "$binary" | grep -E 'NSAppleEventsUsageDescription|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)')" &&
-    [[ -n "$string_matches" ]]
-then
+if [[ "$undefined_symbols" =~ $symbol_pattern ]]; then
+    echo "axorc imports an Apple Events execution API:" >&2
+    echo "${BASH_REMATCH[0]}" >&2
+    exit 1
+fi
+
+if ! embedded_strings="$(strings -a "$binary")"; then
+    echo "Could not inspect axorc embedded strings: $binary" >&2
+    exit 1
+fi
+
+string_pattern='NSAppleScript|NSUserAppleScriptTask|OSAKit(\.framework)?|OSAScript|OSA(Compile|Execute|Load|Store|DoScript)|kOSAComponentType|NSAppleEventsUsageDescription|/usr/bin/osascript|(^|[^[:alnum:]_])osascript([^[:alnum:]_]|$)'
+if [[ "$embedded_strings" =~ $string_pattern ]]; then
     echo "axorc embeds an Apple Events execution surface:" >&2
-    echo "$string_matches" >&2
+    echo "${BASH_REMATCH[0]}" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- make native-only source, symbol, and string inspection fail closed when a scanner exits nonzero
- extend the existing Apple Events and OSA policy to cover related script-task classes, OSAKit, and component symbols
- add an executable policy regression harness and run it from `make native-only`

## Proof

- `make check`
- `swift test` (74 tests passed)
- `shellcheck scripts/test-native-ax-only.sh scripts/test-native-ax-only-policy.sh`
- source-blind behavior validation (7 contract clauses and 3 anti-cheat probes passed)
- structured autoreview: clean, no accepted or actionable findings

This is release-policy tooling only; there is no product API or runtime behavior change.
