### PR TITLE
fix(targeting): fail closed on exact PID input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.
 - Preserve middle and right mouse-button identity across clicks, holds, and drags, and build complete input sequences before posting so allocation failures cannot leave a button held down.
 - Resolve each architecture from SwiftPM's reported output when building universal release artifacts instead of assuming a fixed build directory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add a typed native setter for accessibility selected-text ranges.
 
 ### Fixed
+- Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.
 - Preserve middle and right mouse-button identity across clicks, holds, and drags, and build complete input sequences before posting so allocation failures cannot leave a button held down.
 - Resolve each architecture from SwiftPM's reported output when building universal release artifacts instead of assuming a fixed build directory.
 - Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.

--- a/Package.swift
+++ b/Package.swift
@@ -65,6 +65,12 @@ let package = Package(
             swiftSettings: approachableConcurrencySettings
             // Sources will be inferred by SPM
         ),
+        .testTarget(
+            name: "AXorcistCommandConversionTests",
+            dependencies: ["AXorcist", "axorc"],
+            path: "Tests/AXorcistCommandConversionTests",
+            swiftSettings: approachableConcurrencySettings
+        ),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/Sources/AXorcist/Core/AXCommands.swift
+++ b/Sources/AXorcist/Core/AXCommands.swift
@@ -171,7 +171,25 @@ public struct QueryCommand: Sendable {
         maxDepthForSearch: Int = 10,
         includeChildrenBrief: Bool? = nil)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            attributesToReturn: attributesToReturn,
+            maxDepthForSearch: maxDepthForSearch,
+            includeChildrenBrief: includeChildrenBrief,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        attributesToReturn: [String]? = nil,
+        maxDepthForSearch: Int = 10,
+        includeChildrenBrief: Bool? = nil,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.attributesToReturn = attributesToReturn
         self.maxDepthForSearch = maxDepthForSearch
@@ -181,6 +199,7 @@ public struct QueryCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let attributesToReturn: [String]?
     public let maxDepthForSearch: Int
@@ -197,7 +216,25 @@ public struct PerformActionCommand: Sendable {
         value: AnyCodable? = nil,
         maxDepthForSearch: Int = 10)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            action: action,
+            value: value,
+            maxDepthForSearch: maxDepthForSearch,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        action: String,
+        value: AnyCodable? = nil,
+        maxDepthForSearch: Int = 10,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.action = action
         self.value = value
@@ -207,6 +244,7 @@ public struct PerformActionCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let action: String
     public let value: AnyCodable?
