### PR TITLE
fix: consolidate observer ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
-- Route observe and stop commands through one registry, resolve native element PIDs reliably, recognize current observe success responses, allow callbacks to unsubscribe safely, and clean up watcher tokens on deinitialization.
 - Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.
 - Keep accessibility-tree traversal state local to each search and honor prefetched children, so repeated lookups cannot skip elements seen by earlier commands.
 - Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Route observe and stop commands through one registry, resolve native element PIDs reliably, recognize current observe success responses, allow callbacks to unsubscribe safely, and clean up watcher tokens on deinitialization.
 - Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.
 - Keep accessibility-tree traversal state local to each search and honor prefetched children, so repeated lookups cannot skip elements seen by earlier commands.
 - Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.

--- a/README.md
+++ b/README.md
@@ -493,6 +493,9 @@ Monitor UI changes with these notifications:
 - **AXSelectedTextChanged** - Text selection changes
 - **AXLayoutChanged** - Layout updates
 
+Observe and `stopObservation` commands executed by the same `AXorcist` instance share one subscription registry, so a
+successful stop clears the observations that instance started.
+
 ### Observer Example
 
 ```json

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -15,12 +15,21 @@ import Foundation
 /// - Registration and lifecycle management of notification subscriptions
 /// - Process-specific observer tracking
 /// - Automatic cleanup of observers when processes terminate
-/// - Thread-safe observer operations
+/// - Main-actor-isolated observer operations
 ///
 /// This center ensures efficient resource usage by reusing observers for the same
 /// process and prevents memory leaks by properly cleaning up observers.
 @MainActor
 public final class AXObserverCenter {
+    typealias ObserverSetup = @MainActor (
+        _ pid: pid_t?,
+        _ element: Element?,
+        _ notification: AXNotification) -> AXError
+    typealias ObserverCleanup = @MainActor (
+        _ pid: pid_t?,
+        _ element: Element,
+        _ notification: AXNotification) -> Void
+
     // MARK: - Public State
 
     /// Shared instance
@@ -32,22 +41,31 @@ public final class AXObserverCenter {
     }
 
     /// All registered observer keys
-    public var registeredKeys: [AXNotificationSubscriptionKey] { // Updated to use new key type
-        // return observerKeys // Old way
-        Array(self.subscriptions.keys)
+    public var registeredKeys: [AXNotificationSubscriptionKey] {
+        self.subscriptionStore.registeredKeys
     }
 
     // MARK: - Stored State
 
-    /// Stores multiple handlers per notification key (and optional PID)
-    private var subscriptions: [AXNotificationSubscriptionKey: [UUID: AXNotificationSubscriptionHandler]] = [:]
-    private var subscriptionTokens: [UUID: AXNotificationSubscriptionKey] = [:]
+    private let subscriptionStore = AXObserverSubscriptionStore()
     private var observers: [AXObserverObjAndPID] = []
-    private let subscriptionsLock = NSLock()
+    private let observerSetupOverride: ObserverSetup?
+    private let observerCleanupOverride: ObserverCleanup?
 
     // MARK: - Lifecycle
 
-    private init() {}
+    private init() {
+        self.observerSetupOverride = nil
+        self.observerCleanupOverride = nil
+    }
+
+    init(
+        observerSetup: @escaping ObserverSetup,
+        observerCleanup: @escaping ObserverCleanup)
+    {
+        self.observerSetupOverride = observerSetup
+        self.observerCleanupOverride = observerCleanup
+    }
 }
 
 // MARK: - Public API
@@ -67,27 +85,20 @@ extension AXObserverCenter {
                 "Element: \(elementDescriptionForLog)",
                 "notification: \(notification.rawValue)"))
 
-        let token = SubscriptionToken(id: UUID())
-        let key = AXNotificationSubscriptionKey(pid: pid, notification: notification)
-
-        self.subscriptionsLock.lock()
-        defer { subscriptionsLock.unlock() }
-
-        let setupError = setupUnderlyingObserver(forPid: pid, forElement: element, notification: notification)
+        let registration = self.registrationKey(pid: pid, element: element, notification: notification)
+        let setupError = if self.subscriptionStore.contains(registration: registration) {
+            AXError.success
+        } else {
+            self.setupUnderlyingObserver(registration)
+        }
         guard setupError == .success else {
-            let errorMsg = "Failed to setup underlying AXObserver for \(describePid(pid)) " +
+            let errorMessage = "Failed to setup underlying AXObserver for \(describePid(pid)) " +
                 "notification \(notification.rawValue) (AXError \(setupError.rawValue))"
-            axErrorLog(
-                logSegments(
-                    "Failed to setup underlying AXObserver for \(describePid(pid))",
-                    "notification \(notification.rawValue)",
-                    "error: \(setupError.rawValue)"))
-            return .failure(.observerSetupFailed(details: errorMsg))
+            axErrorLog(errorMessage)
+            return .failure(.observerSetupFailed(details: errorMessage))
         }
 
-        self.subscriptions[key, default: [:]][token.id] = handler
-        self.subscriptionTokens[token.id] = key
-
+        let token = self.subscriptionStore.add(registration: registration, handler: handler)
         axInfoLog(
             logSegments(
                 "Successfully subscribed handler (token: \(token.id)) for \(describePid(pid))",
@@ -96,124 +107,116 @@ extension AXObserverCenter {
     }
 
     public func unsubscribe(token: SubscriptionToken) throws {
-        self.subscriptionsLock.lock()
-        defer { subscriptionsLock.unlock() }
-
-        guard let key = subscriptionTokens.removeValue(forKey: token.id) else {
+        let removal: AXObserverSubscriptionStore.Removal
+        do {
+            removal = try self.subscriptionStore.remove(token: token)
+        } catch {
             axErrorLog("Unsubscribe failed: Token ID \(token.id) not found.")
-            throw AccessibilityError.tokenNotFound(tokenId: token.id)
+            throw error
         }
 
-        guard var handlersForKey = subscriptions[key] else {
-            let tokenKeyDescription = "token \(token.id) (key: \(key))"
-            axWarningLog(
-                logSegments(
-                    "Handler for \(tokenKeyDescription) missing in subscriptions dictionary",
-                    "token existed"))
-            return
-        }
-        guard handlersForKey.removeValue(forKey: token.id) != nil else { return }
-
-        self.subscriptions[key] = handlersForKey
         axInfoLog(
             logSegments(
-                "Successfully unsubscribed handler (token: \(token.id)) for \(describePid(key.pid))",
-                "notification: \(key.notification.rawValue)"))
-        if handlersForKey.isEmpty {
-            self.subscriptions.removeValue(forKey: key)
-            axDebugLog(
-                logSegments(
-                    "No handlers left for \(describePid(key.pid))",
-                    "notification: \(key.notification.rawValue). Key removed from subscriptions"))
-            if let targetPid = key.pid {
-                cleanupUnderlyingObserverNotification(forPid: targetPid, notification: key.notification)
-            }
-        } else {
-            self.subscriptions[key] = handlersForKey
-        }
+                "Successfully unsubscribed handler (token: \(token.id)) " +
+                    "for \(describePid(removal.registration.subscription.pid))",
+                "notification: \(removal.registration.subscription.notification.rawValue)"))
+        guard removal.removedLastHandler else { return }
+
+        axDebugLog(
+            logSegments(
+                "No handlers left for \(describePid(removal.registration.subscription.pid))",
+                "notification: \(removal.registration.subscription.notification.rawValue). " +
+                    "Registration removed from subscriptions"))
+        self.cleanupUnderlyingObserverNotification(removal.registration)
     }
 
     public func removeAllObservers() {
         axInfoLog("Removing all observers and subscriptions globally.")
-        self.subscriptionsLock.lock()
-        defer { subscriptionsLock.unlock() }
+        self.subscriptionStore.removeAll()
 
-        removeAllTokens()
-
-        if !self.observers.isEmpty || !self.subscriptions.isEmpty || !self.subscriptionTokens.isEmpty {
-            axWarningLog(
-                "removeAllObservers: observers, subscriptions, or tokens list not empty after mass unsubscribe. " +
-                    "observers: \(self.observers.count), subscriptions: \(self.subscriptions.count), " +
-                    "tokens: \(self.subscriptionTokens.count)")
-            self.observers.removeAll()
-            self.subscriptions.removeAll()
-            self.subscriptionTokens.removeAll()
+        for record in self.observers {
+            let source = AXObserverGetRunLoopSource(record.observer)
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
+            CFRunLoopSourceInvalidate(source)
         }
+        self.observers.removeAll()
         axInfoLog("All observers and subscriptions have been cleared.")
     }
 
     public func removeAllObservers(for pid: pid_t) {
         axInfoLog("Removing all observers and subscriptions for PID \(pid)")
-        let tokensForPid = self.subscriptionTokens.filter { $0.value.pid == pid }.map(\.key)
-        for tokenId in tokensForPid {
-            try? self.unsubscribe(token: SubscriptionToken(id: tokenId))
+        for token in self.subscriptionStore.tokens(for: pid) {
+            try? self.unsubscribe(token: token)
         }
     }
 
     public func isKeyRegistered(pid: pid_t?, notification: AXNotification) -> Bool {
-        let key = AXNotificationSubscriptionKey(pid: pid, notification: notification)
-        return self.subscriptions[key]?.isEmpty == false
+        self.subscriptionStore.contains(pid: pid, notification: notification)
     }
 }
+
+// MARK: - Canonical Registry
+
+@MainActor
+extension AXObserverCenter: AXObservationRegistry {}
 
 // MARK: - Private Helpers
 
 @MainActor
 extension AXObserverCenter {
-    private func removeAllTokens() {
-        for (tokenId, key) in self.subscriptionTokens {
-            guard var handlers = subscriptions[key] else { continue }
-            handlers.removeValue(forKey: tokenId)
-            if handlers.isEmpty {
-                self.subscriptions.removeValue(forKey: key)
-                self.cleanupUnderlyingObserverNotification(forPid: key.pid, notification: key.notification)
-            } else {
-                self.subscriptions[key] = handlers
-            }
-        }
-        self.subscriptionTokens.removeAll()
-    }
-
     // MARK: - Internal AXObserver Management (previously addObserver / removeObserver)
 
-    /// Ensures an AXObserver is created for the PID and the notification is added to it.
-    /// This is called by `subscribe`.
-    private func setupUnderlyingObserver(
-        forPid pid: pid_t?,
-        forElement element: Element?,
-        notification: AXNotification) -> AXError
+    private func registrationKey(
+        pid: pid_t?,
+        element: Element?,
+        notification: AXNotification) -> AXObserverRegistrationKey
     {
         let targetPid = pid ?? 0
-        self.logObserverSetup(targetPid: targetPid, element: element, notification: notification)
+        let observedElement = Element(self.elementForObservation(
+            pid: pid,
+            targetPid: targetPid,
+            element: element,
+            notification: notification))
+        return AXObserverRegistrationKey(
+            subscription: AXNotificationSubscriptionKey(pid: pid, notification: notification),
+            element: observedElement,
+            scope: self.registrationScope(pid: pid, observedElement: observedElement))
+    }
+
+    private func registrationScope(pid: pid_t?, observedElement: Element) -> AXObserverRegistrationKey.Scope {
+        guard let pid else { return .process }
+        let applicationElement = Element(AXUIElement.application(pid: pid))
+        return observedElement == applicationElement ? .process : .element
+    }
+
+    /// Ensures an AXObserver is created for the exact registration target.
+    private func setupUnderlyingObserver(_ registration: AXObserverRegistrationKey) -> AXError {
+        let subscription = registration.subscription
+        if let observerSetupOverride {
+            return observerSetupOverride(subscription.pid, registration.element, subscription.notification)
+        }
+
+        let targetPid = subscription.pid ?? 0
+        self.logObserverSetup(
+            targetPid: targetPid,
+            element: registration.element,
+            notification: subscription.notification)
         guard let observer = getOrCreateObserver(for: targetPid) else {
             axErrorLog("Failed to get/create AXObserver for effective PID \(targetPid) during setup.")
             return .failure
         }
 
-        let elementToObserveAXUI = self.elementForObservation(
-            pid: pid,
-            targetPid: targetPid,
-            element: element,
-            notification: notification)
-
         let selfPtr = Unmanaged.passUnretained(self).toOpaque()
         let error = AXObserverAddNotification(
             observer,
-            elementToObserveAXUI,
-            notification.rawValue as CFString,
+            registration.element.underlyingElement,
+            subscription.notification.rawValue as CFString,
             selfPtr)
 
-        self.logObserverAddResult(targetPid: targetPid, notification: notification, error: error)
+        self.logObserverAddResult(targetPid: targetPid, notification: subscription.notification, error: error)
+        if error != .success {
+            self.removeObserverIfUnused(targetPid: targetPid)
+        }
         return error
     }
 
@@ -268,21 +271,25 @@ extension AXObserverCenter {
         }
     }
 
-    /// Called when a subscription is removed and its key might no longer be needed by any handler.
-    /// This function will decide if AXObserverRemoveNotification should be called.
-    private func cleanupUnderlyingObserverNotification(forPid pid: pid_t?, notification: AXNotification) {
-        let targetPid = pid ?? 0
+    /// Removes the exact system registration after its final handler unsubscribes.
+    private func cleanupUnderlyingObserverNotification(_ registration: AXObserverRegistrationKey) {
+        let subscription = registration.subscription
+        if let observerCleanupOverride {
+            observerCleanupOverride(subscription.pid, registration.element, subscription.notification)
+            return
+        }
+
+        let targetPid = subscription.pid ?? 0
         axDebugLog(
             logSegments(
                 "Cleanup check for underlying AXObserver notification for \(describePid(targetPid))",
-                "notification: \(notification.rawValue)"))
+                "notification: \(subscription.notification.rawValue)"))
 
-        let specificKey = AXNotificationSubscriptionKey(pid: pid, notification: notification)
-        guard self.subscriptions[specificKey]?.isEmpty ?? true else {
+        guard !self.subscriptionStore.contains(registration: registration) else {
             axDebugLog(
                 logSegments(
-                    "Specific subscriptions still exist for \(describePid(pid))",
-                    "notification: \(notification.rawValue). AXObserver notification retained"))
+                    "Specific subscriptions still exist for \(describePid(subscription.pid))",
+                    "notification: \(subscription.notification.rawValue). AXObserver notification retained"))
             return
         }
 
@@ -290,35 +297,36 @@ extension AXObserverCenter {
             axWarningLog(
                 logSegments(
                     "No AXObserver found for \(describePid(targetPid)) during cleanup",
-                    "notification: \(notification.rawValue)"))
+                    "notification: \(subscription.notification.rawValue)"))
             return
         }
 
-        let elementToObserve = pid == nil ? AXUIElementCreateSystemWide() : AXUIElement.application(pid: targetPid)
-        let error = AXObserverRemoveNotification(observer, elementToObserve, notification.rawValue as CFString)
+        let error = AXObserverRemoveNotification(
+            observer,
+            registration.element.underlyingElement,
+            subscription.notification.rawValue as CFString)
 
         if error == .success {
             axInfoLog(
                 logSegments(
                     "Successfully removed notification from AXObserver for \(describePid(targetPid))",
-                    "key: \(notification.rawValue) during cleanup"))
+                    "key: \(subscription.notification.rawValue) during cleanup"))
             self.removeObserverIfUnused(targetPid: targetPid)
         } else {
             axErrorLog(
                 logSegments(
                     "Failed to remove notification from AXObserver for \(describePid(targetPid))",
-                    "key: \(notification.rawValue)",
+                    "key: \(subscription.notification.rawValue)",
                     "error: \(error.rawValue)"))
         }
     }
 
     private func removeObserverIfUnused(targetPid: pid_t) {
-        let hasAnySubscription = self.subscriptions.contains { key, handlers in
-            let keyPid = key.pid ?? 0
-            return keyPid == targetPid && !handlers.isEmpty
-        }
+        let hasAnySubscription = self.subscriptionStore.containsSubscriptions(forEffectivePID: targetPid)
         guard !hasAnySubscription, let observer = getObserver(for: targetPid) else { return }
-        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .defaultMode)
+        let source = AXObserverGetRunLoopSource(observer)
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
+        CFRunLoopSourceInvalidate(source)
         self.removePidObserverInstance(pid: targetPid)
     }
 
@@ -401,52 +409,17 @@ extension AXObserverCenter {
 
     // MARK: - Main Notification Processing (Called by global callbacks)
 
-    @MainActor // Ensure this runs on the main actor as handlers are @MainActor
-    private func processNotification(
+    func processNotification(
         pid: pid_t,
         notification: AXNotification,
         rawElement: AXUIElement,
         nsUserInfo: [String: Any]?)
     {
-        self.subscriptionsLock.lock()
-        defer { subscriptionsLock.unlock() }
-
-        // Construct keys for both specific PID and global (nil PID)
-        let specificKey = AXNotificationSubscriptionKey(pid: pid, notification: notification)
-        let globalKey = AXNotificationSubscriptionKey(pid: nil, notification: notification)
-
-        var handlersToCall: [AXNotificationSubscriptionHandler] = []
-
-        // Check for handlers specific to this PID and notification
-        if let specificHandlers = subscriptions[specificKey] {
-            handlersToCall.append(contentsOf: specificHandlers.values)
-        }
-
-        // Check for global handlers for this notification (if not already covered by specific PID match)
-        // This ensures global handlers are called even if a specific PID handler also exists for the same notification
-        // type.
-        if let globalHandlers = subscriptions[globalKey] {
-            handlersToCall.append(contentsOf: globalHandlers.values)
-        }
-
-        // Deduplicate handlers if any subscribed to both specific and global for the same notification (though unlikely
-        // with UUID keys)
-        // let uniqueHandlers = Array(Set(handlersToCall)) // Set requires AXNotificationSubscriptionHandler to be
-        // Hashable, which it might not be (closure).
-        // For now, direct invocation. If a handler is in both lists, it will be called twice.
-        // This design assumes handlers are distinct or idempotent if registered for both global and specific.
-
-        if handlersToCall.isEmpty {
-            // axDebugLog("No handlers registered for PID \(pid), Notification \(notification.rawValue).")
-            return
-        }
-
-        // axDebugLog("Processing notification for PID \(pid), Notification \(notification.rawValue). Invoking
-        // \(handlersToCall.count) handlers.")
-
-        for handler in handlersToCall {
-            handler(pid, notification, rawElement, nsUserInfo)
-        }
+        self.subscriptionStore.dispatch(
+            pid: pid,
+            notification: notification,
+            rawElement: rawElement,
+            userInfo: nsUserInfo)
     }
 
     private func convertUserInfoDictionary(_ userInfo: CFDictionary?) -> [String: Any]? {

--- a/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
@@ -15,12 +15,14 @@ extension AXorcist {
         self.logObservationStart(command)
 
         let appIdentifier = command.appIdentifier ?? "focused"
-        let locator = self.makeObservationLocator()
+        let locator = command.locator ?? Locator(criteria: [
+            Criterion(attribute: "AXRole", value: AXRoleNames.kAXApplicationRole, matchType: .exact),
+        ])
 
-        let (targetElement, error) = findTargetElement(
-            for: appIdentifier,
+        let (targetElement, error) = self.resolveObservationTarget(
+            appIdentifier: appIdentifier,
             locator: locator,
-            maxDepthForSearch: command.maxDepthForSearch)
+            maxDepth: command.maxDepthForSearch)
 
         guard let elementToObserve = targetElement else {
             return self.observationNotFoundResponse(
@@ -48,11 +50,6 @@ extension AXorcist {
         GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: message))
     }
 
-    private func makeObservationLocator() -> Locator {
-        let criteria = [Criterion(attribute: "pid", value: "self", matchType: .exact)]
-        return Locator(criteria: criteria)
-    }
-
     private func logObservationTarget(_ element: Element) {
         let message = [
             "HandleObserve: Element to observe:",
@@ -78,34 +75,26 @@ extension AXorcist {
     private func startObservation(
         element: Element,
         command: ObserveCommand,
-        callback: @escaping AXObserverManager.AXNotificationCallback) -> AXResponse
+        callback: @escaping AXNotificationSubscriptionHandler) -> AXResponse
     {
-        do {
-            try AXObserverManager.shared.addObserver(
-                for: element,
-                notification: command.notificationName,
-                callback: callback)
+        switch self.subscribeToObservation(
+            pid: element.pid(),
+            element: element,
+            notification: command.notificationName,
+            handler: callback)
+        {
+        case .success:
             let successMessage = [
                 "HandleObserve: Successfully started observing '\(command.notificationName)' on",
                 element.briefDescription(option: ValueFormatOption.smart),
             ].joined(separator: " ")
             GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: successMessage))
             return .successResponse(payload: AnyCodable(["message": successMessage]))
-        } catch let obError as AXObserverManager.ObserverError {
+        case let .failure(error):
             let details = [
                 "HandleObserve: Failed to add observer.",
-                "Error: \(obError.localizedDescription) (Code: \(obError))",
+                "Error: \(error.localizedDescription) (Code: \(error))",
                 "Pid: \(element.pid()?.description ?? "N/A")",
-                "Notification: \(command.notificationName)",
-            ].joined(separator: " ")
-            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: details))
-            return .errorResponse(message: details, code: .observationFailed)
-        } catch {
-            let details = [
-                "HandleObserve: Failed to add observer with unknown error:",
-                error.localizedDescription,
-                "Element:",
-                element.briefDescription(option: ValueFormatOption.smart),
                 "Notification: \(command.notificationName)",
             ].joined(separator: " ")
             GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: details))
@@ -113,14 +102,14 @@ extension AXorcist {
         }
     }
 
-    private func makeObservationCallback() -> AXObserverManager.AXNotificationCallback {
-        { _, axUIElement, notification, userInfo in
+    private func makeObservationCallback() -> AXNotificationSubscriptionHandler {
+        { _, notification, axUIElement, userInfo in
             let element = Element(axUIElement)
             let userInfoDesc = userInfo.map(String.init(describing:)) ?? "nil"
             let message = [
                 "AXObserver CALLBACK:",
                 "Element: \(element.briefDescription(option: ValueFormatOption.smart))",
-                "Notification: \(notification as String)",
+                "Notification: \(notification.rawValue)",
                 "UserInfo: \(userInfoDesc)",
             ].joined(separator: " ")
             GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: message))

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -26,10 +26,36 @@ import Foundation
 /// - ``AXResponse``
 @MainActor
 public class AXorcist {
+    typealias ObservationTargetResolver = @MainActor (
+        _ appIdentifier: String,
+        _ locator: Locator,
+        _ maxDepth: Int) -> (element: Element?, error: String?)
+
     // MARK: Lifecycle
 
     /// Creates a new AXorcist instance.
-    @MainActor public init() {}
+    @MainActor public init() {
+        self.observationRegistry = AXObserverCenter.shared
+        self.observationTargetResolver = nil
+    }
+
+    init(
+        observationRegistry: any AXObservationRegistry,
+        observationTargetResolver: @escaping ObservationTargetResolver)
+    {
+        self.observationRegistry = observationRegistry
+        self.observationTargetResolver = observationTargetResolver
+    }
+
+    deinit {
+        let registry = self.observationRegistry
+        let tokens = self.observationTokens
+        Task { @MainActor in
+            for token in tokens {
+                try? registry.unsubscribe(token: token)
+            }
+        }
+    }
 
     // MARK: Public
 
@@ -82,6 +108,21 @@ public class AXorcist {
     public func clearLogs() {
         GlobalAXLogger.shared.clearEntries()
         self.logger.log(AXLogEntry(level: .info, message: "Log history cleared."))
+    }
+
+    /// Stops every accessibility observation owned by this AXorcist instance.
+    public func stopObserving() {
+        let tokens = self.observationTokens
+        self.observationTokens.removeAll()
+        for token in tokens {
+            do {
+                try self.observationRegistry.unsubscribe(token: token)
+            } catch {
+                self.logger.log(AXLogEntry(
+                    level: .warning,
+                    message: "Failed to stop observation token \(token.id): \(error.localizedDescription)"))
+            }
+        }
     }
 
     // MARK: Internal
@@ -147,6 +188,42 @@ public class AXorcist {
     // MARK: Private
 
     private let logger = GlobalAXLogger.shared // Use the shared logger
+    private let observationRegistry: any AXObservationRegistry
+    private let observationTargetResolver: ObservationTargetResolver?
+    private var observationTokens: Set<SubscriptionToken> = []
+
+    // MARK: - Observation Ownership
+
+    func resolveObservationTarget(
+        appIdentifier: String,
+        locator: Locator,
+        maxDepth: Int) -> (element: Element?, error: String?)
+    {
+        if let observationTargetResolver = self.observationTargetResolver {
+            return observationTargetResolver(appIdentifier, locator, maxDepth)
+        }
+        return findTargetElement(
+            for: appIdentifier,
+            locator: locator,
+            maxDepthForSearch: maxDepth)
+    }
+
+    func subscribeToObservation(
+        pid: pid_t?,
+        element: Element,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        let result = self.observationRegistry.subscribe(
+            pid: pid,
+            element: element,
+            notification: notification,
+            handler: handler)
+        if case let .success(token) = result {
+            self.observationTokens.insert(token)
+        }
+        return result
+    }
 
     private func execute(commandEnvelope: AXCommandEnvelope) -> AXResponse {
         if let response = executeQueryRelatedCommands(commandEnvelope) {

--- a/Sources/AXorcist/Core/Element+Properties.swift
+++ b/Sources/AXorcist/Core/Element+Properties.swift
@@ -62,20 +62,15 @@ extension Element {
     }
 
     @MainActor public func pid() -> pid_t? {
-        var pidRef: CFTypeRef?
-        let error = AXUIElementCopyAttributeValue(
-            self.underlyingElement,
-            AXAttributeNames.kAXPIDAttribute as CFString,
-            &pidRef)
-        if error == .success, let pidNum = pidRef as? NSNumber {
-            return pid_t(pidNum.intValue)
-        } else {
-            // Use the global axDebugLog helper function for simplicity and correctness
+        var processIdentifier: pid_t = 0
+        let error = AXUIElementGetPid(self.underlyingElement, &processIdentifier)
+        guard error == .success else {
             axDebugLog(
                 "Failed to get PID for element: \(error.rawValue)",
                 details: ["element": AnyCodable(String(describing: self.underlyingElement))])
+            return nil
         }
-        return nil
+        return processIdentifier
     }
 
     /// Hierarchy and Relationship Getters - simplified

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -33,8 +33,21 @@ public class NotificationWatcher {
         self.target = .element(element)
         self.notification = notification
         self.handler = handler
+        self.registry = AXObserverCenter.shared
         let logMessage = "NotificationWatcher initialized for element, notification: \(notification.rawValue)"
         axDebugLog(logMessage)
+    }
+
+    init(
+        forElement element: Element,
+        notification: AXNotification,
+        registry: any AXObservationRegistry,
+        handler: @escaping AXNotificationSubscriptionHandler)
+    {
+        self.target = .element(element)
+        self.notification = notification
+        self.handler = handler
+        self.registry = registry
     }
 
     /// Initializes a watcher for a specific process ID (PID).
@@ -42,8 +55,21 @@ public class NotificationWatcher {
         self.target = .pid(pid)
         self.notification = notification
         self.handler = handler
+        self.registry = AXObserverCenter.shared
         let logMessage = "NotificationWatcher initialized for PID \(pid), notification: \(notification.rawValue)"
         axDebugLog(logMessage)
+    }
+
+    init(
+        forPID pid: pid_t,
+        notification: AXNotification,
+        registry: any AXObservationRegistry,
+        handler: @escaping AXNotificationSubscriptionHandler)
+    {
+        self.target = .pid(pid)
+        self.notification = notification
+        self.handler = handler
+        self.registry = registry
     }
 
     /// Initializes a watcher for a global notification (any application).
@@ -51,21 +77,17 @@ public class NotificationWatcher {
         self.target = .global
         self.notification = notification
         self.handler = handler
+        self.registry = AXObserverCenter.shared
         let logMessage = "NotificationWatcher initialized for global notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
 
     deinit {
         axDebugLog("NotificationWatcher deinit")
-        // Stop observing when the watcher is deallocated
-        // Since stop() is @MainActor, we need to call it from a Task
-        // and handle potential issues if self is already gone.
-        Task { [weak self] in // Add [weak self]
-            guard let self else { // Add guard
-                axDebugLog("NotificationWatcher.deinit: self is nil, cannot call stop().")
-                return
-            }
-            await self.stop() // Call stop on the guarded self
+        guard let token = self.subscriptionToken else { return }
+        let registry = self.registry
+        Task { @MainActor in
+            try? registry.unsubscribe(token: token)
         }
     }
 
@@ -120,7 +142,7 @@ public class NotificationWatcher {
             "(PID: \(pidToLog)), notification: \(self.notification.rawValue)"
         axInfoLog(logStart)
 
-        let subscribeResult = AXObserverCenter.shared.subscribe(
+        let subscribeResult = self.registry.subscribe(
             pid: effectivePid,
             element: elementForSubscription, // Pass element if target is .element
             notification: self.notification,
@@ -153,7 +175,7 @@ public class NotificationWatcher {
         axInfoLog(logStop)
 
         do {
-            try AXObserverCenter.shared.unsubscribe(token: token)
+            try self.registry.unsubscribe(token: token)
             axInfoLog("\(logStop) - UNSUBSCRIBED successfully. Token: \(token.id)")
         } catch {
             axErrorLog("\(logStop) - FAILED to unsubscribe token \(token.id): \(error.localizedDescription)")
@@ -173,6 +195,7 @@ public class NotificationWatcher {
     private let target: ObservationTarget
     private let notification: AXNotification
     private let handler: AXNotificationSubscriptionHandler
+    private let registry: any AXObservationRegistry
     private var subscriptionToken: SubscriptionToken?
     private var isObserving: Bool = false
 }

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -182,6 +182,8 @@ final class AXObserverSubscriptionStore {
             let subscription = registration.subscription
             let matchesGlobal = subscription == globalKey
             let matchesProcess = subscription == specificKey && registration.scope == .process
+            // AXObserver registrations are object-specific. Only application registrations use process scope;
+            // element registrations must not fan the callback out to sibling accessibility objects.
             let matchesElement = subscription == specificKey &&
                 registration.scope == .element &&
                 registration.element == eventElement

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -15,6 +15,18 @@ public typealias AXNotificationSubscriptionHandler = @MainActor ( /* element: El
     _ rawElement: AXUIElement,
     _ nsUserInfo: [String: Any]?) -> Void
 
+/// The single registration boundary used by AXorcist's observer APIs.
+@MainActor
+protocol AXObservationRegistry: AnyObject, Sendable {
+    func subscribe(
+        pid: pid_t?,
+        element: Element?,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+
+    func unsubscribe(token: SubscriptionToken) throws
+}
+
 /// Key for tracking accessibility notification subscriptions.
 ///
 /// Allows for both process-specific and global notification observers.
@@ -25,6 +37,18 @@ public struct AXNotificationSubscriptionKey: Hashable {
 
     /// The accessibility notification type to observe.
     let notification: AXNotification
+}
+
+/// Exact system registration identity retained until the final matching handler unsubscribes.
+struct AXObserverRegistrationKey: Hashable {
+    enum Scope: Hashable {
+        case process
+        case element
+    }
+
+    let subscription: AXNotificationSubscriptionKey
+    let element: Element
+    let scope: Scope
 }
 
 /// Key combining process ID and notification type for observer tracking.
@@ -63,7 +87,111 @@ public struct AXObserverObjAndPID {
 /// // Later...
 /// observerCenter.unsubscribe(token)
 /// ```
