### PR TITLE
fix(input): preserve mouse button event sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Preserve middle and right mouse-button identity across clicks, holds, and drags, and build complete input sequences before posting so allocation failures cannot leave a button held down.
+- Resolve each architecture from SwiftPM's reported output when building universal release artifacts instead of assuming a fixed build directory.
 - Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.
 - Keep accessibility-tree traversal state local to each search and honor prefetched children, so repeated lookups cannot skip elements seen by earlier commands.
 - Stop probing or linking Apple Events for legacy automation-permission status; deprecated compatibility APIs now return unknown while Accessibility permission checks remain native AX-only.

--- a/Sources/AXorcist/Core/Element+UIAutomation.swift
+++ b/Sources/AXorcist/Core/Element+UIAutomation.swift
@@ -10,6 +10,38 @@ public enum MouseButton: String, Sendable {
     case middle
 }
 
+struct MouseButtonEventKinds: Equatable {
+    let button: CGMouseButton
+    let down: CGEventType
+    let dragged: CGEventType
+    let up: CGEventType
+}
+
+extension MouseButton {
+    var eventKinds: MouseButtonEventKinds {
+        switch self {
+        case .left:
+            MouseButtonEventKinds(
+                button: .left,
+                down: .leftMouseDown,
+                dragged: .leftMouseDragged,
+                up: .leftMouseUp)
+        case .right:
+            MouseButtonEventKinds(
+                button: .right,
+                down: .rightMouseDown,
+                dragged: .rightMouseDragged,
+                up: .rightMouseUp)
+        case .middle:
+            MouseButtonEventKinds(
+                button: .center,
+                down: .otherMouseDown,
+                dragged: .otherMouseDragged,
+                up: .otherMouseUp)
+        }
+    }
+}
+
 // MARK: - Click Operations
 
 extension Element {
@@ -58,9 +90,7 @@ extension Element {
     {
         let clampedCount = max(1, clickCount)
 
-        let downType: CGEventType = (button == .left ? .leftMouseDown : .rightMouseDown)
-        let upType: CGEventType = (button == .left ? .leftMouseUp : .rightMouseUp)
-        let mouseButton: CGMouseButton = (button == .left ? .left : .right)
+        let eventKinds = button.eventKinds
 
         var pairs: [(down: CGEvent, up: CGEvent)] = []
         pairs.reserveCapacity(clampedCount)
@@ -68,18 +98,18 @@ extension Element {
         for clickIndex in 1...clampedCount {
             guard let mouseDown = CGEvent(
                 mouseEventSource: nil,
-                mouseType: downType,
+                mouseType: eventKinds.down,
                 mouseCursorPosition: point,
-                mouseButton: mouseButton)
+                mouseButton: eventKinds.button)
             else {
                 throw UIAutomationError.failedToCreateEvent
             }
 
             guard let mouseUp = CGEvent(
                 mouseEventSource: nil,
-                mouseType: upType,
+                mouseType: eventKinds.up,
                 mouseCursorPosition: point,
-                mouseButton: mouseButton)
+                mouseButton: eventKinds.button)
             else {
                 throw UIAutomationError.failedToCreateEvent
             }

--- a/Sources/AXorcist/Core/InputDriver.swift
+++ b/Sources/AXorcist/Core/InputDriver.swift
@@ -1,5 +1,6 @@
 import AppKit
 import CoreGraphics
+import Dispatch
 import Foundation
 
 /// Lightweight, allocation-conscious helpers for synthesizing user input.
@@ -8,6 +9,8 @@ import Foundation
 /// the underlying AX/UI toolkits already impose. Callers (e.g. Peekaboo) can
 /// layer heuristics or visualization on top without paying a baseline tax.
 public enum InputDriver {
+    typealias MouseEventFactory = @MainActor (CGEventType, CGPoint, CGMouseButton) -> CGEvent?
+
     // MARK: - Mouse
 
     /// Click at a screen point.
@@ -50,30 +53,16 @@ public enum InputDriver {
     /// Press and hold at a point for a duration (simulates force click fallback).
     @MainActor
     public static func pressHold(at point: CGPoint, button: MouseButton = .left, duration: TimeInterval) throws {
-        let buttonType: CGMouseButton = (button == .left ? .left : .right)
-        let downType: CGEventType = (button == .left ? .leftMouseDown : .rightMouseDown)
-        let upType: CGEventType = (button == .left ? .leftMouseUp : .rightMouseUp)
-
-        guard let down = CGEvent(
-            mouseEventSource: nil,
-            mouseType: downType,
-            mouseCursorPosition: point,
-            mouseButton: buttonType)
-        else { throw UIAutomationError.failedToCreateEvent }
-        down.setDoubleValueField(.mouseEventPressure, value: 2.0)
-        down.post(tap: .cghidEventTap)
+        let events = try self.pressHoldEvents(at: point, button: button)
+        self.refreshTimestamp(events.down)
+        events.down.post(tap: .cghidEventTap)
 
         if duration > 0 {
             Thread.sleep(forTimeInterval: duration)
         }
 
-        guard let up = CGEvent(
-            mouseEventSource: nil,
-            mouseType: upType,
-            mouseCursorPosition: point,
-            mouseButton: buttonType)
-        else { throw UIAutomationError.failedToCreateEvent }
-        up.post(tap: .cghidEventTap)
+        self.refreshTimestamp(events.up)
+        events.up.post(tap: .cghidEventTap)
     }
 
     /// Drag from → to using the given button.
@@ -85,45 +74,93 @@ public enum InputDriver {
         steps: Int = 20,
         interStepDelay: TimeInterval = 0.0) throws
     {
-        let steps = max(1, steps)
+        let events = try self.dragEvents(from: start, to: end, button: button, steps: steps)
+        self.refreshTimestamp(events.down)
+        events.down.post(tap: .cghidEventTap)
 
-        let buttonType: CGMouseButton = (button == .left ? .left : .right)
-        let downType: CGEventType = (button == .left ? .leftMouseDown : .rightMouseDown)
-        let dragType: CGEventType = .leftMouseDragged
-        let upType: CGEventType = (button == .left ? .leftMouseUp : .rightMouseUp)
-
-        guard let down = CGEvent(
-            mouseEventSource: nil,
-            mouseType: downType,
-            mouseCursorPosition: start,
-            mouseButton: buttonType)
-        else { throw UIAutomationError.failedToCreateEvent }
-        down.post(tap: .cghidEventTap)
-
-        for i in 1...steps {
-            let t = CGFloat(i) / CGFloat(steps)
-            let pos = CGPoint(
-                x: start.x + (end.x - start.x) * t,
-                y: start.y + (end.y - start.y) * t)
-            guard let move = CGEvent(
-                mouseEventSource: nil,
-                mouseType: dragType,
-                mouseCursorPosition: pos,
-                mouseButton: buttonType)
-            else { continue }
+        for move in events.moves {
+            self.refreshTimestamp(move)
             move.post(tap: .cghidEventTap)
             if interStepDelay > 0 {
                 Thread.sleep(forTimeInterval: interStepDelay)
             }
         }
 
-        guard let up = CGEvent(
+        self.refreshTimestamp(events.up)
+        events.up.post(tap: .cghidEventTap)
+    }
+
+    @MainActor
+    static func pressHoldEvents(
+        at point: CGPoint,
+        button: MouseButton,
+        makeEvent: MouseEventFactory = InputDriver.makeMouseEvent) throws -> (down: CGEvent, up: CGEvent)
+    {
+        let eventKinds = button.eventKinds
+        guard let down = makeEvent(eventKinds.down, point, eventKinds.button),
+              let up = makeEvent(eventKinds.up, point, eventKinds.button)
+        else {
+            throw UIAutomationError.failedToCreateEvent
+        }
+        down.setDoubleValueField(.mouseEventPressure, value: 2.0)
+        return (down, up)
+    }
+
+    @MainActor
+    static func dragEvents(
+        from start: CGPoint,
+        to end: CGPoint,
+        button: MouseButton,
+        steps requestedSteps: Int,
+        makeEvent: MouseEventFactory = InputDriver.makeMouseEvent) throws -> (
+        down: CGEvent,
+        moves: [CGEvent],
+        up: CGEvent)
+    {
+        let steps = max(1, requestedSteps)
+        let eventKinds = button.eventKinds
+        guard let down = makeEvent(eventKinds.down, start, eventKinds.button) else {
+            throw UIAutomationError.failedToCreateEvent
+        }
+
+        var moves: [CGEvent] = []
+        moves.reserveCapacity(steps)
+        for index in 1...steps {
+            let progress = CGFloat(index) / CGFloat(steps)
+            let position = CGPoint(
+                x: start.x + (end.x - start.x) * progress,
+                y: start.y + (end.y - start.y) * progress)
+            guard let move = makeEvent(eventKinds.dragged, position, eventKinds.button) else {
+                throw UIAutomationError.failedToCreateEvent
+            }
+            moves.append(move)
+        }
+
+        guard let up = makeEvent(eventKinds.up, end, eventKinds.button) else {
+            throw UIAutomationError.failedToCreateEvent
+        }
+        return (down, moves, up)
+    }
+
+    @MainActor
+    static func refreshTimestamp(
+        _ event: CGEvent,
+        timestamp: CGEventTimestamp = DispatchTime.now().uptimeNanoseconds)
+    {
+        event.timestamp = timestamp
+    }
+
+    @MainActor
+    private static func makeMouseEvent(
+        type: CGEventType,
+        point: CGPoint,
+        button: CGMouseButton) -> CGEvent?
+    {
+        CGEvent(
             mouseEventSource: nil,
-            mouseType: upType,
-            mouseCursorPosition: end,
-            mouseButton: buttonType)
-        else { throw UIAutomationError.failedToCreateEvent }
-        up.post(tap: .cghidEventTap)
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: button)
     }
 
     /// Scroll by deltas (line-based). Positive `deltaY` scrolls up.

--- a/Tests/AXorcistTests/ClickEventGenerationTests.swift
+++ b/Tests/AXorcistTests/ClickEventGenerationTests.swift
@@ -38,4 +38,18 @@ struct ClickEventGenerationTests {
         #expect(pairs[1].down.getIntegerValueField(.mouseEventClickState) == 2)
         #expect(pairs[1].up.getIntegerValueField(.mouseEventClickState) == 2)
     }
+
+    @Test
+    @MainActor
+    func `Middle click uses other mouse events and the center button`() throws {
+        let pairs = try Element.buildClickEventPairs(
+            at: CGPoint(x: 10, y: 20),
+            button: .middle,
+            clickCount: 1)
+
+        #expect(pairs[0].down.type == .otherMouseDown)
+        #expect(pairs[0].up.type == .otherMouseUp)
+        #expect(pairs[0].down.getIntegerValueField(.mouseEventButtonNumber) == 2)
+        #expect(pairs[0].up.getIntegerValueField(.mouseEventButtonNumber) == 2)
+    }
 }

--- a/Tests/AXorcistTests/InputDriverTests.swift
+++ b/Tests/AXorcistTests/InputDriverTests.swift
@@ -14,9 +14,109 @@ struct InputDriverTests {
     @Test
     func `cachedLocation populates cache when empty`() {
         var cache: CGPoint?
-        _ = InputDriver.cachedLocation(using: &cache)
-        // If running in CI without UI, location may be nil; just assert cache mirrors result.
-        #expect(cache == InputDriver.currentLocation())
+        let result = InputDriver.cachedLocation(using: &cache)
+        #expect(cache == result)
+    }
+
+    @Test
+    func `mouse button event kinds preserve all three buttons`() {
+        #expect(MouseButton.left.eventKinds == MouseButtonEventKinds(
+            button: .left,
+            down: .leftMouseDown,
+            dragged: .leftMouseDragged,
+            up: .leftMouseUp))
+        #expect(MouseButton.right.eventKinds == MouseButtonEventKinds(
+            button: .right,
+            down: .rightMouseDown,
+            dragged: .rightMouseDragged,
+            up: .rightMouseUp))
+        #expect(MouseButton.middle.eventKinds == MouseButtonEventKinds(
+            button: .center,
+            down: .otherMouseDown,
+            dragged: .otherMouseDragged,
+            up: .otherMouseUp))
+    }
+
+    @Test
+    @MainActor
+    func `right drag prebuilds the complete matching event sequence`() throws {
+        let events = try InputDriver.dragEvents(
+            from: CGPoint(x: 10, y: 20),
+            to: CGPoint(x: 30, y: 40),
+            button: .right,
+            steps: 2)
+
+        #expect(events.down.type == .rightMouseDown)
+        #expect(events.moves.map(\.type) == [.rightMouseDragged, .rightMouseDragged])
+        #expect(events.up.type == .rightMouseUp)
+    }
+
+    @Test
+    @MainActor
+    func `drag allocation failure returns no partial sequence`() {
+        var creationCount = 0
+        do {
+            _ = try InputDriver.dragEvents(
+                from: CGPoint(x: 10, y: 20),
+                to: CGPoint(x: 30, y: 40),
+                button: .middle,
+                steps: 3,
+                makeEvent: { type, point, button in
+                    creationCount += 1
+                    guard creationCount < 3 else { return nil }
+                    return CGEvent(
+                        mouseEventSource: nil,
+                        mouseType: type,
+                        mouseCursorPosition: point,
+                        mouseButton: button)
+                })
+            Issue.record("Expected drag event creation to fail")
+        } catch UIAutomationError.failedToCreateEvent {
+            // Expected: the builder returns no sequence for a caller to post.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(creationCount == 3)
+    }
+
+    @Test
+    @MainActor
+    func `press hold allocation failure returns before posting`() {
+        var creationCount = 0
+        do {
+            _ = try InputDriver.pressHoldEvents(
+                at: CGPoint(x: 10, y: 20),
+                button: .middle,
+                makeEvent: { type, point, button in
+                    creationCount += 1
+                    guard creationCount == 1 else { return nil }
+                    return CGEvent(
+                        mouseEventSource: nil,
+                        mouseType: type,
+                        mouseCursorPosition: point,
+                        mouseButton: button)
+                })
+            Issue.record("Expected press-hold event creation to fail")
+        } catch UIAutomationError.failedToCreateEvent {
+            // Expected: mouse-down is never returned to the caller on partial allocation.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+        #expect(creationCount == 2)
+    }
+
+    @Test
+    @MainActor
+    func `preallocated mouse events can be timestamped at delivery`() throws {
+        let events = try InputDriver.pressHoldEvents(
+            at: CGPoint(x: 10, y: 20),
+            button: .left)
+
+        InputDriver.refreshTimestamp(events.down, timestamp: 100)
+        InputDriver.refreshTimestamp(events.up, timestamp: 200)
+
+        #expect(events.down.timestamp == 100)
+        #expect(events.up.timestamp == 200)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- map left, right, and middle buttons to their matching Core Graphics down, drag, and up event families
- allocate complete press-hold and drag sequences before posting the first event, preventing partial allocation from leaving a button held down
- refresh preallocated event timestamps immediately before delivery so requested hold and drag timing remains observable
- make the cursor-cache fixture compare against its own read instead of a second physical-cursor sample

## Proof

- focused click/input tests: 15
- full suite: 93 tests
- Debug and Release builds
- SwiftFormat and strict SwiftLint: zero violations
- native-only source and policy gates
- final P0-P2 review clean at 0.97
