### PR TITLE
refactor: remove dead process fallback and fix universal builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,14 @@
 # Define the output binary name
 BINARY_NAME = axorc
 UNIVERSAL_BINARY_PATH = ./$(BINARY_NAME)
-RELEASE_BUILD_DIR := ./.build/arm64-apple-macosx/release
-RELEASE_BUILD_DIR_X86 := ./.build/x86_64-apple-macosx/release
 
-# Build for arm64 and x86_64, then lipo them together
-# -Xswiftc -Osize: Optimize for size
-# -Xlinker -Wl,-dead_strip: Remove dead code
-# strip -x: Strip symbol table and debug info
-# Ensure old binary is removed first
+# Build and ad-hoc sign a universal local binary.
 all:
-	@echo "Cleaning old binary and build artifacts..."
+	@echo "Cleaning old binary..."
 	rm -f $(UNIVERSAL_BINARY_PATH)
-	swift package clean
-	@echo "Building for arm64..."
-	swift build --arch arm64 -c release -Xswiftc -Osize -Xlinker -dead_strip
-	@echo "Building for x86_64..."
-	swift build --arch x86_64 -c release -Xswiftc -Osize -Xlinker -dead_strip
-	@echo "Creating universal binary..."
-	lipo -create -output $(UNIVERSAL_BINARY_PATH) $(RELEASE_BUILD_DIR)/$(BINARY_NAME) $(RELEASE_BUILD_DIR_X86)/$(BINARY_NAME)
-	@echo "Stripping symbols from universal binary..."
-	strip -x $(UNIVERSAL_BINARY_PATH)
+	./scripts/build-universal-binary.sh $(UNIVERSAL_BINARY_PATH) --adhoc
 	@echo "Build complete: $(UNIVERSAL_BINARY_PATH)"
 	@ls -l $(UNIVERSAL_BINARY_PATH)
-	@codesign -s - $(UNIVERSAL_BINARY_PATH)
-	@echo "Codesigned $(UNIVERSAL_BINARY_PATH)"
 
 
 clean:

--- a/Sources/AXorcist/Core/ProcessUtils.swift
+++ b/Sources/AXorcist/Core/ProcessUtils.swift
@@ -205,22 +205,6 @@ private func pidForResolvedBundleID(_ bundleID: String, fromPath path: String) -
     return nil
 }
 
-func findFrontmostApplicationPid() -> pid_t? {
-    processDebugLog("ProcessUtils: findFrontmostApplicationPid called.")
-    if let frontmostApp = NSWorkspace.shared.frontmostApplication {
-        processDebugLog(
-            "ProcessUtils: Frontmost app for findFrontmostApplicationPid is '\(frontmostApp.localizedName ?? "nil")'",
-            "PID: \(frontmostApp.processIdentifier)",
-            "BundleID: \(frontmostApp.bundleIdentifier ?? "nil")",
-            "Terminated: \(frontmostApp.isTerminated)")
-        return frontmostApp.processIdentifier
-    } else {
-        processWarningLog(
-            "ProcessUtils: NSWorkspace.shared.frontmostApplication returned nil in findFrontmostApplicationPid.")
-        return nil
-    }
-}
-
 public func getParentProcessName() -> String? {
     let parentPid = getppid()
     processDebugLog("ProcessUtils: Parent PID is \(parentPid).")

--- a/scripts/build-release-artifact.sh
+++ b/scripts/build-release-artifact.sh
@@ -65,19 +65,10 @@ checksum_path="$archive_path.sha256"
 rm -rf "$stage_dir" "$archive_path" "$checksum_path"
 mkdir -p "$stage_dir"
 
-swift build -c release --arch arm64 --product axorc
-swift build -c release --arch x86_64 --product axorc
-
-lipo -create \
-  .build/arm64-apple-macosx/release/axorc \
-  .build/x86_64-apple-macosx/release/axorc \
-  -output "$binary_path"
-strip -x "$binary_path"
-
 if [[ "$adhoc" == true ]]; then
-  codesign --force --sign - "$binary_path"
+  "$repo_root/scripts/build-universal-binary.sh" "$binary_path" --adhoc
 else
-  codesign --force --options runtime --timestamp --sign "$AXORC_CODESIGN_IDENTITY" "$binary_path"
+  "$repo_root/scripts/build-universal-binary.sh" "$binary_path"
 fi
 
 codesign --verify --strict --verbose=2 "$binary_path"

--- a/scripts/build-universal-binary.sh
+++ b/scripts/build-universal-binary.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-universal-binary.sh <output-path> [--adhoc]
+
+Builds a universal release axorc binary at the requested path. Publishable
+builds require AXORC_CODESIGN_IDENTITY to name a Developer ID Application
+identity. Use --adhoc only for local or CI verification.
+EOF
+}
+
+if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+output_path="$1"
+shift
+adhoc=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --adhoc)
+      adhoc=true
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ "$adhoc" == false && -z "${AXORC_CODESIGN_IDENTITY:-}" ]]; then
+  echo "AXORC_CODESIGN_IDENTITY is required for publishable artifacts." >&2
+  exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/axorc-universal.XXXXXX")"
+cleanup() {
+  rm -rf "$stage_dir"
+}
+trap cleanup EXIT
+
+build_architecture() {
+  local architecture="$1"
+  local destination="$2"
+  local bin_dir
+
+  swift build -c release --arch "$architecture" --product axorc
+  bin_dir="$(swift build -c release --arch "$architecture" --show-bin-path)"
+  if [[ ! -x "$bin_dir/axorc" ]]; then
+    echo "Built axorc binary is missing for $architecture: $bin_dir/axorc" >&2
+    exit 1
+  fi
+  install -m 0755 "$bin_dir/axorc" "$destination"
+}
+
+arm64_binary="$stage_dir/axorc-arm64"
+x86_64_binary="$stage_dir/axorc-x86_64"
+build_architecture arm64 "$arm64_binary"
+build_architecture x86_64 "$x86_64_binary"
+
+mkdir -p "$(dirname "$output_path")"
+lipo -create "$arm64_binary" "$x86_64_binary" -output "$output_path"
+strip -x "$output_path"
+
+if [[ "$adhoc" == true ]]; then
+  codesign --force --sign - "$output_path"
+else
+  codesign --force --options runtime --timestamp --sign "$AXORC_CODESIGN_IDENTITY" "$output_path"
+fi
+
+codesign --verify --strict --verbose=2 "$output_path"
+file "$output_path" | grep -q 'universal binary'
+echo "Created universal binary $output_path"


### PR DESCRIPTION
## Summary

- remove the unused frontmost-PID resolver and its dead fallback path
- centralize universal SwiftPM output discovery in the release script
- make Makefile and release-artifact packaging reuse that proven universal builder

## Proof

- 87 tests
- Debug and Release builds
- native-only, formatting, lint, and ShellCheck gates
- arm64 and x86_64 archive checksum/codesign verification
- Makefile and formula artifact proof
- final P0-P2 review clean

The release fix was reproduced against the old failing `lipo` output path before the shared builder was introduced.