@@ -217,7 +255,23 @@ public struct GetAttributesCommand: Sendable {
     // MARK: Lifecycle
 
     public init(appIdentifier: String?, locator: Locator, attributes: [String], maxDepthForSearch: Int = 10) {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            attributes: attributes,
+            maxDepthForSearch: maxDepthForSearch,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        attributes: [String],
+        maxDepthForSearch: Int = 10,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.attributes = attributes
         self.maxDepthForSearch = maxDepthForSearch
@@ -226,6 +280,7 @@ public struct GetAttributesCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let attributes: [String]
     public let maxDepthForSearch: Int
@@ -243,7 +298,29 @@ public struct DescribeElementCommand: Sendable {
         includeIgnored: Bool = false,
         maxSearchDepth: Int = 10)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            formatOption: formatOption,
+            maxDepthForSearch: maxDepthForSearch,
+            depth: depth,
+            includeIgnored: includeIgnored,
+            maxSearchDepth: maxSearchDepth,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        formatOption: ValueFormatOption = .smart,
+        maxDepthForSearch: Int = 10,
+        depth: Int = 3,
+        includeIgnored: Bool = false,
+        maxSearchDepth: Int = 10,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.formatOption = formatOption
         self.maxDepthForSearch = maxDepthForSearch
@@ -255,6 +332,7 @@ public struct DescribeElementCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let formatOption: ValueFormatOption
     public let maxDepthForSearch: Int
@@ -273,7 +351,25 @@ public struct ExtractTextCommand: Sendable {
         includeChildren: Bool? = nil,
         maxDepth: Int? = nil)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            maxDepthForSearch: maxDepthForSearch,
+            includeChildren: includeChildren,
+            maxDepth: maxDepth,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        maxDepthForSearch: Int = 10,
+        includeChildren: Bool? = nil,
+        maxDepth: Int? = nil,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.maxDepthForSearch = maxDepthForSearch
         self.includeChildren = includeChildren
@@ -283,6 +379,7 @@ public struct ExtractTextCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let maxDepthForSearch: Int
     public let includeChildren: Bool?
@@ -293,7 +390,23 @@ public struct SetFocusedValueCommand: Sendable {
     // MARK: Lifecycle
 
     public init(appIdentifier: String?, locator: Locator, value: String, maxDepthForSearch: Int = 10) {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            value: value,
+            maxDepthForSearch: maxDepthForSearch,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator,
+        value: String,
+        maxDepthForSearch: Int = 10,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.value = value
         self.maxDepthForSearch = maxDepthForSearch
@@ -302,6 +415,7 @@ public struct SetFocusedValueCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator
     public let value: String
     public let maxDepthForSearch: Int
@@ -357,7 +471,21 @@ public struct GetFocusedElementCommand: Sendable {
     // MARK: Lifecycle
 
     public init(appIdentifier: String?, attributesToReturn: [String]? = nil, includeChildrenBrief: Bool? = nil) {
+        self.init(
+            appIdentifier: appIdentifier,
+            attributesToReturn: attributesToReturn,
+            includeChildrenBrief: includeChildrenBrief,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        attributesToReturn: [String]? = nil,
+        includeChildrenBrief: Bool? = nil,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.attributesToReturn = attributesToReturn
         self.includeChildrenBrief = includeChildrenBrief
     }
@@ -365,6 +493,7 @@ public struct GetFocusedElementCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let attributesToReturn: [String]?
     public let includeChildrenBrief: Bool?
 }
@@ -382,7 +511,31 @@ public struct ObserveCommand: Sendable {
         includeElementDetails: [String]? = nil,
         maxDepthForSearch: Int = 10)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            locator: locator,
+            notifications: notifications,
+            includeDetails: includeDetails,
+            watchChildren: watchChildren,
+            notificationName: notificationName,
+            includeElementDetails: includeElementDetails,
+            maxDepthForSearch: maxDepthForSearch,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String?,
+        locator: Locator? = nil,
+        notifications: [String],
+        includeDetails: Bool = true,
+        watchChildren: Bool = false,
+        notificationName: AXNotification,
+        includeElementDetails: [String]? = nil,
+        maxDepthForSearch: Int = 10,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.locator = locator
         self.notifications = notifications
         self.includeDetails = includeDetails
@@ -395,6 +548,7 @@ public struct ObserveCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let locator: Locator?
     public let notifications: [String]
     public let includeDetails: Bool
@@ -409,13 +563,31 @@ public struct CollectAllCommand: Sendable {
     // MARK: Lifecycle
 
     public init(
-        appIdentifier: String? = nil, // Provide default nil
+        appIdentifier: String? = nil,
         attributesToReturn: [String]? = nil,
         maxDepth: Int = 10,
         filterCriteria: [String: String]? = nil,
         valueFormatOption: ValueFormatOption? = .smart)
     {
+        self.init(
+            appIdentifier: appIdentifier,
+            attributesToReturn: attributesToReturn,
+            maxDepth: maxDepth,
+            filterCriteria: filterCriteria,
+            valueFormatOption: valueFormatOption,
+            pid: nil)
+    }
+
+    public init(
+        appIdentifier: String? = nil, // Provide default nil
+        attributesToReturn: [String]? = nil,
+        maxDepth: Int = 10,
+        filterCriteria: [String: String]? = nil,
+        valueFormatOption: ValueFormatOption? = .smart,
+        pid: Int?)
+    {
         self.appIdentifier = appIdentifier
+        self.pid = pid
         self.attributesToReturn = attributesToReturn
         self.maxDepth = maxDepth
         self.filterCriteria = filterCriteria
@@ -425,6 +597,7 @@ public struct CollectAllCommand: Sendable {
     // MARK: Public
 
     public let appIdentifier: String?
+    public let pid: Int?
     public let attributesToReturn: [String]?
     public let maxDepth: Int
     public let filterCriteria: [String: String]? // JSON string for criteria, or can be decoded

--- a/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
@@ -17,20 +17,18 @@ extension AXorcist {
     public func handlePerformAction(command: PerformActionCommand) -> AXResponse {
         self.logPerformActionStart(command)
 
-        let appIdentifier = command.appIdentifier ?? "focused"
-        let (foundElement, errorMessage) = findTargetElement(
-            for: appIdentifier,
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: command.maxDepthForSearch)
-
-        guard let element = foundElement else {
-            let fallback = missingElementMessage(
-                prefix: "HandlePerformAction",
-                appIdentifier: appIdentifier,
-                locatorDescription: String(describing: command.locator))
-            let message = errorMessage ?? fallback
-            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
-            return .errorResponse(message: message, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
 
         return self.executeResolvedAction(command: command, on: element)
@@ -41,20 +39,18 @@ extension AXorcist {
     public func handleSetFocusedValue(command: SetFocusedValueCommand) -> AXResponse {
         self.logSetFocusedValueStart(command)
 
-        let appIdentifier = command.appIdentifier ?? "focused"
-        let (foundElement, errorMessage) = findTargetElement(
-            for: appIdentifier,
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: command.maxDepthForSearch)
-
-        guard let element = foundElement else {
-            let fallback = missingElementMessage(
-                prefix: "HandleSetFocusedValue",
-                appIdentifier: appIdentifier,
-                locatorDescription: String(describing: command.locator))
-            let message = errorMessage ?? fallback
-            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
-            return .errorResponse(message: message, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
 
         if self.ensureFocusCapability(for: element) {
@@ -73,16 +69,18 @@ extension AXorcist {
                 "IncludeChildren: \(String(describing: command.includeChildren)), " +
                 "MaxDepth: \(String(describing: command.maxDepth))"))
 
-        let (foundElement, error) = findTargetElement(
-            for: command.appIdentifier ?? "focused",
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: command.maxDepthForSearch)
-
-        guard let element = foundElement else {
-            let errorMessage = error ?? "HandleExtractText: Element not found for app " +
-                "'\(String(describing: command.appIdentifier))' with locator \(command.locator)."
-            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
-            return .errorResponse(message: errorMessage, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .debug,
@@ -292,9 +290,5 @@ extension AXorcist {
                 "HandleSetFocusedValue: Failed to set kAXFocusedAttribute for \(elementDescription),",
                 "but proceeding to set value.",
             ].joined(separator: " ")))
-    }
-
-    private func missingElementMessage(prefix: String, appIdentifier: String, locatorDescription: String) -> String {
-        "\(prefix): Element not found for app '\(appIdentifier)' with locator \(locatorDescription)."
     }
 }

--- a/Sources/AXorcist/Core/AXorcist+FocusedElementHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+FocusedElementHandler.swift
@@ -18,12 +18,13 @@ extension AXorcist {
             level: .info,
             message: "HandleGetFocused: App '\(appInfo)', Attributes: \(attributes)"))
 
-        guard let appElement = getApplicationElement(for: command.appIdentifier ?? "focused") else {
-            let target = String(describing: command.appIdentifier)
-            let errorMessage =
-                "HandleGetFocused: Could not get application element for '\(target)'."
-            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
-            return .errorResponse(message: errorMessage, code: .elementNotFound)
+        let appElement: Element
+        switch resolveApplicationTarget(appIdentifier: command.appIdentifier, pid: command.pid) {
+        case let .success(resolvedTarget):
+            appElement = resolvedTarget.element
+        case let .failure(error):
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
         let appDescription = appElement.briefDescription(option: ValueFormatOption.smart)
         GlobalAXLogger.shared.log(AXLogEntry(

--- a/Sources/AXorcist/Core/AXorcist+GetElementAtPointHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+GetElementAtPointHandler.swift
@@ -4,17 +4,43 @@ import Foundation
 @MainActor
 extension AXorcist {
     public func handleGetElementAtPoint(command: GetElementAtPointCommand) -> AXResponse {
+        self.executeGetElementAtPoint(
+            command: command,
+            applicationResolver: nativeApplicationElement,
+            elementResolver: Element.elementAtPoint)
+    }
+
+    func executeGetElementAtPoint(
+        command: GetElementAtPointCommand,
+        applicationResolver: AXApplicationElementResolver,
+        elementResolver: (CGPoint, pid_t) -> Element?) -> AXResponse
+    {
         self.logGetPointRequest(command)
 
-        guard let appElement = self.applicationElement(for: command) else {
-            return self.applicationContextError(command: command)
+        let resolvedTarget: AXResolvedApplicationTarget
+        switch resolveApplicationTarget(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
+            using: applicationResolver)
+        {
+        case let .success(target):
+            resolvedTarget = target
+        case let .failure(error):
+            return error.response
         }
 
-        self.logContextElement(appElement)
+        self.logContextElement(resolvedTarget.element)
 
-        let pid: pid_t = command.pid.map(pid_t.init) ?? appElement.pid() ?? 0
-        guard let element = Element.elementAtPoint(command.point, pid: pid) else {
-            return self.noElementResponse(command: command)
+        guard let pid = resolvedTarget.element.pid(), pid > 0 else {
+            return AXCommandTargetError.applicationNotFound(
+                "Could not determine the PID for \(resolvedTarget.target.description).").response
+        }
+        guard let element = elementResolver(command.point, pid) else {
+            return self.noElementResponse(command: command, target: resolvedTarget.target)
+        }
+        guard element.pid() == pid else {
+            return AXCommandTargetError.elementNotFound(
+                "The element at the requested point did not belong to \(resolvedTarget.target.description).").response
         }
 
         self.logLocatedElement(element)
@@ -29,33 +55,19 @@ extension AXorcist {
         GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: message))
     }
 
-    private func applicationElement(for command: GetElementAtPointCommand) -> Element? {
-        getApplicationElement(for: command.appIdentifier ?? "focused")
-    }
-
-    private func applicationContextError(command: GetElementAtPointCommand) -> AXResponse {
-        let target = command.appIdentifier ?? "focused"
-        let message = """
-        HandleGetElementAtPoint: Could not get application element for '\(target)'.
-        Application context is required even though elementAtPoint is system-wide.
-        """
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: message))
-        return .errorResponse(message: message, code: .elementNotFound)
-    }
-
     private func logContextElement(_ element: Element) {
         let description = element.briefDescription(option: .smart)
         GlobalAXLogger.shared.log(AXLogEntry(level: .debug, message: "Context app element: \(description)"))
     }
 
-    private func noElementResponse(command: GetElementAtPointCommand) -> AXResponse {
-        let target = command.appIdentifier ?? "focused"
+    private func noElementResponse(
+        command: GetElementAtPointCommand,
+        target: AXApplicationTarget) -> AXResponse
+    {
         let point = "[\(command.point.x), \(command.point.y)]"
-        let message = "No UI element found at \(point) for app '\(target)'."
+        let message = "No UI element found at \(point) for \(target.description)."
         GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: message))
-        let payload = NoElementAtPointPayload(message: message, element: nil)
-        return .successResponse(payload: AnyCodable(payload))
+        return .errorResponse(message: message, code: .elementNotFound)
     }
 
     private func logLocatedElement(_ element: Element) {
@@ -74,9 +86,4 @@ extension AXorcist {
             fullAXDescription: element.briefDescription(option: .stringified),
             path: element.generatePathString().components(separatedBy: " -> "))
     }
-}
-
-private struct NoElementAtPointPayload: Codable {
-    let message: String
-    let element: AXElementData?
 }

--- a/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
@@ -14,21 +14,22 @@ extension AXorcist {
     public func handleObserve(command: ObserveCommand) -> AXResponse {
         self.logObservationStart(command)
 
-        let appIdentifier = command.appIdentifier ?? "focused"
         let locator = command.locator ?? Locator(criteria: [
             Criterion(attribute: "AXRole", value: AXRoleNames.kAXApplicationRole, matchType: .exact),
         ])
 
-        let (targetElement, error) = self.resolveObservationTarget(
-            appIdentifier: appIdentifier,
+        let elementToObserve: Element
+        switch self.resolveObservationTarget(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: locator,
             maxDepth: command.maxDepthForSearch)
-
-        guard let elementToObserve = targetElement else {
-            return self.observationNotFoundResponse(
-                appIdentifier: appIdentifier,
-                locator: locator,
-                error: error)
+        {
+        case let .success(resolvedElement):
+            elementToObserve = resolvedElement
+        case let .failure(error):
+            GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
 
         self.logObservationTarget(elementToObserve)
@@ -56,20 +57,6 @@ extension AXorcist {
             element.briefDescription(option: ValueFormatOption.smart),
         ].joined(separator: " ")
         GlobalAXLogger.shared.log(AXLogEntry(level: .debug, message: message))
-    }
-
-    private func observationNotFoundResponse(
-        appIdentifier: String,
-        locator: Locator,
-        error: String?) -> AXResponse
-    {
-        let fallback = [
-            "HandleObserve: Element to observe not found for app '\(appIdentifier)'",
-            "locator \(String(describing: locator))",
-        ].joined(separator: ", ")
-        let errorMessage = error ?? fallback
-        GlobalAXLogger.shared.log(AXLogEntry(level: .error, message: errorMessage))
-        return .errorResponse(message: errorMessage, code: .elementNotFound)
     }
 
     private func startObservation(

--- a/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
@@ -28,7 +28,6 @@ extension AXorcist {
             "HandleQuery: App '\(command.appIdentifier ?? "focused")'",
             "Locator: \(command.locator)")
 
-        let appIdentifier = command.appIdentifier ?? "focused"
         let resolvedMaxDepth = externalMaxDepth ?? 10
 
         // DEBUG LOG FOR MAX DEPTH
@@ -37,16 +36,18 @@ extension AXorcist {
             "HandleQuery: externalMaxDepth = \(String(describing: externalMaxDepth))",
             "resolved maxDepth = \(resolvedMaxDepth)")
 
-        let (foundElement, findError) = findTargetElement(
-            for: appIdentifier,
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: resolvedMaxDepth)
-
-        guard let element = foundElement else {
-            let errorMessage = findError ??
-                "HandleQuery: Element not found for app '\(appIdentifier)' with locator \(command.locator)."
-            self.logQuery(.error, errorMessage)
-            return .errorResponse(message: errorMessage, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            self.logQuery(.error, error.message)
+            return error.response
         }
         self.logQuery(
             .debug,
@@ -71,19 +72,18 @@ extension AXorcist {
             "Locator: \(command.locator)",
             "Attributes: \(command.attributes.joined(separator: ", "))")
 
-        let (foundElement, findError) = findTargetElement(
-            for: command.appIdentifier ?? "focused",
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: command.maxDepthForSearch)
-
-        guard let element = foundElement else {
-            let fallbackError = [
-                "HandleGetAttrs: Element not found for app '\(command.appIdentifier ?? "focused")'",
-                "Locator: \(command.locator)",
-            ].joined(separator: ", ")
-            let errorMessage = findError ?? fallbackError
-            self.logQuery(.error, errorMessage)
-            return .errorResponse(message: errorMessage, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            self.logQuery(.error, error.message)
+            return error.response
         }
         self.logQuery(
             .debug,
@@ -126,19 +126,18 @@ extension AXorcist {
             "Depth: \(command.depth)",
             "IncludeIgnored: \(command.includeIgnored)")
 
-        let (foundElement, findError) = findTargetElement(
-            for: command.appIdentifier ?? "focused",
+        let element: Element
+        switch resolveTargetElement(
+            appIdentifier: command.appIdentifier,
+            pid: command.pid,
             locator: command.locator,
             maxDepthForSearch: command.maxSearchDepth)
-
-        guard let element = foundElement else {
-            let fallbackError = [
-                "HandleDescribe: Element not found for app '\(command.appIdentifier ?? "focused")'",
-                "Locator: \(command.locator)",
-            ].joined(separator: ", ")
-            let errorMessage = findError ?? fallbackError
-            self.logQuery(.error, errorMessage)
-            return .errorResponse(message: errorMessage, code: .elementNotFound)
+        {
+        case let .success(resolvedElement):
+            element = resolvedElement
+        case let .failure(error):
+            self.logQuery(.error, error.message)
+            return error.response
         }
         self.logQuery(
             .debug,

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -135,28 +135,13 @@ public class AXorcist {
             message: "HandleCollectAll: Starting collection for app '\(command.appIdentifier ?? "focused")' " +
                 "with maxDepth: \(command.maxDepth)"))
 
-        // Find the target application element
         let rootElement: Element
-        if let appId = command.appIdentifier, appId != "focused" {
-            // Find specific application
-            if let appPid = pid(forAppIdentifier: appId),
-               let app = Element.application(for: appPid)
-            {
-                rootElement = app
-            } else {
-                let errorMessage = "HandleCollectAll: Could not find application '\(appId)'."
-                self.logger.log(AXLogEntry(level: .error, message: errorMessage))
-                return .errorResponse(message: errorMessage, code: .applicationNotFound)
-            }
-        } else {
-            // Use focused application
-            if let app = Element.focusedApplication() {
-                rootElement = app
-            } else {
-                let errorMessage = "HandleCollectAll: No focused application found."
-                self.logger.log(AXLogEntry(level: .error, message: errorMessage))
-                return .errorResponse(message: errorMessage, code: .applicationNotFound)
-            }
+        switch resolveApplicationTarget(appIdentifier: command.appIdentifier, pid: command.pid) {
+        case let .success(resolvedTarget):
+            rootElement = resolvedTarget.element
+        case let .failure(error):
+            self.logger.log(AXLogEntry(level: .error, message: error.message))
+            return error.response
         }
 
         // Collect all elements recursively
@@ -195,15 +180,31 @@ public class AXorcist {
     // MARK: - Observation Ownership
 
     func resolveObservationTarget(
-        appIdentifier: String,
+        appIdentifier: String?,
+        pid: Int?,
         locator: Locator,
-        maxDepth: Int) -> (element: Element?, error: String?)
+        maxDepth: Int) -> Result<Element, AXCommandTargetError>
     {
-        if let observationTargetResolver = self.observationTargetResolver {
-            return observationTargetResolver(appIdentifier, locator, maxDepth)
+        let target: AXApplicationTarget
+        do {
+            target = try AXApplicationTarget(appIdentifier: appIdentifier, pid: pid)
+        } catch let error as AXCommandTargetError {
+            return .failure(error)
+        } catch {
+            return .failure(.applicationNotFound("Unable to resolve observation target."))
         }
-        return findTargetElement(
-            for: appIdentifier,
+
+        if let observationTargetResolver = self.observationTargetResolver {
+            let result = observationTargetResolver(target.lookupIdentifier, locator, maxDepth)
+            if let element = result.element {
+                return .success(element)
+            }
+            return .failure(.elementNotFound(
+                result.error ?? "Element to observe was not found in \(target.description)."))
+        }
+        return resolveTargetElement(
+            appIdentifier: appIdentifier,
+            pid: pid,
             locator: locator,
             maxDepthForSearch: maxDepth)
     }

--- a/Sources/AXorcist/Core/CommandTarget.swift
+++ b/Sources/AXorcist/Core/CommandTarget.swift
@@ -1,0 +1,156 @@
+import ApplicationServices
+import Foundation
+
+enum AXApplicationTarget: Equatable, Sendable {
+    case focused
+    case identifier(String)
+    case process(pid_t)
+
+    init(appIdentifier: String?, pid: Int?) throws {
+        if let appIdentifier, let pid {
+            throw AXCommandTargetError.conflictingSelectors(application: appIdentifier, pid: pid)
+        }
+
+        if let pid {
+            guard pid > 0, pid <= Int(pid_t.max) else {
+                throw AXCommandTargetError.invalidProcessIdentifier(pid)
+            }
+            self = .process(pid_t(pid))
+            return
+        }
+
+        guard let appIdentifier else {
+            self = .focused
+            return
+        }
+        guard !appIdentifier.isEmpty else {
+            throw AXCommandTargetError.emptyApplicationIdentifier
+        }
+        self = appIdentifier == "focused" ? .focused : .identifier(appIdentifier)
+    }
+
+    var description: String {
+        switch self {
+        case .focused:
+            "focused application"
+        case let .identifier(identifier):
+            "application '\(identifier)'"
+        case let .process(pid):
+            "process \(pid)"
+        }
+    }
+
+    var lookupIdentifier: String {
+        switch self {
+        case .focused:
+            "focused"
+        case let .identifier(identifier):
+            identifier
+        case let .process(pid):
+            String(pid)
+        }
+    }
+}
+
+enum AXCommandTargetError: Error, Equatable {
+    case conflictingSelectors(application: String, pid: Int)
+    case emptyApplicationIdentifier
+    case invalidProcessIdentifier(Int)
+    case applicationNotFound(String)
+    case elementNotFound(String)
+
+    var responseCode: AXErrorCode {
+        switch self {
+        case .conflictingSelectors, .emptyApplicationIdentifier, .invalidProcessIdentifier:
+            .invalidParameter
+        case .applicationNotFound:
+            .applicationNotFound
+        case .elementNotFound:
+            .elementNotFound
+        }
+    }
+
+    var message: String {
+        switch self {
+        case let .conflictingSelectors(application, pid):
+            "Specify either application '\(application)' or PID \(pid), not both."
+        case .emptyApplicationIdentifier:
+            "Application identifier must not be empty."
+        case let .invalidProcessIdentifier(pid):
+            "PID must be between 1 and \(pid_t.max); received \(pid)."
+        case let .applicationNotFound(target), let .elementNotFound(target):
+            target
+        }
+    }
+
+    @MainActor var response: AXResponse {
+        .errorResponse(message: self.message, code: self.responseCode)
+    }
+}
+
+struct AXResolvedApplicationTarget {
+    let target: AXApplicationTarget
+    let element: Element
+}
+
+typealias AXApplicationElementResolver = @MainActor (AXApplicationTarget) -> Element?
+
+@MainActor
+func nativeApplicationElement(for target: AXApplicationTarget) -> Element? {
+    switch target {
+    case .focused:
+        getApplicationElement(for: "focused")
+    case let .identifier(identifier):
+        getApplicationElement(for: identifier)
+    case let .process(pid):
+        Element.application(for: pid)
+    }
+}
+
+@MainActor
+func resolveApplicationTarget(
+    appIdentifier: String?,
+    pid: Int?,
+    using resolver: AXApplicationElementResolver = nativeApplicationElement)
+    -> Result<AXResolvedApplicationTarget, AXCommandTargetError>
+{
+    let target: AXApplicationTarget
+    do {
+        target = try AXApplicationTarget(appIdentifier: appIdentifier, pid: pid)
+    } catch let error as AXCommandTargetError {
+        return .failure(error)
+    } catch {
+        return .failure(.applicationNotFound("Unable to resolve application target."))
+    }
+
+    guard let element = resolver(target) else {
+        return .failure(.applicationNotFound("Could not resolve \(target.description)."))
+    }
+    return .success(AXResolvedApplicationTarget(target: target, element: element))
+}
+
+@MainActor
+func resolveTargetElement(
+    appIdentifier: String?,
+    pid: Int?,
+    locator: Locator,
+    maxDepthForSearch: Int,
+    using resolver: AXApplicationElementResolver = nativeApplicationElement)
+    -> Result<Element, AXCommandTargetError>
+{
+    switch resolveApplicationTarget(appIdentifier: appIdentifier, pid: pid, using: resolver) {
+    case let .failure(error):
+        return .failure(error)
+    case let .success(resolvedTarget):
+        let result = findTargetElement(
+            startingFrom: resolvedTarget.element,
+            targetDescription: resolvedTarget.target.description,
+            locator: locator,
+            maxDepthForSearch: maxDepthForSearch)
+        guard let element = result.element else {
+            return .failure(.elementNotFound(
+                result.error ?? "Element not found in \(resolvedTarget.target.description)."))
+        }
+        return .success(element)
+    }
+}

--- a/Sources/AXorcist/Core/Element+UIAutomation.swift
+++ b/Sources/AXorcist/Core/Element+UIAutomation.swift
@@ -169,20 +169,33 @@ extension Element {
 extension Element {
     /// Type text into this element
     @MainActor public func typeText(_ text: String, delay: TimeInterval = 0.005, clearFirst: Bool = false) throws {
-        // Focus the element first
-        if attribute(Attribute<Bool>.focused) != true {
-            // Try to focus the element
-            _ = setValue(true, forAttribute: Attribute<Bool>.focused.rawValue)
-            // Some elements can't be focused directly, that's OK
-        }
+        try self.typeText(
+            text,
+            delay: delay,
+            clearFirst: clearFirst,
+            focused: { self.attribute(Attribute<Bool>.focused) },
+            focus: { self.setValue(true, forAttribute: Attribute<Bool>.focused.rawValue) },
+            eventDispatcher: { text, delay, clearFirst in
+                if clearFirst {
+                    try self.clearField()
+                }
+                try Element.typeText(text, delay: delay)
+            })
+    }
 
-        // Clear existing text if requested
-        if clearFirst {
-            try self.clearField()
+    @MainActor
+    func typeText(
+        _ text: String,
+        delay: TimeInterval,
+        clearFirst: Bool,
+        focused: () -> Bool?,
+        focus: () -> Bool,
+        eventDispatcher: (String, TimeInterval, Bool) throws -> Void) throws
+    {
+        guard focused() == true || focus() else {
+            throw UIAutomationError.elementFocusFailed
         }
-
-        // Type the text
-        try Element.typeText(text, delay: delay)
+        try eventDispatcher(text, delay, clearFirst)
     }
 
     /// Clear the text field
@@ -815,6 +828,7 @@ extension Element {
 
 public enum UIAutomationError: Error, LocalizedError {
     case failedToCreateEvent
+    case elementFocusFailed
     case elementNotEnabled
     case elementNotActionable(timeout: TimeInterval)
     case unsupportedKey(String)
@@ -825,6 +839,8 @@ public enum UIAutomationError: Error, LocalizedError {
         switch self {
         case .failedToCreateEvent:
             "Failed to create system event"
+        case .elementFocusFailed:
+            "Failed to focus element before typing"
         case .elementNotEnabled:
             "Element is not enabled"
         case let .elementNotActionable(timeout):

--- a/Sources/AXorcist/Core/Element+UIAutomation.swift
+++ b/Sources/AXorcist/Core/Element+UIAutomation.swift
@@ -173,8 +173,10 @@ extension Element {
             text,
             delay: delay,
             clearFirst: clearFirst,
-            focused: { self.attribute(Attribute<Bool>.focused) },
-            focus: { self.setValue(true, forAttribute: Attribute<Bool>.focused.rawValue) },
+            ensureFocus: {
+                self.attribute(Attribute<Bool>.focused) == true ||
+                    self.setValue(true, forAttribute: Attribute<Bool>.focused.rawValue)
+            },
             eventDispatcher: { text, delay, clearFirst in
                 if clearFirst {
                     try self.clearField()
@@ -188,12 +190,11 @@ extension Element {
         _ text: String,
         delay: TimeInterval,
         clearFirst: Bool,
-        focused: () -> Bool?,
-        focus: () -> Bool,
+        ensureFocus: () -> Bool,
         eventDispatcher: (String, TimeInterval, Bool) throws -> Void) throws
     {
-        guard focused() == true || focus() else {
-            throw UIAutomationError.elementFocusFailed
+        guard ensureFocus() else {
+            throw ElementTypingError.focusFailed
         }
         try eventDispatcher(text, delay, clearFirst)
     }
@@ -828,7 +829,6 @@ extension Element {
 
 public enum UIAutomationError: Error, LocalizedError {
     case failedToCreateEvent
-    case elementFocusFailed
     case elementNotEnabled
     case elementNotActionable(timeout: TimeInterval)
     case unsupportedKey(String)
@@ -839,8 +839,6 @@ public enum UIAutomationError: Error, LocalizedError {
         switch self {
         case .failedToCreateEvent:
             "Failed to create system event"
-        case .elementFocusFailed:
-            "Failed to focus element before typing"
         case .elementNotEnabled:
             "Element is not enabled"
         case let .elementNotActionable(timeout):
@@ -852,5 +850,13 @@ public enum UIAutomationError: Error, LocalizedError {
         case .missingFrame:
             "Element has no frame attribute"
         }
+    }
+}
+
+enum ElementTypingError: Error, LocalizedError {
+    case focusFailed
+
+    var errorDescription: String? {
+        "Failed to focus element before typing"
     }
 }

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -60,15 +60,30 @@ public func findTargetElement(
     locator: Locator,
     maxDepthForSearch: Int) -> (element: Element?, error: String?)
 {
-    let locatorDebug = logFindTargetSetup(
-        appIdentifier: appIdentifier,
-        locator: locator,
-        maxDepth: maxDepthForSearch)
-    let pathHintDebugString = locatorDebug.pathHint
     guard let appElement = getApplicationElement(for: appIdentifier) else {
         logger.error("FTE: No app element for \(appIdentifier)")
         return (nil, "Application not found or not accessible: \(appIdentifier)")
     }
+
+    return findTargetElement(
+        startingFrom: appElement,
+        targetDescription: appIdentifier,
+        locator: locator,
+        maxDepthForSearch: maxDepthForSearch)
+}
+
+@MainActor
+func findTargetElement(
+    startingFrom appElement: Element,
+    targetDescription: String,
+    locator: Locator,
+    maxDepthForSearch: Int) -> (element: Element?, error: String?)
+{
+    let locatorDebug = logFindTargetSetup(
+        appIdentifier: targetDescription,
+        locator: locator,
+        maxDepth: maxDepthForSearch)
+    let pathHintDebugString = locatorDebug.pathHint
 
     var currentSearchElement = appElement
     var searchStartingPointDescription = "application root \(appElement.briefDescription(option: .smart))"

--- a/Sources/axorc/CommandTypeExtensions.swift
+++ b/Sources/axorc/CommandTypeExtensions.swift
@@ -42,7 +42,8 @@ extension CommandType {
                 debugPathSearch: commandEnvelope.locator?.debugPathSearch),
             attributesToReturn: commandEnvelope.attributes,
             maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
-            includeChildrenBrief: commandEnvelope.includeChildrenBrief))
+            includeChildrenBrief: commandEnvelope.includeChildrenBrief,
+            pid: commandEnvelope.pid))
     }
 
     private static func createPerformActionCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand? {
@@ -52,7 +53,8 @@ extension CommandType {
             locator: commandEnvelope.locator ?? Locator(criteria: []),
             action: actionName,
             value: commandEnvelope.actionValue,
-            maxDepthForSearch: commandEnvelope.maxDepth ?? 10))
+            maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
+            pid: commandEnvelope.pid))
     }
 
     private static func createGetAttributesCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand {
@@ -60,7 +62,8 @@ extension CommandType {
             appIdentifier: commandEnvelope.application,
             locator: commandEnvelope.locator ?? Locator(criteria: []),
             attributes: commandEnvelope.attributes ?? [],
-            maxDepthForSearch: commandEnvelope.maxDepth ?? 10))
+            maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
+            pid: commandEnvelope.pid))
     }
 
     private static func createDescribeElementCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand {
@@ -69,7 +72,8 @@ extension CommandType {
             locator: commandEnvelope.locator ?? Locator(criteria: []),
             depth: commandEnvelope.maxDepth ?? 3,
             includeIgnored: commandEnvelope.includeIgnoredElements ?? false,
-            maxSearchDepth: commandEnvelope.maxDepth ?? 10))
+            maxSearchDepth: commandEnvelope.maxDepth ?? 10,
+            pid: commandEnvelope.pid))
     }
 
     private static func createExtractTextCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand {
@@ -78,7 +82,8 @@ extension CommandType {
             locator: commandEnvelope.locator ?? Locator(criteria: []),
             maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
             includeChildren: commandEnvelope.includeChildrenInText ?? false,
-            maxDepth: commandEnvelope.maxDepth))
+            maxDepth: commandEnvelope.maxDepth,
+            pid: commandEnvelope.pid))
     }
 
     private static func createCollectAllCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand {
@@ -87,7 +92,8 @@ extension CommandType {
             attributesToReturn: commandEnvelope.attributes,
             maxDepth: commandEnvelope.maxDepth ?? 10,
             filterCriteria: commandEnvelope.filterCriteria,
-            valueFormatOption: ValueFormatOption.smart))
+            valueFormatOption: ValueFormatOption.smart,
+            pid: commandEnvelope.pid))
     }
 
     private static func createBatchCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand? {
@@ -121,7 +127,8 @@ extension CommandType {
             appIdentifier: commandEnvelope.application,
             locator: commandEnvelope.locator ?? Locator(criteria: []),
             value: value,
-            maxDepthForSearch: commandEnvelope.maxDepth ?? 10))
+            maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
+            pid: commandEnvelope.pid))
     }
 
     private static func createGetElementAtPointCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand? {
@@ -141,7 +148,8 @@ extension CommandType {
         .getFocusedElement(GetFocusedElementCommand(
             appIdentifier: commandEnvelope.application,
             attributesToReturn: commandEnvelope.attributes,
-            includeChildrenBrief: commandEnvelope.includeChildrenBrief))
+            includeChildrenBrief: commandEnvelope.includeChildrenBrief,
+            pid: commandEnvelope.pid))
     }
 
     private static func createObserveCommand(_ commandEnvelope: CommandEnvelope) -> AXCommand? {
@@ -165,6 +173,7 @@ extension CommandType {
             watchChildren: commandEnvelope.watchChildren ?? false,
             notificationName: axNotification,
             includeElementDetails: commandEnvelope.includeElementDetails,
-            maxDepthForSearch: commandEnvelope.maxDepth ?? 10))
+            maxDepthForSearch: commandEnvelope.maxDepth ?? 10,
+            pid: commandEnvelope.pid))
     }
 }

--- a/Tests/AXorcistCommandConversionTests/CommandPIDConversionTests.swift
+++ b/Tests/AXorcistCommandConversionTests/CommandPIDConversionTests.swift
@@ -1,0 +1,76 @@
+import CoreGraphics
+import Testing
+@testable import axorc
+@testable import AXorcist
+
+@Suite("Command PID conversion")
+@MainActor
+struct CommandPIDConversionTests {
+    @Test
+    func `CLI conversion preserves PID for every targeted command`() {
+        let expectedPID = 91337
+        let locator = Locator(criteria: [
+            Criterion(attribute: AXAttributeNames.kAXRoleAttribute, value: AXRoleNames.kAXButtonRole),
+        ])
+        let commands: [CommandEnvelope] = [
+            .init(commandId: "query", command: .query, locator: locator, pid: expectedPID),
+            .init(
+                commandId: "action",
+                command: .performAction,
+                locator: locator,
+                actionName: AXActionNames.kAXPressAction,
+                pid: expectedPID),
+            .init(
+                commandId: "attributes",
+                command: .getAttributes,
+                attributes: [AXAttributeNames.kAXTitleAttribute],
+                locator: locator,
+                pid: expectedPID),
+            .init(commandId: "describe", command: .describeElement, locator: locator, pid: expectedPID),
+            .init(commandId: "extract", command: .extractText, locator: locator, pid: expectedPID),
+            .init(commandId: "collect", command: .collectAll, pid: expectedPID),
+            .init(
+                commandId: "value",
+                command: .setFocusedValue,
+                locator: locator,
+                actionValue: AnyCodable("value"),
+                pid: expectedPID),
+            .init(commandId: "focused", command: .getFocusedElement, pid: expectedPID),
+            .init(
+                commandId: "observe",
+                command: .observe,
+                locator: locator,
+                pid: expectedPID,
+                notifications: [AXNotification.valueChanged.rawValue]),
+            .init(
+                commandId: "point",
+                command: .getElementAtPoint,
+                point: CGPoint(x: 1, y: 2),
+                pid: expectedPID),
+        ]
+
+        for envelope in commands {
+            guard let command = envelope.command.toAXCommand(commandEnvelope: envelope) else {
+                Issue.record("Failed to convert \(envelope.command.rawValue)")
+                continue
+            }
+            #expect(self.targetPID(in: command) == expectedPID)
+        }
+    }
+
+    private func targetPID(in command: AXCommand) -> Int? {
+        switch command {
+        case let .query(command): command.pid
+        case let .performAction(command): command.pid
+        case let .getAttributes(command): command.pid
+        case let .describeElement(command): command.pid
+        case let .extractText(command): command.pid
+        case let .setFocusedValue(command): command.pid
+        case let .getElementAtPoint(command): command.pid
+        case let .getFocusedElement(command): command.pid
+        case let .observe(command): command.pid
+        case let .collectAll(command): command.pid
+        case .batch: nil
+        }
+    }
+}

--- a/Tests/AXorcistTests/CommandTargetSafetyTests.swift
+++ b/Tests/AXorcistTests/CommandTargetSafetyTests.swift
@@ -1,0 +1,83 @@
+import ApplicationServices
+import CoreGraphics
+import Testing
+@testable import AXorcist
+
+@Suite("Command target safety")
+@MainActor
+struct CommandTargetSafetyTests {
+    @Test
+    func `point lookup rejects conflicting selectors before resolution`() {
+        var applicationResolutionCount = 0
+        var pointLookupCount = 0
+        let command = GetElementAtPointCommand(
+            point: CGPoint(x: 10, y: 20),
+            appIdentifier: "com.example.fixture",
+            pid: 42)
+
+        let response = AXorcist().executeGetElementAtPoint(
+            command: command,
+            applicationResolver: { _ in
+                applicationResolutionCount += 1
+                return nil
+            },
+            elementResolver: { _, _ in
+                pointLookupCount += 1
+                return nil
+            })
+
+        #expect(response.error?.code == .invalidParameter)
+        #expect(applicationResolutionCount == 0)
+        #expect(pointLookupCount == 0)
+    }
+
+    @Test
+    func `missing PID target cannot fall back to focused application`() {
+        let expectedPID: pid_t = 42424
+        var resolvedTarget: AXApplicationTarget?
+        var pointLookupCount = 0
+        let command = GetElementAtPointCommand(
+            point: CGPoint(x: 10, y: 20),
+            pid: Int(expectedPID))
+
+        let response = AXorcist().executeGetElementAtPoint(
+            command: command,
+            applicationResolver: { target in
+                resolvedTarget = target
+                return nil
+            },
+            elementResolver: { _, _ in
+                pointLookupCount += 1
+                return nil
+            })
+
+        #expect(resolvedTarget == .process(expectedPID))
+        #expect(response.error?.code == .applicationNotFound)
+        #expect(pointLookupCount == 0)
+    }
+
+    @Test
+    func `missing point element is an error`() {
+        let expectedPID: pid_t = 54321
+        let application = Element(AXUIElementCreateApplication(expectedPID))
+        var receivedPID: pid_t?
+        let command = GetElementAtPointCommand(
+            point: CGPoint(x: 10, y: 20),
+            pid: Int(expectedPID))
+
+        let response = AXorcist().executeGetElementAtPoint(
+            command: command,
+            applicationResolver: { target in
+                #expect(target == .process(expectedPID))
+                return application
+            },
+            elementResolver: { _, pid in
+                receivedPID = pid
+                return nil
+            })
+
+        #expect(receivedPID == expectedPID)
+        #expect(response.status == "error")
+        #expect(response.error?.code == .elementNotFound)
+    }
+}

--- a/Tests/AXorcistTests/InputDriverTests.swift
+++ b/Tests/AXorcistTests/InputDriverTests.swift
@@ -17,14 +17,13 @@ struct InputDriverTests {
                 "do not dispatch",
                 delay: 0,
                 clearFirst: true,
-                focused: { false },
-                focus: {
+                ensureFocus: {
                     focusAttempts += 1
                     return false
                 },
                 eventDispatcher: { _, _, _ in eventDispatches += 1 })
             Issue.record("Expected typing to fail before dispatch")
-        } catch UIAutomationError.elementFocusFailed {
+        } catch ElementTypingError.focusFailed {
             // Expected: no clear, delete, or text event can reach the global event tap.
         } catch {
             Issue.record("Unexpected error: \(error)")

--- a/Tests/AXorcistTests/InputDriverTests.swift
+++ b/Tests/AXorcistTests/InputDriverTests.swift
@@ -1,9 +1,39 @@
+import ApplicationServices
 import CoreGraphics
 import Testing
 @testable import AXorcist
 
 @Suite("InputDriver cursor helpers")
 struct InputDriverTests {
+    @Test
+    @MainActor
+    func `failed focus prevents every typing event`() {
+        let element = Element(AXUIElementCreateSystemWide())
+        var focusAttempts = 0
+        var eventDispatches = 0
+
+        do {
+            try element.typeText(
+                "do not dispatch",
+                delay: 0,
+                clearFirst: true,
+                focused: { false },
+                focus: {
+                    focusAttempts += 1
+                    return false
+                },
+                eventDispatcher: { _, _, _ in eventDispatches += 1 })
+            Issue.record("Expected typing to fail before dispatch")
+        } catch UIAutomationError.elementFocusFailed {
+            // Expected: no clear, delete, or text event can reach the global event tap.
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(focusAttempts == 1)
+        #expect(eventDispatches == 0)
+    }
+
     @Test
     func `cachedLocation returns cached value when present`() {
         var cache: CGPoint? = CGPoint(x: 10, y: 20)


### PR DESCRIPTION
## Summary

- refuse text entry before any global keyboard event when the target element cannot be focused
- preserve explicit PID selectors through query, action, value, observe, and point command conversion
- centralize exact app/PID target resolution so an explicit PID never falls back to the focused app
- reject conflicting app+PID selectors and return truthful application/element-not-found errors
- preserve existing public initializers through additive PID properties and overloads

## Proof

- full deterministic suite: 98 tests; live-UI suites remain skipped
- Release build
- `make check`: SwiftFormat, zero SwiftLint violations, and both native-only gates
- API digester against `377a207`: no breaking changes
- source-blind release CLI checks for conflicting selectors and nonexistent PID
- final P0-P2 review clean on the full baseline stack; one commit-relative P2 was rejected by the baseline API-digester proof
- `git diff --check`

No AppleScript or Apple Events surface was added.
