### PR TITLE
fix: isolate accessibility traversal state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Keep accessibility-tree traversal state local to each search and honor prefetched children, so repeated lookups cannot skip elements seen by earlier commands.
 - Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.
 - Route the published `AXSetValue` compatibility command through the native value-attribute setter instead of treating it as a macOS accessibility action.
 - Execute accessibility actions directly through one system-call owner, preserving native AX failures without redundant action-discovery round trips.

--- a/Sources/AXorcist/Core/Element+Hierarchy.swift
+++ b/Sources/AXorcist/Core/Element+Hierarchy.swift
@@ -20,6 +20,10 @@ extension Element {
 
     @MainActor
     public func children(strict: Bool = false) -> [Element]? { // Added strict parameter
+        if let prefetchedChildren {
+            return prefetchedChildren
+        }
+
         // Logging for this top-level call
         // self.briefDescription() is assumed to be refactored and available
         self.axVerboseDebug("Getting children for element: \(self.briefDescription(option: .smart)), strict: \(strict)")

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -65,9 +65,6 @@ public func findTargetElement(
         locator: locator,
         maxDepth: maxDepthForSearch)
     let pathHintDebugString = locatorDebug.pathHint
-    resetTraversalState()
-    defer { traversalDeadline = nil }
-
     guard let appElement = getApplicationElement(for: appIdentifier) else {
         logger.error("FTE: No app element for \(appIdentifier)")
         return (nil, "Application not found or not accessible: \(appIdentifier)")
@@ -193,7 +190,7 @@ private func applyCriteriaSearch(
         stopAtFirstMatch: axorcStopAtFirstMatch,
         maxDepth: maxDepthForSearch)
 
-    traverseAndSearch(
+    let nodesVisited = runTraversal(
         element: startElement,
         visitor: searchVisitor,
         currentDepth: 0,
@@ -204,7 +201,7 @@ private func applyCriteriaSearch(
         logger.info(
             logSegments(
                 "FindTargetEl: Found final descendant matching criteria: \(foundDescription)",
-                "Nodes visited = \(traversalNodeCounter)"))
+                "Nodes visited = \(nodesVisited)"))
         return (foundMatch, nil)
     }
 
@@ -212,7 +209,7 @@ private func applyCriteriaSearch(
     let finalSearchError = logSegments(
         "FTE: Not found C=[\(criteriaDesc)] from \(searchStartingPointDescription)",
         "Max depth visited = \(searchVisitor.deepestDepthReached) of \(maxDepthForSearch)",
-        "Nodes visited = \(traversalNodeCounter)")
+        "Nodes visited = \(nodesVisited)")
     logger.warning(finalSearchError)
     return (nil, finalSearchError)
 }
@@ -233,11 +230,6 @@ private func logFindTargetSetup(
             "C=\(criteria)",
             "PH=\(locator.rootElementPathHint?.count ?? 0)"))
     return (pathHint, criteria)
-}
-
-private func resetTraversalState() {
-    traversalNodeCounter = 0
-    traversalDeadline = Date().addingTimeInterval(axorcTraversalTimeout)
 }
 
 // MARK: - Element Collection Logic
