### PR TITLE
fix: preserve parameterized attributed strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.
 - Keep accessibility-tree traversal state local to each search and honor prefetched children, so repeated lookups cannot skip elements seen by earlier commands.
 - Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.
 - Route the published `AXSetValue` compatibility command through the native value-attribute setter instead of treating it as a macOS accessibility action.

--- a/Sources/AXorcist/Core/Element+ParameterizedAttributes.swift
+++ b/Sources/AXorcist/Core/Element+ParameterizedAttributes.swift
@@ -24,18 +24,15 @@ extension Element {
             return nil
         }
 
-        guard let finalValue = ValueUnwrapper.unwrap(resultCFValue) else {
-            axDebugLog("Unwrapping CFValue for parameterized attribute \(attribute.rawValue) resulted in nil.")
-            return nil
-        }
-
-        return self.castValueToType(finalValue, attribute: attribute)
+        return self.convertCFTypeToSwiftType(resultCFValue, attribute: attribute)
     }
 
     @MainActor
-    private func convertParameterToCFTypeRef(_ parameter: Any, attribute: Attribute<some Any>) -> CFTypeRef? {
+    func convertParameterToCFTypeRef(_ parameter: Any, attribute: Attribute<some Any>) -> CFTypeRef? {
         if var range = parameter as? CFRange {
             return AXValueCreate(.cfRange, &range)
+        } else if let element = parameter as? Element {
+            return element.underlyingElement
         } else if let string = parameter as? String {
             return string as CFString
         } else if let number = parameter as? NSNumber {
@@ -71,31 +68,6 @@ extension Element {
         }
 
         return resultCFValue
-    }
-
-    @MainActor
-    private func castValueToType<T>(_ finalValue: Any, attribute: Attribute<T>) -> T? {
-        if T.self == String.self {
-            if let str = finalValue as? String {
-                return str as? T
-            }
-            if let attrStr = finalValue as? NSAttributedString {
-                return attrStr.string as? T
-            }
-            axDebugLog(
-                "Failed to cast unwrapped value for String attribute \(attribute.rawValue). " +
-                    "Value: \(finalValue)")
-            return nil
-        }
-
-        if let castedValue = finalValue as? T {
-            return castedValue
-        }
-
-        axWarningLog(
-            "Fallback cast attempt for parameterized attribute '\(attribute.rawValue)' " +
-                "to type \(T.self) FAILED. Unwrapped value was \(type(of: finalValue)): \(finalValue)")
-        return nil
     }
 }
 

--- a/Sources/AXorcist/Core/Element.swift
+++ b/Sources/AXorcist/Core/Element.swift
@@ -168,51 +168,7 @@ public struct Element: Equatable, Hashable, Sendable {
 
     @MainActor
     public func parameterizedAttribute<T>(_ attribute: Attribute<T>, parameter: Any) -> T? {
-        var value: CFTypeRef?
-        let error: AXError
-
-        // Need to bridge the parameter to CFTypeRef
-        let cfParameter: CFTypeRef
-        if let num = parameter as? NSNumber {
-            cfParameter = num
-        } else if let str = parameter as? String {
-            cfParameter = str as CFString
-        } else if let element = parameter as? Element {
-            cfParameter = element.underlyingElement
-        } else {
-            // Fallback for other types or if bridging is complex; might need more specific handling
-            // For now, attempt to bridge directly, or log error if not possible
-            if CFGetTypeID(parameter as CFTypeRef) == 0 { // Heuristic: Check if it's already a CFTypeRef or bridgable
-                GlobalAXLogger.shared.log(AXLogEntry(
-                    level: .debug,
-                    message: "Parameterized attribute '\(attribute.rawValue)' called with " +
-                        "non-CF bridgable Swift type: \(type(of: parameter)). This might fail."))
-            }
-            cfParameter = parameter as CFTypeRef // This can crash if parameter is not CF-bridgable
-        }
-
-        error = AXUIElementCopyParameterizedAttributeValue(
-            self.underlyingElement,
-            attribute.rawValue as CFString,
-            cfParameter,
-            &value)
-
-        if error != .success {
-            if error != .noValue {
-                GlobalAXLogger.shared.log(AXLogEntry(
-                    level: .debug,
-                    message: "Error \(error.rawValue) fetching parameterized attribute '\(attribute.rawValue)'."))
-            }
-            return nil
-        }
-        guard let unwrappedCFValue = value else {
-            GlobalAXLogger.shared.log(AXLogEntry(
-                level: .debug,
-                message: "Parameterized attribute '\(attribute.rawValue)' value was nil after fetch."))
-            return nil
-        }
-        // Use the type conversion functionality from Element+TypeConversion.swift
-        return convertCFTypeToSwiftType(unwrappedCFValue, attribute: attribute)
+        self.parameterizedAttribute(attribute, forParameter: parameter)
     }
 
     @MainActor

--- a/Tests/AXorcistTests/ParameterizedAttributeConversionTests.swift
+++ b/Tests/AXorcistTests/ParameterizedAttributeConversionTests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import ApplicationServices
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Parameterized Attribute Conversion Tests", .tags(.safe))
+@MainActor
+struct ParameterizedAttributeConversionTests {
+    @Test
+    func `Attributed strings preserve their native result type`() throws {
+        let element = Element(AXUIElementCreateSystemWide())
+        let expected = NSAttributedString(
+            string: "Hello",
+            attributes: [.foregroundColor: NSColor.systemBlue])
+        let rawValue = expected as CFAttributedString
+
+        let converted: NSAttributedString? = element.convertCFTypeToSwiftType(
+            rawValue,
+            attribute: .attributedStringForRangeParameterized)
+
+        #expect(try #require(converted).isEqual(to: expected))
+    }
+
+    @Test
+    func `Attributed strings still project to plain strings when requested`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        let rawValue = NSAttributedString(string: "Hello") as CFAttributedString
+        let stringAttribute = Attribute<String>(
+            AXAttributeNames.kAXAttributedStringForRangeParameterizedAttribute)
+
+        let converted: String? = element.convertCFTypeToSwiftType(
+            rawValue,
+            attribute: stringAttribute)
+
+        #expect(converted == "Hello")
+    }
+
+    @Test
+    func `CFRange parameters use a native AXValue`() throws {
+        let element = Element(AXUIElementCreateSystemWide())
+        let expected = CFRange(location: 7, length: 11)
+
+        let bridged = try #require(element.convertParameterToCFTypeRef(
+            expected,
+            attribute: Attribute<String>.stringForRangeParameterized))
+        #expect(CFGetTypeID(bridged) == AXValueGetTypeID())
+
+        let axValue = unsafeDowncast(bridged, to: AXValue.self)
+        let actual = try #require(axValue.cfRange())
+        #expect(axValue.valueType == .cfRange)
+        #expect(actual.location == expected.location)
+        #expect(actual.length == expected.length)
+    }
+
+    @Test
+    func `Element parameters preserve their underlying accessibility identity`() throws {
+        let receiver = Element(AXUIElementCreateSystemWide())
+        let expected = Element(AXUIElementCreateApplication(2_000_000_123))
+
+        let bridged = try #require(receiver.convertParameterToCFTypeRef(
+            expected,
+            attribute: Attribute<AXUIElement>.cellForColumnAndRowParameterized))
+
+        #expect(CFGetTypeID(bridged) == AXUIElementGetTypeID())
+        #expect(CFEqual(bridged, expected.underlyingElement))
+    }
+}


### PR DESCRIPTION
## Summary

- route both public generic parameterized-attribute accessors through one native AX call and one typed conversion path
- preserve native `NSAttributedString` results instead of erasing them to `String` before the declared-type cast
- retain plain-string projection for callers that request `String`
- preserve native `CFRange` boxing and `Element` parameter identity
- remove the duplicate parameter/result conversion implementation without changing either public signature

The former `forParameter:` path called `ValueUnwrapper` first. That utility intentionally converts `CFAttributedString` to plain text, so `attributedString(forRange:)` could not return a non-nil value even when macOS supplied its declared native result.

No AppleScript, JXA, OSA, Apple Events, permission, or action-policy behavior changes.

## Proof

- focused parameterized conversion suite: 4/4
- full debug suite: 79/79 across 23 suites, 0 failures
- full release suite: 79/79 across 23 suites, 0 failures
- SwiftFormat: 0/142 files require formatting
- SwiftLint strict: 0 violations
- native AX-only source and binary policy checks: pass
- `git diff --check`: pass
- structured review and secret scan: clean, no accepted/actionable finding

The normal automation-dependent integration suites remain skipped when their explicit opt-in environment is absent.