-public struct SubscriptionToken: Hashable {
+public nonisolated struct SubscriptionToken: Hashable, Sendable {
     /// Unique identifier for this subscription.
     let id: UUID
+}
+
+/// Main-actor-isolated subscription storage. Dispatch snapshots handlers before invoking them,
+/// so callbacks can safely unsubscribe themselves or other callbacks.
+@MainActor
+final class AXObserverSubscriptionStore {
+    struct Removal {
+        let registration: AXObserverRegistrationKey
+        let removedLastHandler: Bool
+    }
+
+    private var subscriptions: [AXObserverRegistrationKey: [UUID: AXNotificationSubscriptionHandler]] = [:]
+    private var subscriptionTokens: [UUID: AXObserverRegistrationKey] = [:]
+
+    var registeredKeys: [AXNotificationSubscriptionKey] {
+        Array(Set(self.subscriptions.keys.map(\.subscription)))
+    }
+
+    func add(
+        registration: AXObserverRegistrationKey,
+        handler: @escaping AXNotificationSubscriptionHandler) -> SubscriptionToken
+    {
+        let token = SubscriptionToken(id: UUID())
+        self.subscriptions[registration, default: [:]][token.id] = handler
+        self.subscriptionTokens[token.id] = registration
+        return token
+    }
+
+    func remove(token: SubscriptionToken) throws -> Removal {
+        guard let registration = self.subscriptionTokens.removeValue(forKey: token.id) else {
+            throw AccessibilityError.tokenNotFound(tokenId: token.id)
+        }
+
+        guard var handlers = self.subscriptions[registration], handlers.removeValue(forKey: token.id) != nil else {
+            return Removal(
+                registration: registration,
+                removedLastHandler: self.subscriptions[registration]?.isEmpty != false)
+        }
+
+        if handlers.isEmpty {
+            self.subscriptions.removeValue(forKey: registration)
+        } else {
+            self.subscriptions[registration] = handlers
+        }
+        return Removal(registration: registration, removedLastHandler: handlers.isEmpty)
+    }
+
+    func removeAll() {
+        self.subscriptions.removeAll()
+        self.subscriptionTokens.removeAll()
+    }
+
+    func tokens(for pid: pid_t) -> [SubscriptionToken] {
+        self.subscriptionTokens.compactMap { tokenID, registration in
+            registration.subscription.pid == pid ? SubscriptionToken(id: tokenID) : nil
+        }
+    }
+
+    func contains(pid: pid_t?, notification: AXNotification) -> Bool {
+        self.subscriptions.contains { registration, handlers in
+            registration.subscription.pid == pid &&
+                registration.subscription.notification == notification &&
+                !handlers.isEmpty
+        }
+    }
+
+    func contains(registration: AXObserverRegistrationKey) -> Bool {
+        self.subscriptions[registration]?.isEmpty == false
+    }
+
+    func containsSubscriptions(forEffectivePID pid: pid_t) -> Bool {
+        self.subscriptions.contains { registration, handlers in
+            (registration.subscription.pid ?? 0) == pid && !handlers.isEmpty
+        }
+    }
+
+    func dispatch(
+        pid: pid_t,
+        notification: AXNotification,
+        rawElement: AXUIElement,
+        userInfo: [String: Any]?)
+    {
+        let specificKey = AXNotificationSubscriptionKey(
+            pid: pid,
+            notification: notification)
+        let globalKey = AXNotificationSubscriptionKey(pid: nil, notification: notification)
+        var handlersToCall: [AXNotificationSubscriptionHandler] = []
+        let eventElement = Element(rawElement)
+        for (registration, handlers) in self.subscriptions {
+            let subscription = registration.subscription
+            let matchesGlobal = subscription == globalKey
+            let matchesProcess = subscription == specificKey && registration.scope == .process
+            let matchesElement = subscription == specificKey &&
+                registration.scope == .element &&
+                registration.element == eventElement
+            if matchesGlobal || matchesProcess || matchesElement {
+                handlersToCall.append(contentsOf: handlers.values)
+            }
+        }
+
+        for handler in handlersToCall {
+            handler(pid, notification, rawElement, userInfo)
+        }
+    }
 }

--- a/Sources/AXorcist/Utils/AXObserverManager.swift
+++ b/Sources/AXorcist/Utils/AXObserverManager.swift
@@ -4,9 +4,10 @@ import Foundation
 
 /// Manages accessibility observers for monitoring UI element changes.
 ///
-/// `AXObserverManager` provides a centralized system for managing accessibility observers
-/// that monitor changes to UI elements. It handles observer lifecycle, notification routing,
-/// and ensures proper cleanup of resources.
+/// Legacy raw-callback observer API retained for source compatibility.
+///
+/// New code should use ``AXObserverCenter`` or ``NotificationWatcher``. AXorcist commands no longer
+/// use this separate compatibility manager, so observe and stop operations share one token registry.
 ///
 /// ## Overview
 ///
@@ -35,6 +36,7 @@ import Foundation
 /// - ``AXNotificationCallback``
 /// - ``ObserverError``
 @MainActor
+@available(*, deprecated, message: "Use AXObserverCenter or NotificationWatcher for token-based observation")
 public class AXObserverManager {
     // MARK: Lifecycle
 
@@ -184,6 +186,7 @@ public class AXObserverManager {
 }
 
 @MainActor
+@available(*, deprecated, message: "Use AXObserverCenter or NotificationWatcher for token-based observation")
 extension AXObserverManager {
     private func updateExistingObserver(
         info: inout ObserverInfo,

--- a/Sources/axorc/AXORCMain.swift
+++ b/Sources/axorc/AXORCMain.swift
@@ -104,20 +104,19 @@ struct AXORCCommand: ParsableCommand {
         }
 
         if command.command == .observe {
-            self.handleObserveCommand(resultJsonString: resultJsonString, debugCLI: self.debug)
+            self.handleSuccessfulObserveCommand(owner: axorcist)
         } else {
             axClearLogs()
         }
     }
 
     @MainActor
-    private func handleObserveCommand(resultJsonString: String, debugCLI: Bool) {
-        let observerSetupSucceeded = self.parseObserveSetup(resultJsonString)
-        if observerSetupSucceeded {
-            axInfoLog(
-                logSegments(
-                    "AXORCMain: Observer setup successful",
-                    "Process will remain alive by running current RunLoop"))
+    private func handleSuccessfulObserveCommand(owner: AXorcist) {
+        axInfoLog(
+            logSegments(
+                "AXORCMain: Observer setup successful",
+                "Process will remain alive by running current RunLoop"))
+        withExtendedLifetime(owner) {
             #if DEBUG
             axInfoLog("AXORCMain: DEBUG mode - entering RunLoop.current.run() for observer.")
             RunLoop.current.run()
@@ -131,54 +130,6 @@ struct AXORCCommand: ParsableCommand {
             fputs(errorPayload, stderr)
             fflush(stderr)
             #endif
-        } else {
-            axErrorLog(
-                logSegments(
-                    "AXORCMain: Observe command setup reported failure or result was not a success status",
-                    "Exiting"))
-        }
-    }
-
-    private func parseObserveSetup(_ jsonString: String) -> Bool {
-        guard let resultData = jsonString.data(using: .utf8) else {
-            axErrorLog("AXORCMain: Could not convert result JSON string to data for observe setup check.")
-            return false
-        }
-
-        do {
-            if
-                let jsonOutput = try JSONSerialization.jsonObject(with: resultData, options: []) as?
-                [String: Any],
-                let success = jsonOutput["success"] as? Bool,
-                let status = jsonOutput["status"] as? String
-            {
-                axInfoLog(
-                    logSegments(
-                        "AXORCMain: Parsed initial response for observe",
-                        "success=\(success)",
-                        "status=\(status)"))
-                if success, status == "observer_started" {
-                    axInfoLog("AXORCMain: Observer setup deemed SUCCEEDED for observe command.")
-                    return true
-                }
-                axInfoLog(
-                    logSegments(
-                        "AXORCMain: Observer setup deemed FAILED for observe command",
-                        "success=\(success)",
-                        "status=\(status)"))
-                return false
-            }
-            axErrorLog(
-                logSegments(
-                    "AXORCMain: Failed to parse expected fields (success, status)",
-                    "from observe setup JSON"))
-            return false
-        } catch {
-            axErrorLog(
-                logSegments(
-                    "AXORCMain: Could not parse result JSON from observe setup to check for success",
-                    error.localizedDescription))
-            return false
         }
     }
 

--- a/Sources/axorc/CommandExecutor.swift
+++ b/Sources/axorc/CommandExecutor.swift
@@ -34,6 +34,10 @@ struct CommandExecutor {
         return self.processCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
     }
 
+    static func stopObservations(axorcist: AXorcist) {
+        axorcist.stopObserving()
+    }
+
     // MARK: Private
 
     /// Simplified to only adjust detail level based on command specific flag, if CLI debug is on.
@@ -73,8 +77,8 @@ struct CommandExecutor {
         .ping: { command, _, debugCLI in handlePingCommand(command: command, debugCLI: debugCLI) },
         .batch: handleBatchCommand,
         .observe: handleObserveCommand,
-        .stopObservation: { command, _, debugCLI in
-            handleStopObservationCommand(command: command, debugCLI: debugCLI)
+        .stopObservation: { command, axorcist, debugCLI in
+            handleStopObservationCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
         },
         .isProcessTrusted: { command, _, _ in handleIsProcessTrustedCommand(command: command) },
         .isAXFeatureEnabled: { command, _, _ in handleIsAXFeatureEnabledCommand(command: command) },
@@ -181,8 +185,12 @@ struct CommandExecutor {
     }
 
     @MainActor
-    private static func handleStopObservationCommand(command: CommandEnvelope, debugCLI: Bool) -> String {
-        AXObserverCenter.shared.removeAllObservers()
+    private static func handleStopObservationCommand(
+        command: CommandEnvelope,
+        axorcist: AXorcist,
+        debugCLI: Bool) -> String
+    {
+        self.stopObservations(axorcist: axorcist)
         let stopResponse = FinalResponse(
             commandId: command.commandId,
             commandType: command.command.rawValue,

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -1,0 +1,251 @@
+import ApplicationServices
+import Darwin
+import Foundation
+import Testing
+@testable import axorc
+@testable import AXorcist
+
+@Suite("Observer lifecycle")
+@MainActor
+struct ObserverLifecycleTests {
+    @Test
+    func `application PID uses the native element identity`() {
+        let processIdentifier = getpid()
+        let element = Element(AXUIElementCreateApplication(processIdentifier))
+
+        #expect(element.pid() == processIdentifier)
+    }
+
+    @Test
+    func `CLI recognizes the current observe success response`() {
+        #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"success\"}"))
+        #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"error\"}") == false)
+    }
+
+    @Test
+    func `observe and stop use the same registry without clearing unrelated subscriptions`() throws {
+        let registry = RecordingObservationRegistry()
+        let target = Element(AXUIElementCreateSystemWide())
+        let unrelatedToken = try registry.subscribe(
+            pid: 7,
+            element: nil,
+            notification: .titleChanged)
+        { _, _, _, _ in }.get()
+        var resolvedRole: String?
+        let axorcist = AXorcist(
+            observationRegistry: registry,
+            observationTargetResolver: { _, locator, _ in
+                resolvedRole = locator.criteria.first?.value
+                return (target, nil)
+            })
+        let observe = ObserveCommand(
+            appIdentifier: "fixture",
+            locator: Locator(criteria: [
+                Criterion(attribute: "AXRole", value: AXRoleNames.kAXButtonRole, matchType: .exact),
+            ]),
+            notifications: [AXNotification.valueChanged.rawValue],
+            notificationName: .valueChanged)
+
+        let observeResponse = axorcist.runCommand(AXCommandEnvelope(
+            commandID: "observe-owner",
+            command: .observe(observe)))
+
+        #expect(observeResponse.status == "success")
+        #expect(resolvedRole == AXRoleNames.kAXButtonRole)
+        #expect(registry.activeSubscriptionCount == 2)
+
+        CommandExecutor.stopObservations(axorcist: axorcist)
+
+        #expect(registry.unsubscribeCallCount == 1)
+        #expect(registry.activeSubscriptionCount == 1)
+        #expect(registry.contains(unrelatedToken))
+    }
+
+    @Test
+    func `callback can unsubscribe itself during dispatch`() throws {
+        var cleanupCount = 0
+        var cleanedElement: Element?
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in .success },
+            observerCleanup: { _, element, _ in
+                cleanupCount += 1
+                cleanedElement = element
+            })
+        var callbackCount = 0
+        var token: SubscriptionToken?
+        let observedElement = Element(AXUIElementCreateApplication(42))
+        let subscription = center.subscribe(
+            pid: 42,
+            element: observedElement,
+            notification: .valueChanged)
+        { _, _, _, _ in
+            callbackCount += 1
+            if let token {
+                try? center.unsubscribe(token: token)
+            }
+        }
+        token = try subscription.get()
+
+        center.processNotification(
+            pid: 42,
+            notification: .valueChanged,
+            rawElement: observedElement.underlyingElement,
+            nsUserInfo: nil)
+
+        #expect(callbackCount == 1)
+        #expect(cleanupCount == 1)
+        #expect(cleanedElement == observedElement)
+        #expect(center.isKeyRegistered(pid: 42, notification: .valueChanged) == false)
+    }
+
+    @Test
+    func `element registrations dispatch only to their exact target`() {
+        let store = AXObserverSubscriptionStore()
+        let subscription = AXNotificationSubscriptionKey(pid: 91, notification: .valueChanged)
+        let firstElement = Element(AXUIElementCreateApplication(91))
+        let secondElement = Element(AXUIElementCreateApplication(92))
+        var firstCount = 0
+        var secondCount = 0
+        var processCount = 0
+        _ = store.add(
+            registration: AXObserverRegistrationKey(
+                subscription: subscription,
+                element: firstElement,
+                scope: .element))
+        { _, _, _, _ in firstCount += 1 }
+        _ = store.add(
+            registration: AXObserverRegistrationKey(
+                subscription: subscription,
+                element: secondElement,
+                scope: .element))
+        { _, _, _, _ in secondCount += 1 }
+        _ = store.add(
+            registration: AXObserverRegistrationKey(
+                subscription: subscription,
+                element: firstElement,
+                scope: .process))
+        { _, _, _, _ in processCount += 1 }
+
+        store.dispatch(
+            pid: 91,
+            notification: .valueChanged,
+            rawElement: firstElement.underlyingElement,
+            userInfo: nil)
+
+        #expect(firstCount == 1)
+        #expect(secondCount == 0)
+        #expect(processCount == 1)
+    }
+
+    @Test
+    func `shared registration cleans up its exact target after the final token`() throws {
+        var setupCount = 0
+        var cleanedElement: Element?
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, element, _ in cleanedElement = element })
+        let observedElement = Element(AXUIElementCreateApplication(73))
+        let first = try center.subscribe(
+            pid: 73,
+            element: nil,
+            notification: .valueChanged)
+        { _, _, _, _ in }.get()
+        let second = try center.subscribe(
+            pid: 73,
+            element: observedElement,
+            notification: .valueChanged)
+        { _, _, _, _ in }.get()
+
+        #expect(setupCount == 1)
+        try center.unsubscribe(token: first)
+        #expect(cleanedElement == nil)
+        #expect(center.isKeyRegistered(pid: 73, notification: .valueChanged))
+
+        try center.unsubscribe(token: second)
+        #expect(cleanedElement == observedElement)
+        #expect(center.isKeyRegistered(pid: 73, notification: .valueChanged) == false)
+    }
+
+    @Test
+    func `watcher deinit unregisters its token`() async throws {
+        let registry = RecordingObservationRegistry()
+        var watcher: NotificationWatcher? = NotificationWatcher(
+            forPID: getpid(),
+            notification: .valueChanged,
+            registry: registry)
+        { _, _, _, _ in }
+        try watcher?.start()
+        #expect(registry.activeSubscriptionCount == 1)
+
+        weak let weakWatcher = watcher
+        watcher = nil
+        #expect(weakWatcher == nil)
+        for _ in 0..<10 where registry.unsubscribeCallCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(registry.unsubscribeCallCount == 1)
+        #expect(registry.activeSubscriptionCount == 0)
+    }
+
+    @Test
+    func `AXorcist deinit unregisters its owned tokens`() async {
+        let registry = RecordingObservationRegistry()
+        let target = Element(AXUIElementCreateSystemWide())
+        var axorcist: AXorcist? = AXorcist(
+            observationRegistry: registry,
+            observationTargetResolver: { _, _, _ in (target, nil) })
+        let observe = ObserveCommand(
+            appIdentifier: "fixture",
+            notifications: [AXNotification.valueChanged.rawValue],
+            notificationName: .valueChanged)
+        _ = axorcist?.runCommand(AXCommandEnvelope(commandID: "deinit-owner", command: .observe(observe)))
+        #expect(registry.activeSubscriptionCount == 1)
+
+        weak let weakAXorcist = axorcist
+        axorcist = nil
+        #expect(weakAXorcist == nil)
+        for _ in 0..<10 where registry.unsubscribeCallCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(registry.unsubscribeCallCount == 1)
+        #expect(registry.activeSubscriptionCount == 0)
+    }
+}
+
+@MainActor
+private final class RecordingObservationRegistry: AXObservationRegistry {
+    private var subscriptions: [SubscriptionToken: AXNotificationSubscriptionHandler] = [:]
+
+    private(set) var unsubscribeCallCount = 0
+
+    var activeSubscriptionCount: Int {
+        self.subscriptions.count
+    }
+
+    func contains(_ token: SubscriptionToken) -> Bool {
+        self.subscriptions[token] != nil
+    }
+
+    func subscribe(
+        pid _: pid_t?,
+        element _: Element?,
+        notification _: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        let token = SubscriptionToken(id: UUID())
+        self.subscriptions[token] = handler
+        return .success(token)
+    }
+
+    func unsubscribe(token: SubscriptionToken) throws {
+        self.unsubscribeCallCount += 1
+        guard self.subscriptions.removeValue(forKey: token) != nil else {
+            throw AccessibilityError.tokenNotFound(tokenId: token.id)
+        }
+    }
+}

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -180,9 +180,9 @@ struct ObserverLifecycleTests {
         try watcher?.start()
         #expect(registry.activeSubscriptionCount == 1)
 
-        weak let weakWatcher = watcher
+        let weakWatcher = WeakReference(watcher)
         watcher = nil
-        #expect(weakWatcher == nil)
+        #expect(weakWatcher.value == nil)
         for _ in 0..<10 where registry.unsubscribeCallCount == 0 {
             await Task.yield()
         }
@@ -205,15 +205,24 @@ struct ObserverLifecycleTests {
         _ = axorcist?.runCommand(AXCommandEnvelope(commandID: "deinit-owner", command: .observe(observe)))
         #expect(registry.activeSubscriptionCount == 1)
 
-        weak let weakAXorcist = axorcist
+        let weakAXorcist = WeakReference(axorcist)
         axorcist = nil
-        #expect(weakAXorcist == nil)
+        #expect(weakAXorcist.value == nil)
         for _ in 0..<10 where registry.unsubscribeCallCount == 0 {
             await Task.yield()
         }
 
         #expect(registry.unsubscribeCallCount == 1)
         #expect(registry.activeSubscriptionCount == 0)
+    }
+}
+
+@MainActor
+private final class WeakReference<Value: AnyObject> {
+    weak var value: Value?
+
+    init(_ value: Value?) {
+        self.value = value
     }
 }
 


### PR DESCRIPTION
## Summary

- route `observe`, `stopObservation`, and `NotificationWatcher` through one token-based `AXObserverCenter` registry
- retain exact process/element registration identity so final unsubscription removes the matching native notification and callbacks dispatch only to their target
- make `AXorcist` own the observations it starts and clean them up on stop or deinit without clearing unrelated subscribers
- resolve element PIDs with the native Accessibility API and keep the legacy raw-callback manager as a deprecated source-compatibility boundary
- remove duplicate CLI success parsing and retain the observer owner across the debug run loop

## Proof

- observer lifecycle: 8/8
- full debug: 87/87
- full Release: 87/87
- `make check` clean: SwiftFormat, strict SwiftLint, and both native-only gates
- diff and TruffleHog clean
- P0-P2 autoreview clean at 0.88 after hardening owner lifetime
- changelog-only release-ownership follow-up review clean at 0.99

The public behavior note remains in the README. The consuming Peekaboo product changelog will record this fix when its submodule pin advances.