@@ -290,23 +282,78 @@ public func traverseAndSearch(
     currentDepth: Int,
     maxDepth: Int)
 {
+    _ = runTraversal(
+        element: element,
+        visitor: visitor,
+        currentDepth: currentDepth,
+        maxDepth: maxDepth)
+}
+
+private struct TraversalContext {
+    var visitedElements: Set<Element> = []
+    var nodeCount = 0
+    var didLogTimeout = false
+    let deadline: Date
+
+    init(timeout: TimeInterval) {
+        self.deadline = Date().addingTimeInterval(timeout)
+    }
+}
+
+@MainActor
+private func runTraversal(
+    element: Element,
+    visitor: any ElementVisitor,
+    currentDepth: Int,
+    maxDepth: Int) -> Int
+{
+    var context = TraversalContext(timeout: axorcTraversalTimeout)
+    _ = traverseAndSearch(
+        element: element,
+        visitor: visitor,
+        currentDepth: currentDepth,
+        maxDepth: maxDepth,
+        context: &context)
+    return context.nodeCount
+}
+
+@MainActor
+private func traverseAndSearch(
+    element: Element,
+    visitor: any ElementVisitor,
+    currentDepth: Int,
+    maxDepth: Int,
+    context: inout TraversalContext) -> Bool
+{
+    guard Date() <= context.deadline else {
+        if !context.didLogTimeout {
+            logger.warning("Traverse: search timeout (\(axorcTraversalTimeout)s) reached. Aborting traversal.")
+            context.didLogTimeout = true
+        }
+        return true
+    }
+
     let elementDescription = element.briefDescription(option: ValueFormatOption.smart)
 
     guard currentDepth <= maxDepth else {
         logTraversalDepthExceeded(maxDepth, elementDescription)
-        return
+        return false
     }
 
-    traversalNodeCounter += 1
+    guard context.visitedElements.insert(element).inserted else {
+        return false
+    }
+
+    context.nodeCount += 1
     let visitResult = visitor.visit(element: element, depth: currentDepth)
 
     switch visitResult {
     case .stop:
         logTraversalEvent("STOP", elementDescription: elementDescription, depth: currentDepth)
-        return
+        return true
     case .skipChildren:
         logTraversalEvent("SKIP_CHILDREN", elementDescription: elementDescription, depth: currentDepth)
-        return // Do not process children
+        return false
     case .continue:
         logTraversalEvent(
             "CONTINUE",
@@ -316,37 +363,22 @@ public func traverseAndSearch(
         // Continue to process children
     }
 
-    // Maintain a static visited set per traversal to avoid cycles.
-    // We store the CFHash of AXUIElement to uniquely identify.
-    enum VisitedSet { nonisolated(unsafe) static var set = Set<UInt>() }
-
     if let children = element.children(strict: false), !children.isEmpty,
        axorcScanAll || (element.role().map { containerRoles.contains($0) } ?? false)
     {
-        // Abort if we are past the deadline
-        if let deadline = traversalDeadline, Date() > deadline {
-            logger.warning("Traverse: global search timeout (\(axorcTraversalTimeout)s) reached. Aborting traversal.")
-            return
-        }
-
         for child in children {
-            let hashVal: UInt = CFHash(child.underlyingElement)
-            if !VisitedSet.set.insert(hashVal).inserted {
-                continue // already visited; skip to avoid cycles
-            }
-            traverseAndSearch(element: child, visitor: visitor, currentDepth: currentDepth + 1, maxDepth: maxDepth)
-            if let searchVisitor = visitor as? SearchVisitor,
-               searchVisitor.stopAtFirstMatchInternal,
-               searchVisitor.foundElement != nil
-            {
-                logger.debug(
-                    logSegments(
-                        "Traverse: SearchVisitor found match and stopAtFirstMatch is true",
-                        "Stopping traversal early"))
-                return // Stop traversal early
+            guard !traverseAndSearch(
+                element: child,
+                visitor: visitor,
+                currentDepth: currentDepth + 1,
+                maxDepth: maxDepth,
+                context: &context)
+            else {
+                return true
             }
         }
     }
+    return false
 }
 
 private func logTraversalDepthExceeded(_ maxDepth: Int, _ elementDescription: String) {
@@ -537,13 +569,6 @@ private let containerRoles: Set<String> = [
 ]
 
 // MARK: - Search Timeout Handling
-
-/// Global deadline used by `traverseAndSearch` to abort extremely long walks.
-/// It is _only_ set for the duration of a single public search call and then cleared again.
-private nonisolated(unsafe) var traversalDeadline: Date?
-
-/// Counts how many nodes have been visited during the current `findTargetElement` invocation.
-private nonisolated(unsafe) var traversalNodeCounter: Int = 0
 
 /// Default timeout (seconds) for a full tree traversal. Override at runtime by setting `axorcTraversalTimeout`.
 public nonisolated(unsafe) var axorcTraversalTimeout: TimeInterval = 30

--- a/Tests/AXorcistTests/TraversalStateTests.swift
+++ b/Tests/AXorcistTests/TraversalStateTests.swift
@@ -1,0 +1,45 @@
+import ApplicationServices
+import Testing
+@testable import AXorcist
+
+@Suite("Accessibility tree traversal state")
+@MainActor
+struct TraversalStateTests {
+    @Test
+    func `Repeated traversals use independent visited sets`() {
+        let child = self.element(pid: 2_000_000_002, role: AXRoleNames.kAXButtonRole)
+        let root = self.element(pid: 2_000_000_001, role: AXRoleNames.kAXApplicationRole, children: [child])
+
+        #expect(root.children() == [child])
+
+        let firstVisitor = CountingVisitor()
+        traverseAndSearch(element: root, visitor: firstVisitor, currentDepth: 0, maxDepth: 2)
+
+        let secondVisitor = CountingVisitor()
+        traverseAndSearch(element: root, visitor: secondVisitor, currentDepth: 0, maxDepth: 2)
+
+        #expect(firstVisitor.visitCount == 2)
+        #expect(secondVisitor.visitCount == 2)
+    }
+
+    private func element(pid: pid_t, role: String, children: [Element] = []) -> Element {
+        Element(
+            AXUIElementCreateApplication(pid),
+            attributes: [
+                AXAttributeNames.kAXRoleAttribute: .string(role),
+                AXAttributeNames.kAXTitleAttribute: .string("test-\(pid)"),
+            ],
+            children: children,
+            actions: [])
+    }
+}
+
+@MainActor
+private final class CountingVisitor: ElementVisitor {
+    private(set) var visitCount = 0
+
+    func visit(element _: Element, depth _: Int) -> TreeVisitorResult {
+        self.visitCount += 1
+        return .continue
+    }
+}


### PR DESCRIPTION
## Summary

- keep visited elements, deadlines, and node counts local to one accessibility-tree traversal
- propagate visitor stops and traversal timeouts through the complete walk
- honor prefetched child trees instead of issuing fresh Accessibility reads
- cover repeated traversals with an in-memory regression test

## Why

The previous visited set was process-global and never reset. A long-lived host or a batch of commands could therefore skip a valid element merely because an earlier traversal had already seen it. The new per-invocation context also uses full element identity rather than hash-only identity.

## Testing

- `swift test --filter TraversalStateTests`
- `swift test` (75 tests passed; permission-gated automation suites skipped as expected)
- `make check` (SwiftFormat, SwiftLint, and both native-AX-only policy checks)
