### PR TITLE
refactor(search): isolate and consolidate traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ All notable changes to AXorcist will be documented in this file.
 
 ### Added
 - Add a typed native setter for accessibility selected-text ranges.
+- Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.
+- Route the visitor, collection, element-search, UI-automation, and deep JSON-path walkers through one identity-aware traversal kernel while preserving their established order, depth, pruning, and match semantics.
 - Preserve middle and right mouse-button identity across clicks, holds, and drags, and build complete input sequences before posting so allocation failures cannot leave a button held down.
 - Resolve each architecture from SwiftPM's reported output when building universal release artifacts instead of assuming a fixed build directory.
 - Preserve attributed-string parameterized results and route both public generic accessors through one native conversion path.

--- a/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+ActionHandlers.swift
@@ -15,6 +15,13 @@ extension AXorcist {
     // MARK: - Perform Action Handler
 
     public func handlePerformAction(command: PerformActionCommand) -> AXResponse {
+        self.handlePerformAction(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handlePerformAction(
+        command: PerformActionCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logPerformActionStart(command)
 
         let element: Element
@@ -22,7 +29,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: command.maxDepthForSearch)
+            maxDepthForSearch: command.maxDepthForSearch,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement
@@ -37,6 +45,13 @@ extension AXorcist {
     // MARK: - Set Focused Value Handler
 
     public func handleSetFocusedValue(command: SetFocusedValueCommand) -> AXResponse {
+        self.handleSetFocusedValue(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleSetFocusedValue(
+        command: SetFocusedValueCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logSetFocusedValueStart(command)
 
         let element: Element
@@ -44,7 +59,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: command.maxDepthForSearch)
+            maxDepthForSearch: command.maxDepthForSearch,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement
@@ -62,6 +78,13 @@ extension AXorcist {
     // MARK: - Extract Text Handler
 
     public func handleExtractText(command: ExtractTextCommand) -> AXResponse {
+        self.handleExtractText(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleExtractText(
+        command: ExtractTextCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .info,
             message: "HandleExtractText: App '\(String(describing: command.appIdentifier))', " +
@@ -74,7 +97,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: command.maxDepthForSearch)
+            maxDepthForSearch: command.maxDepthForSearch,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement

--- a/Sources/AXorcist/Core/AXorcist+BatchHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+BatchHandler.swift
@@ -11,6 +11,13 @@ import Foundation
 @MainActor
 extension AXorcist {
     public func handleBatchCommands(command: AXBatchCommand) -> AXResponse {
+        self.handleBatchCommands(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleBatchCommands(
+        command: AXBatchCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         GlobalAXLogger.shared.log(AXLogEntry(
             level: .info,
             message: "HandleBatch: Received \(command.commands.count) sub-commands."))
@@ -24,7 +31,9 @@ extension AXorcist {
                 message: "HandleBatch: Processing sub-command \(index + 1)/\(command.commands.count): " +
                     "ID '\(subCommandEnvelope.commandID)', Type: \(subCommandEnvelope.command.type)"))
 
-            let response = self.processSingleBatchCommand(subCommandEnvelope.command)
+            let response = self.processSingleBatchCommand(
+                subCommandEnvelope.command,
+                traversalOptions: traversalOptions)
             results.append(response)
 
             if response.status != "success" {
@@ -54,53 +63,68 @@ extension AXorcist {
         }
     }
 
-    private func processSingleBatchCommand(_ command: AXCommand) -> AXResponse {
-        if let response = self.processQueryAndActionCommands(command) {
+    private func processSingleBatchCommand(
+        _ command: AXCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
+        if let response = self.processQueryAndActionCommands(command, traversalOptions: traversalOptions) {
             return response
         }
-        if let response = self.processFocusAndPointCommands(command) {
+        if let response = self.processFocusAndPointCommands(command, traversalOptions: traversalOptions) {
             return response
         }
-        return self.processBatchSpecificCommands(command)
+        return self.processBatchSpecificCommands(command, traversalOptions: traversalOptions)
     }
 
-    private func processQueryAndActionCommands(_ command: AXCommand) -> AXResponse? {
+    private func processQueryAndActionCommands(
+        _ command: AXCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse?
+    {
         switch command {
         case let .query(queryCommand):
-            handleQuery(command: queryCommand, maxDepth: queryCommand.maxDepthForSearch)
+            handleQuery(
+                command: queryCommand,
+                maxDepth: queryCommand.maxDepthForSearch,
+                traversalOptions: traversalOptions)
         case let .performAction(actionCommand):
-            handlePerformAction(command: actionCommand)
+            handlePerformAction(command: actionCommand, traversalOptions: traversalOptions)
         case let .getAttributes(getAttributesCommand):
-            handleGetAttributes(command: getAttributesCommand)
+            handleGetAttributes(command: getAttributesCommand, traversalOptions: traversalOptions)
         case let .describeElement(describeCommand):
-            handleDescribeElement(command: describeCommand)
+            handleDescribeElement(command: describeCommand, traversalOptions: traversalOptions)
         case let .extractText(extractTextCommand):
-            handleExtractText(command: extractTextCommand)
+            handleExtractText(command: extractTextCommand, traversalOptions: traversalOptions)
         case let .setFocusedValue(setFocusedValueCommand):
-            handleSetFocusedValue(command: setFocusedValueCommand)
+            handleSetFocusedValue(command: setFocusedValueCommand, traversalOptions: traversalOptions)
         default:
             nil
         }
     }
 
-    private func processFocusAndPointCommands(_ command: AXCommand) -> AXResponse? {
+    private func processFocusAndPointCommands(
+        _ command: AXCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse?
+    {
         switch command {
         case let .getElementAtPoint(getElementAtPointCommand):
             handleGetElementAtPoint(command: getElementAtPointCommand)
         case let .getFocusedElement(getFocusedElementCommand):
             handleGetFocusedElement(command: getFocusedElementCommand)
         case let .collectAll(collectAllCommand):
-            handleCollectAll(command: collectAllCommand)
+            handleCollectAll(command: collectAllCommand, traversalOptions: traversalOptions)
         default:
             nil
         }
     }
 
-    private func processBatchSpecificCommands(_ command: AXCommand) -> AXResponse {
+    private func processBatchSpecificCommands(
+        _ command: AXCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         switch command {
         case let .observe(observeCommand):
             GlobalAXLogger.shared.log(AXLogEntry(level: .info, message: "BatchProc: Processing Observe command."))
-            return handleObserve(command: observeCommand)
+            return handleObserve(command: observeCommand, traversalOptions: traversalOptions)
         case .batch:
             return .errorResponse(
                 message: "Nested batch commands are not supported within a single batch operation.",

--- a/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
+++ b/Sources/AXorcist/Core/AXorcist+ObservationHandler.swift
@@ -12,6 +12,13 @@ import Foundation
 @MainActor
 extension AXorcist {
     public func handleObserve(command: ObserveCommand) -> AXResponse {
+        self.handleObserve(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleObserve(
+        command: ObserveCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logObservationStart(command)
 
         let locator = command.locator ?? Locator(criteria: [
@@ -23,7 +30,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: locator,
-            maxDepth: command.maxDepthForSearch)
+            maxDepth: command.maxDepthForSearch,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             elementToObserve = resolvedElement

--- a/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
+++ b/Sources/AXorcist/Core/AXorcist+QueryHandlers.swift
@@ -23,6 +23,17 @@ extension AXorcist {
     // MARK: - Query Handler
 
     public func handleQuery(command: QueryCommand, maxDepth externalMaxDepth: Int?) -> AXResponse {
+        self.handleQuery(
+            command: command,
+            maxDepth: externalMaxDepth,
+            traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleQuery(
+        command: QueryCommand,
+        maxDepth externalMaxDepth: Int?,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logQuery(
             .info,
             "HandleQuery: App '\(command.appIdentifier ?? "focused")'",
@@ -41,7 +52,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: resolvedMaxDepth)
+            maxDepthForSearch: resolvedMaxDepth,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement
@@ -66,6 +78,13 @@ extension AXorcist {
     // MARK: - Get Attributes Handler
 
     public func handleGetAttributes(command: GetAttributesCommand) -> AXResponse {
+        self.handleGetAttributes(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleGetAttributes(
+        command: GetAttributesCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logQuery(
             .info,
             "HandleGetAttrs: App '\(command.appIdentifier ?? "focused")'",
@@ -77,7 +96,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: command.maxDepthForSearch)
+            maxDepthForSearch: command.maxDepthForSearch,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement
@@ -119,6 +139,13 @@ extension AXorcist {
     // MARK: - Describe Element Handler
 
     public func handleDescribeElement(command: DescribeElementCommand) -> AXResponse {
+        self.handleDescribeElement(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    public func handleDescribeElement(
+        command: DescribeElementCommand,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logQuery(
             .info,
             "HandleDescribe: App '\(command.appIdentifier ?? "focused")'",
@@ -131,7 +158,8 @@ extension AXorcist {
             appIdentifier: command.appIdentifier,
             pid: command.pid,
             locator: command.locator,
-            maxDepthForSearch: command.maxSearchDepth)
+            maxDepthForSearch: command.maxSearchDepth,
+            traversalOptions: traversalOptions)
         {
         case let .success(resolvedElement):
             element = resolvedElement

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -87,11 +87,21 @@ public class AXorcist {
     /// let response = AXorcist.shared.runCommand(envelope)
     /// ```
     public func runCommand(_ commandEnvelope: AXCommandEnvelope) -> AXResponse {
+        self.runCommand(commandEnvelope, traversalOptions: .snapshotDefaults())
+    }
+
+    /// Executes an accessibility command with an immutable request-scoped traversal policy.
+    public func runCommand(
+        _ commandEnvelope: AXCommandEnvelope,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         self.logger.log(AXLogEntry(
             level: .info,
             message: "RunCommand: ID '\(commandEnvelope.commandID)', Type: \(commandEnvelope.command.type)"))
 
-        let response = self.execute(commandEnvelope: commandEnvelope)
+        let response = self.execute(
+            commandEnvelope: commandEnvelope,
+            traversalOptions: traversalOptions)
 
         self.logger.log(AXLogEntry(
             level: .info,
@@ -130,6 +140,13 @@ public class AXorcist {
     // MARK: - CollectAll Handler (New)
 
     func handleCollectAll(command: CollectAllCommand) -> AXResponse {
+        self.handleCollectAll(command: command, traversalOptions: .snapshotDefaults())
+    }
+
+    func handleCollectAll(
+        command: CollectAllCommand,
+        traversalOptions _: AXTraversalOptions) -> AXResponse
+    {
         self.logger.log(AXLogEntry(
             level: .info,
             message: "HandleCollectAll: Starting collection for app '\(command.appIdentifier ?? "focused")' " +
@@ -144,21 +161,14 @@ public class AXorcist {
             return error.response
         }
 
-        // Collect all elements recursively
-        var collectedElements: [AXElementData] = []
-        var visitedElements: Set<UInt> = []
         let attributesToFetch = command.attributesToReturn ?? AXMiscConstants.defaultAttributesToFetch
         let collectionContext = ElementCollectionContext(
             maxDepth: command.maxDepth,
             filterCriteria: command.filterCriteria,
             attributesToFetch: attributesToFetch)
-
-        self.collectElementsRecursively(
-            element: rootElement,
-            currentDepth: 0,
-            context: collectionContext,
-            visited: &visitedElements,
-            collectedElements: &collectedElements)
+        let collectedElements = self.collectElementData(
+            from: rootElement,
+            context: collectionContext)
 
         self.logger.log(AXLogEntry(
             level: .info,
@@ -177,13 +187,37 @@ public class AXorcist {
     private let observationTargetResolver: ObservationTargetResolver?
     private var observationTokens: Set<SubscriptionToken> = []
 
+    private func collectElementData(
+        from root: Element,
+        context: ElementCollectionContext) -> [AXElementData]
+    {
+        var collectedElements: [AXElementData] = []
+        traverseAXTree(
+            from: root,
+            maxDepth: context.maxDepth,
+            visit: { element, _ in
+                let shouldInclude = context.filterCriteria.map { criteria in
+                    elementMatchesCriteria(element, criteria: criteria)
+                } ?? true
+                if shouldInclude {
+                    collectedElements.append(buildQueryResponse(
+                        element: element,
+                        attributesToFetch: context.attributesToFetch,
+                        includeChildrenBrief: false))
+                }
+                return .continue
+            })
+        return collectedElements
+    }
+
     // MARK: - Observation Ownership
 
     func resolveObservationTarget(
         appIdentifier: String?,
         pid: Int?,
         locator: Locator,
-        maxDepth: Int) -> Result<Element, AXCommandTargetError>
+        maxDepth: Int,
+        traversalOptions: AXTraversalOptions) -> Result<Element, AXCommandTargetError>
     {
         let target: AXApplicationTarget
         do {
@@ -206,7 +240,8 @@ public class AXorcist {
             appIdentifier: appIdentifier,
             pid: pid,
             locator: locator,
-            maxDepthForSearch: maxDepth)
+            maxDepthForSearch: maxDepth,
+            traversalOptions: traversalOptions)
     }
 
     func subscribeToObservation(
@@ -226,98 +261,73 @@ public class AXorcist {
         return result
     }
 
-    private func execute(commandEnvelope: AXCommandEnvelope) -> AXResponse {
-        if let response = executeQueryRelatedCommands(commandEnvelope) {
+    private func execute(
+        commandEnvelope: AXCommandEnvelope,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
+        if let response = executeQueryRelatedCommands(commandEnvelope, traversalOptions: traversalOptions) {
             return response
         }
-        if let response = executeInteractionCommands(commandEnvelope) {
+        if let response = executeInteractionCommands(commandEnvelope, traversalOptions: traversalOptions) {
             return response
         }
-        return self.executeObserverCommands(commandEnvelope)
+        return self.executeObserverCommands(commandEnvelope, traversalOptions: traversalOptions)
     }
 
-    private func executeQueryRelatedCommands(_ envelope: AXCommandEnvelope) -> AXResponse? {
+    private func executeQueryRelatedCommands(
+        _ envelope: AXCommandEnvelope,
+        traversalOptions: AXTraversalOptions) -> AXResponse?
+    {
         switch envelope.command {
         case let .query(queryCommand):
-            handleQuery(command: queryCommand, maxDepth: queryCommand.maxDepthForSearch)
+            handleQuery(
+                command: queryCommand,
+                maxDepth: queryCommand.maxDepthForSearch,
+                traversalOptions: traversalOptions)
         case let .getAttributes(getAttributesCommand):
-            handleGetAttributes(command: getAttributesCommand)
+            handleGetAttributes(command: getAttributesCommand, traversalOptions: traversalOptions)
         case let .describeElement(describeCommand):
-            handleDescribeElement(command: describeCommand)
+            handleDescribeElement(command: describeCommand, traversalOptions: traversalOptions)
         case let .collectAll(collectAllCommand):
-            self.handleCollectAll(command: collectAllCommand)
+            self.handleCollectAll(command: collectAllCommand, traversalOptions: traversalOptions)
         default:
             nil
         }
     }
 
-    private func executeInteractionCommands(_ envelope: AXCommandEnvelope) -> AXResponse? {
+    private func executeInteractionCommands(
+        _ envelope: AXCommandEnvelope,
+        traversalOptions: AXTraversalOptions) -> AXResponse?
+    {
         switch envelope.command {
         case let .performAction(actionCommand):
-            handlePerformAction(command: actionCommand)
+            handlePerformAction(command: actionCommand, traversalOptions: traversalOptions)
         case let .extractText(extractTextCommand):
-            handleExtractText(command: extractTextCommand)
+            handleExtractText(command: extractTextCommand, traversalOptions: traversalOptions)
         case let .setFocusedValue(setFocusedValueCommand):
-            handleSetFocusedValue(command: setFocusedValueCommand)
+            handleSetFocusedValue(command: setFocusedValueCommand, traversalOptions: traversalOptions)
         default:
             nil
         }
     }
 
-    private func executeObserverCommands(_ envelope: AXCommandEnvelope) -> AXResponse {
+    private func executeObserverCommands(
+        _ envelope: AXCommandEnvelope,
+        traversalOptions: AXTraversalOptions) -> AXResponse
+    {
         switch envelope.command {
         case let .batch(batchCommandEnvelope):
-            handleBatchCommands(command: batchCommandEnvelope)
+            handleBatchCommands(command: batchCommandEnvelope, traversalOptions: traversalOptions)
         case let .getElementAtPoint(getElementAtPointCommand):
             handleGetElementAtPoint(command: getElementAtPointCommand)
         case let .getFocusedElement(getFocusedElementCommand):
             handleGetFocusedElement(command: getFocusedElementCommand)
         case let .observe(observeCommand):
-            handleObserve(command: observeCommand)
+            handleObserve(command: observeCommand, traversalOptions: traversalOptions)
         default:
             .errorResponse(
                 message: "Unsupported command type: \(envelope.command.type)",
                 code: .unknownCommand)
-        }
-    }
-
-    private func collectElementsRecursively(
-        element: Element,
-        currentDepth: Int,
-        context: ElementCollectionContext,
-        visited: inout Set<UInt>,
-        collectedElements: inout [AXElementData])
-    {
-        // Check depth limit
-        guard currentDepth <= context.maxDepth else { return }
-
-        // Prevent infinite loops caused by cyclic AX hierarchies (Window → App → Window …)
-        let hashValue = CFHash(element.underlyingElement)
-        guard visited.insert(hashValue).inserted else { return }
-
-        // A filter controls which elements are returned, not which branches are traversed.
-        // Descendants can match even when their parent does not.
-        let shouldInclude = context.filterCriteria.map { criteria in
-            elementMatchesCriteria(element, criteria: criteria)
-        } ?? true
-        if shouldInclude {
-            let elementData = buildQueryResponse(
-                element: element,
-                attributesToFetch: context.attributesToFetch,
-                includeChildrenBrief: false)
-            collectedElements.append(elementData)
-        }
-
-        // Recursively collect children
-        if let children = element.children() {
-            for child in children {
-                self.collectElementsRecursively(
-                    element: child,
-                    currentDepth: currentDepth + 1,
-                    context: context,
-                    visited: &visited,
-                    collectedElements: &collectedElements)
-            }
         }
     }
 

--- a/Sources/AXorcist/Core/CommandTarget.swift
+++ b/Sources/AXorcist/Core/CommandTarget.swift
@@ -135,6 +135,7 @@ func resolveTargetElement(
     pid: Int?,
     locator: Locator,
     maxDepthForSearch: Int,
+    traversalOptions: AXTraversalOptions = .snapshotDefaults(),
     using resolver: AXApplicationElementResolver = nativeApplicationElement)
     -> Result<Element, AXCommandTargetError>
 {
@@ -146,7 +147,8 @@ func resolveTargetElement(
             startingFrom: resolvedTarget.element,
             targetDescription: resolvedTarget.target.description,
             locator: locator,
-            maxDepthForSearch: maxDepthForSearch)
+            maxDepthForSearch: maxDepthForSearch,
+            traversalOptions: traversalOptions)
         guard let element = result.element else {
             return .failure(.elementNotFound(
                 result.error ?? "Element not found in \(resolvedTarget.target.description)."))

--- a/Sources/AXorcist/Core/Element+Search.swift
+++ b/Sources/AXorcist/Core/Element+Search.swift
@@ -47,7 +47,15 @@ extension Element {
         options: ElementSearchOptions = ElementSearchOptions()) -> [Element]
     {
         var results: [Element] = []
-        self.searchElementsRecursively(matching: query, options: options, currentDepth: 0, results: &results)
+        traverseAXTree(
+            from: self,
+            maxDepth: options.maxDepth > 0 ? options.maxDepth : nil)
+        { element, _ in
+            if element.matches(query: query, options: options) {
+                results.append(element)
+            }
+            return .continue
+        }
         return results
     }
 
@@ -61,7 +69,18 @@ extension Element {
         matching query: String,
         options: ElementSearchOptions = ElementSearchOptions()) -> Element?
     {
-        self.findElementRecursively(matching: query, options: options, currentDepth: 0)
+        var result: Element?
+        traverseAXTree(
+            from: self,
+            maxDepth: options.maxDepth > 0 ? options.maxDepth : nil)
+        { element, _ in
+            guard element.matches(query: query, options: options) else {
+                return .continue
+            }
+            result = element
+            return .stop
+        }
+        return result
     }
 
     /// Search for elements by role
@@ -75,7 +94,21 @@ extension Element {
         options: ElementSearchOptions = ElementSearchOptions()) -> [Element]
     {
         var results: [Element] = []
-        self.searchElementsByRoleRecursively(role: role, options: options, currentDepth: 0, results: &results)
+        traverseAXTree(
+            from: self,
+            maxDepth: options.maxDepth > 0 ? options.maxDepth : nil)
+        { element, _ in
+            if options.visibleOnly, element.isHidden() == true {
+                return .skipChildren
+            }
+            if options.enabledOnly, element.isEnabled() == false {
+                return .skipChildren
+            }
+            if element.role() == role {
+                results.append(element)
+            }
+            return .continue
+        }
         return results
     }
 
@@ -130,106 +163,6 @@ extension Element {
 
         return false
     }
-
-    // MARK: - Private Search Methods
-
-    @MainActor
-    private func searchElementsRecursively(
-        matching query: String,
-        options: ElementSearchOptions,
-        currentDepth: Int,
-        results: inout [Element])
-    {
-        // Check depth limit
-        if options.maxDepth > 0, currentDepth > options.maxDepth {
-            return
-        }
-
-        // Check if current element matches
-        if self.matches(query: query, options: options) {
-            results.append(self)
-        }
-
-        // Search children
-        if let children = children() {
-            for child in children {
-                child.searchElementsRecursively(
-                    matching: query,
-                    options: options,
-                    currentDepth: currentDepth + 1,
-                    results: &results)
-            }
-        }
-    }
-
-    @MainActor
-    private func findElementRecursively(
-        matching query: String,
-        options: ElementSearchOptions,
-        currentDepth: Int) -> Element?
-    {
-        // Check depth limit
-        if options.maxDepth > 0, currentDepth > options.maxDepth {
-            return nil
-        }
-
-        // Check if current element matches
-        if self.matches(query: query, options: options) {
-            return self
-        }
-
-        // Search children
-        if let children = children() {
-            for child in children {
-                if let found = child.findElementRecursively(
-                    matching: query,
-                    options: options,
-                    currentDepth: currentDepth + 1)
-                {
-                    return found
-                }
-            }
-        }
-
-        return nil
-    }
-
-    @MainActor
-    private func searchElementsByRoleRecursively(
-        role: String,
-        options: ElementSearchOptions,
-        currentDepth: Int,
-        results: inout [Element])
-    {
-        // Check depth limit
-        if options.maxDepth > 0, currentDepth > options.maxDepth {
-            return
-        }
-
-        // Check visibility and enabled state if required
-        if options.visibleOnly, isHidden() == true {
-            return
-        }
-        if options.enabledOnly, isEnabled() == false {
-            return
-        }
-
-        // Check if current element has the specified role
-        if self.role() == role {
-            results.append(self)
-        }
-
-        // Search children
-        if let children = children() {
-            for child in children {
-                child.searchElementsByRoleRecursively(
-                    role: role,
-                    options: options,
-                    currentDepth: currentDepth + 1,
-                    results: &results)
-            }
-        }
-    }
 }
 
 // MARK: - Convenience Methods
@@ -256,18 +189,14 @@ extension Element {
     /// Find element by identifier
     @MainActor
     public func findElement(byIdentifier identifier: String) -> Element? {
-        if self.identifier() == identifier {
-            return self
-        }
-
-        if let children = children() {
-            for child in children {
-                if let found = child.findElement(byIdentifier: identifier) {
-                    return found
-                }
+        var result: Element?
+        traverseAXTree(from: self) { element, _ in
+            if element.identifier() == identifier {
+                result = element
+                return .stop
             }
+            return .continue
         }
-
-        return nil
+        return result
     }
 }

--- a/Sources/AXorcist/Core/Element+UIAutomation.swift
+++ b/Sources/AXorcist/Core/Element+UIAutomation.swift
@@ -764,27 +764,18 @@ extension Element {
         maxDepth: Int = 10) -> [Element]
     {
         var results: [Element] = []
-
-        // Check self
-        if self.matchesCriteria(role: role, title: title, label: label, value: value, identifier: identifier) {
-            results.append(self)
-        }
-
-        // Check children recursively
-        if maxDepth > 0 {
-            if let children = children() {
-                for child in children {
-                    results.append(contentsOf: child.findElements(
-                        role: role,
-                        title: title,
-                        label: label,
-                        value: value,
-                        identifier: identifier,
-                        maxDepth: maxDepth - 1))
-                }
+        traverseAXTree(from: self, maxDepth: max(0, maxDepth)) { element, _ in
+            if element.matchesCriteria(
+                role: role,
+                title: title,
+                label: label,
+                value: value,
+                identifier: identifier)
+            {
+                results.append(element)
             }
+            return .continue
         }
-
         return results
     }
 

--- a/Sources/AXorcist/Search/AXTraversalOptions.swift
+++ b/Sources/AXorcist/Search/AXTraversalOptions.swift
@@ -1,0 +1,77 @@
+import Foundation
+import os
+
+/// Immutable policy for one accessibility-tree traversal request.
+public nonisolated struct AXTraversalOptions: Sendable, Equatable {
+    /// The library defaults used when a caller does not provide an explicit policy.
+    public nonisolated static let standard = AXTraversalOptions(
+        timeout: 30,
+        scanAll: false,
+        stopAtFirstMatch: true)
+
+    public let timeout: TimeInterval
+    public let scanAll: Bool
+    public let stopAtFirstMatch: Bool
+
+    public nonisolated init(
+        timeout: TimeInterval = AXTraversalOptions.standard.timeout,
+        scanAll: Bool = AXTraversalOptions.standard.scanAll,
+        stopAtFirstMatch: Bool = AXTraversalOptions.standard.stopAtFirstMatch)
+    {
+        self.timeout = timeout
+        self.scanAll = scanAll
+        self.stopAtFirstMatch = stopAtFirstMatch
+    }
+
+    nonisolated static func snapshotDefaults() -> AXTraversalOptions {
+        axTraversalDefaultsStore.withLock { $0 }
+    }
+
+    nonisolated static func replaceDefaults(_ options: AXTraversalOptions) {
+        axTraversalDefaultsStore.withLock { $0 = options }
+    }
+}
+
+private nonisolated let axTraversalDefaultsStore = OSAllocatedUnfairLock(initialState: AXTraversalOptions.standard)
+
+/// Legacy process default. Prefer passing ``AXTraversalOptions`` to each request.
+@available(*, deprecated, message: "Pass AXTraversalOptions to each traversal request instead.")
+public nonisolated var axorcTraversalTimeout: TimeInterval {
+    get { AXTraversalOptions.snapshotDefaults().timeout }
+    set {
+        axTraversalDefaultsStore.withLock {
+            $0 = AXTraversalOptions(
+                timeout: newValue,
+                scanAll: $0.scanAll,
+                stopAtFirstMatch: $0.stopAtFirstMatch)
+        }
+    }
+}
+
+/// Legacy process default. Prefer passing ``AXTraversalOptions`` to each request.
+@available(*, deprecated, message: "Pass AXTraversalOptions to each traversal request instead.")
+public nonisolated var axorcScanAll: Bool {
+    get { AXTraversalOptions.snapshotDefaults().scanAll }
+    set {
+        axTraversalDefaultsStore.withLock {
+            $0 = AXTraversalOptions(
+                timeout: $0.timeout,
+                scanAll: newValue,
+                stopAtFirstMatch: $0.stopAtFirstMatch)
+        }
+    }
+}
+
+/// Legacy process default. Prefer passing ``AXTraversalOptions`` to each request.
+@available(*, deprecated, message: "Pass AXTraversalOptions to each traversal request instead.")
+public nonisolated var axorcStopAtFirstMatch: Bool {
+    get { AXTraversalOptions.snapshotDefaults().stopAtFirstMatch }
+    set {
+        axTraversalDefaultsStore.withLock {
+            $0 = AXTraversalOptions(
+                timeout: $0.timeout,
+                scanAll: $0.scanAll,
+                stopAtFirstMatch: newValue)
+        }
+    }
+}

--- a/Sources/AXorcist/Search/AXTreeTraversal.swift
+++ b/Sources/AXorcist/Search/AXTreeTraversal.swift
@@ -32,10 +32,17 @@ private struct AXTraversalPendingElement {
     let depth: Int
 }
 
+private enum AXTraversalVisitDisposition {
+    case continueTraversal
+    case skipChildren
+    case stop
+}
+
 private struct AXTraversalState {
     var pending: [AXTraversalPendingElement]
     var breadthIndex = 0
-    var visited = Set<Element>()
+    var visitDispositions: [Element: AXTraversalVisitDisposition] = [:]
+    var shallowestExpandedDepth: [Element: Int] = [:]
 
     init(root: Element, initialDepth: Int) {
         self.pending = [AXTraversalPendingElement(element: root, depth: initialDepth)]
@@ -75,6 +82,38 @@ private struct AXTraversalState {
             AXTraversalPendingElement(element: $0, depth: parentDepth + 1)
         })
     }
+
+    mutating func visitDisposition(
+        for pendingElement: AXTraversalPendingElement,
+        visit: (Element, Int) -> TreeVisitorResult) -> AXTraversalVisitDisposition
+    {
+        if let disposition = self.visitDispositions[pendingElement.element] {
+            return disposition
+        }
+        let disposition: AXTraversalVisitDisposition = switch visit(
+            pendingElement.element,
+            pendingElement.depth)
+        {
+        case .continue:
+            .continueTraversal
+        case .skipChildren:
+            .skipChildren
+        case .stop:
+            .stop
+        }
+        self.visitDispositions[pendingElement.element] = disposition
+        return disposition
+    }
+
+    mutating func shouldExpand(_ pendingElement: AXTraversalPendingElement) -> Bool {
+        if let previousDepth = self.shallowestExpandedDepth[pendingElement.element],
+           previousDepth <= pendingElement.depth
+        {
+            return false
+        }
+        self.shallowestExpandedDepth[pendingElement.element] = pendingElement.depth
+        return true
+    }
 }
 
 /// The single identity-aware tree walker used by AXorcist's downward traversal surfaces.
@@ -108,23 +147,21 @@ func traverseAXTree(
         if let maxDepth, next.depth > maxDepth {
             continue
         }
-        guard state.visited.insert(next.element).inserted else {
-            continue
-        }
-
-        let visitResult = visit(next.element, next.depth)
-        switch visitResult {
+        switch state.visitDisposition(for: next, visit: visit) {
         case .stop:
             stopped = true
         case .skipChildren:
             continue
-        case .continue:
+        case .continueTraversal:
             break
         }
         if stopped {
             break
         }
         guard shouldDescend(next.element, next.depth) else {
+            continue
+        }
+        guard state.shouldExpand(next) else {
             continue
         }
         if let maxDepth, next.depth >= maxDepth {
@@ -138,7 +175,7 @@ func traverseAXTree(
     }
 
     return AXTraversalResult(
-        visitedCount: state.visited.count,
+        visitedCount: state.visitDispositions.count,
         timedOut: timedOut,
         stopped: stopped)
 }

--- a/Sources/AXorcist/Search/AXTreeTraversal.swift
+++ b/Sources/AXorcist/Search/AXTreeTraversal.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+enum AXTraversalOrder {
+    case depthFirst
+    case breadthFirst
+}
+
+struct AXTraversalResult {
+    let visitedCount: Int
+    let timedOut: Bool
+    let stopped: Bool
+}
+
+typealias AXTraversalClock = @MainActor () -> TimeInterval
+typealias AXTraversalChildrenProvider = @MainActor (Element, Bool) -> [Element]?
+
+struct AXTraversalExecutionPolicy {
+    let options: AXTraversalOptions
+    let now: AXTraversalClock
+
+    init(
+        options: AXTraversalOptions,
+        now: @escaping AXTraversalClock = { ProcessInfo.processInfo.systemUptime })
+    {
+        self.options = options
+        self.now = now
+    }
+}
+
+private struct AXTraversalPendingElement {
+    let element: Element
+    let depth: Int
+}
+
+private struct AXTraversalState {
+    var pending: [AXTraversalPendingElement]
+    var breadthIndex = 0
+    var visited = Set<Element>()
+
+    init(root: Element, initialDepth: Int) {
+        self.pending = [AXTraversalPendingElement(element: root, depth: initialDepth)]
+    }
+
+    func hasPending(order: AXTraversalOrder) -> Bool {
+        switch order {
+        case .depthFirst:
+            !self.pending.isEmpty
+        case .breadthFirst:
+            self.breadthIndex < self.pending.count
+        }
+    }
+
+    mutating func removeNext(order: AXTraversalOrder) -> AXTraversalPendingElement {
+        switch order {
+        case .depthFirst:
+            return self.pending.removeLast()
+        case .breadthFirst:
+            defer { self.breadthIndex += 1 }
+            return self.pending[self.breadthIndex]
+        }
+    }
+
+    mutating func appendChildren(
+        _ children: [Element],
+        parentDepth: Int,
+        order: AXTraversalOrder)
+    {
+        let orderedChildren: [Element] = switch order {
+        case .depthFirst:
+            Array(children.reversed())
+        case .breadthFirst:
+            children
+        }
+        self.pending.append(contentsOf: orderedChildren.map {
+            AXTraversalPendingElement(element: $0, depth: parentDepth + 1)
+        })
+    }
+}
+
+/// The single identity-aware tree walker used by AXorcist's downward traversal surfaces.
+@MainActor
+@discardableResult
+func traverseAXTree(
+    from root: Element,
+    initialDepth: Int = 0,
+    maxDepth: Int? = nil,
+    order: AXTraversalOrder = .depthFirst,
+    strictChildren: Bool = false,
+    timeout: TimeInterval? = nil,
+    now: AXTraversalClock = { ProcessInfo.processInfo.systemUptime },
+    children: AXTraversalChildrenProvider = { element, strict in element.children(strict: strict) },
+    shouldDescend: (Element, Int) -> Bool = { _, _ in true },
+    onTimeout: () -> Void = {},
+    visit: (Element, Int) -> TreeVisitorResult) -> AXTraversalResult
+{
+    let deadline = timeout.map { now() + $0 }
+    var state = AXTraversalState(root: root, initialDepth: initialDepth)
+    var timedOut = false
+    var stopped = false
+
+    while state.hasPending(order: order) {
+        let next = state.removeNext(order: order)
+        if let deadline, now() > deadline {
+            timedOut = true
+            onTimeout()
+            break
+        }
+        if let maxDepth, next.depth > maxDepth {
+            continue
+        }
+        guard state.visited.insert(next.element).inserted else {
+            continue
+        }
+
+        let visitResult = visit(next.element, next.depth)
+        switch visitResult {
+        case .stop:
+            stopped = true
+        case .skipChildren:
+            continue
+        case .continue:
+            break
+        }
+        if stopped {
+            break
+        }
+        guard shouldDescend(next.element, next.depth) else {
+            continue
+        }
+        if let maxDepth, next.depth >= maxDepth {
+            continue
+        }
+        guard let childElements = children(next.element, strictChildren), !childElements.isEmpty else {
+            continue
+        }
+
+        state.appendChildren(childElements, parentDepth: next.depth, order: order)
+    }
+
+    return AXTraversalResult(
+        visitedCount: state.visited.count,
+        timedOut: timedOut,
+        stopped: stopped)
+}

--- a/Sources/AXorcist/Search/ElementSearch.swift
+++ b/Sources/AXorcist/Search/ElementSearch.swift
@@ -60,6 +60,20 @@ public func findTargetElement(
     locator: Locator,
     maxDepthForSearch: Int) -> (element: Element?, error: String?)
 {
+    findTargetElement(
+        for: appIdentifier,
+        locator: locator,
+        maxDepthForSearch: maxDepthForSearch,
+        traversalOptions: .snapshotDefaults())
+}
+
+@MainActor
+public func findTargetElement(
+    for appIdentifier: String,
+    locator: Locator,
+    maxDepthForSearch: Int,
+    traversalOptions: AXTraversalOptions) -> (element: Element?, error: String?)
+{
     guard let appElement = getApplicationElement(for: appIdentifier) else {
         logger.error("FTE: No app element for \(appIdentifier)")
         return (nil, "Application not found or not accessible: \(appIdentifier)")
@@ -69,7 +83,8 @@ public func findTargetElement(
         startingFrom: appElement,
         targetDescription: appIdentifier,
         locator: locator,
-        maxDepthForSearch: maxDepthForSearch)
+        maxDepthForSearch: maxDepthForSearch,
+        traversalOptions: traversalOptions)
 }
 
 @MainActor
@@ -78,6 +93,22 @@ func findTargetElement(
     targetDescription: String,
     locator: Locator,
     maxDepthForSearch: Int) -> (element: Element?, error: String?)
+{
+    findTargetElement(
+        startingFrom: appElement,
+        targetDescription: targetDescription,
+        locator: locator,
+        maxDepthForSearch: maxDepthForSearch,
+        traversalOptions: .snapshotDefaults())
+}
+
+@MainActor
+func findTargetElement(
+    startingFrom appElement: Element,
+    targetDescription: String,
+    locator: Locator,
+    maxDepthForSearch: Int,
+    traversalOptions: AXTraversalOptions) -> (element: Element?, error: String?)
 {
     let locatorDebug = logFindTargetSetup(
         appIdentifier: targetDescription,
@@ -91,9 +122,9 @@ func findTargetElement(
     let pathResult = performPathNavigation(
         currentElement: currentSearchElement,
         locator: locator,
-        maxDepthForSearch: maxDepthForSearch,
         pathHintDebugString: pathHintDebugString,
-        searchStartingPointDescription: searchStartingPointDescription)
+        searchStartingPointDescription: searchStartingPointDescription,
+        traversalOptions: traversalOptions)
 
     if let error = pathResult.error {
         return (nil, error)
@@ -117,7 +148,8 @@ func findTargetElement(
         startElement: currentSearchElement,
         locator: locator,
         maxDepthForSearch: maxDepthForSearch,
-        searchStartingPointDescription: searchStartingPointDescription)
+        searchStartingPointDescription: searchStartingPointDescription,
+        traversalOptions: traversalOptions)
 
     if let error = criteriaResult.error {
         return (nil, error)
@@ -128,9 +160,9 @@ func findTargetElement(
 private func performPathNavigation(
     currentElement: Element,
     locator: Locator,
-    maxDepthForSearch: Int,
     pathHintDebugString: String,
-    searchStartingPointDescription: String) -> PathNavigationResult
+    searchStartingPointDescription: String,
+    traversalOptions: AXTraversalOptions) -> PathNavigationResult
 {
     var element = currentElement
     var description = searchStartingPointDescription
@@ -161,8 +193,8 @@ private func performPathNavigation(
     if let navigatedElement = findDescendantAtPath(
         currentRoot: element,
         pathComponents: pathSteps,
-        maxDepth: maxDepthForSearch,
-        debugSearch: locator.debugPathSearch ?? false)
+        debugSearch: locator.debugPathSearch ?? false,
+        traversalOptions: traversalOptions)
     {
         logger.info(
             logSegments(
@@ -184,7 +216,8 @@ private func applyCriteriaSearch(
     startElement: Element,
     locator: Locator,
     maxDepthForSearch: Int,
-    searchStartingPointDescription: String) -> (element: Element?, error: String?)
+    searchStartingPointDescription: String,
+    traversalOptions: AXTraversalOptions) -> (element: Element?, error: String?)
 {
     let criteriaCount = locator.criteria.count
     let matchAll = locator.matchAll ?? true
@@ -202,14 +235,15 @@ private func applyCriteriaSearch(
         criteria: locator.criteria,
         matchType: finalSearchMatchType,
         matchAllCriteria: finalSearchMatchAll,
-        stopAtFirstMatch: axorcStopAtFirstMatch,
+        stopAtFirstMatch: traversalOptions.stopAtFirstMatch,
         maxDepth: maxDepthForSearch)
 
     let nodesVisited = runTraversal(
         element: startElement,
         visitor: searchVisitor,
         currentDepth: 0,
-        maxDepth: maxDepthForSearch)
+        maxDepth: maxDepthForSearch,
+        executionPolicy: AXTraversalExecutionPolicy(options: traversalOptions))
 
     if let foundMatch = searchVisitor.foundElement {
         let foundDescription = foundMatch.briefDescription(option: .smart)
@@ -256,6 +290,22 @@ public func collectAllElements(
     maxDepth: Int = AXMiscConstants.defaultMaxDepthSearch,
     includeIgnored: Bool = false) -> [Element]
 {
+    collectAllElements(
+        from: startElement,
+        matching: criteria,
+        maxDepth: maxDepth,
+        includeIgnored: includeIgnored,
+        traversalOptions: .snapshotDefaults())
+}
+
+@MainActor
+public func collectAllElements(
+    from startElement: Element,
+    matching criteria: [Criterion]? = nil,
+    maxDepth: Int = AXMiscConstants.defaultMaxDepthSearch,
+    includeIgnored: Bool = false,
+    traversalOptions: AXTraversalOptions) -> [Element]
+{
     let criteriaDebugString = criteria?
         .map { "\($0.attribute):\($0.value)(\($0.matchType?.rawValue ?? "exact"))" }
         .joined(separator: ", ")
@@ -268,7 +318,12 @@ public func collectAllElements(
             "I=\(includeIgnored)"))
 
     let visitor = CollectAllVisitor(criteria: criteria, includeIgnored: includeIgnored)
-    traverseAndSearch(element: startElement, visitor: visitor, currentDepth: 0, maxDepth: maxDepth)
+    traverseAndSearch(
+        element: startElement,
+        visitor: visitor,
+        currentDepth: 0,
+        maxDepth: maxDepth,
+        traversalOptions: traversalOptions)
 
     logger.info("CA: Found \(visitor.collectedElements.count)")
     return visitor.collectedElements
@@ -297,22 +352,44 @@ public func traverseAndSearch(
     currentDepth: Int,
     maxDepth: Int)
 {
+    traverseAndSearch(
+        element: element,
+        visitor: visitor,
+        currentDepth: currentDepth,
+        maxDepth: maxDepth,
+        traversalOptions: .snapshotDefaults())
+}
+
+@MainActor
+public func traverseAndSearch(
+    element: Element,
+    visitor: any ElementVisitor,
+    currentDepth: Int,
+    maxDepth: Int,
+    traversalOptions: AXTraversalOptions)
+{
+    traverseAndSearch(
+        element: element,
+        visitor: visitor,
+        currentDepth: currentDepth,
+        maxDepth: maxDepth,
+        executionPolicy: AXTraversalExecutionPolicy(options: traversalOptions))
+}
+
+@MainActor
+func traverseAndSearch(
+    element: Element,
+    visitor: any ElementVisitor,
+    currentDepth: Int,
+    maxDepth: Int,
+    executionPolicy: AXTraversalExecutionPolicy)
+{
     _ = runTraversal(
         element: element,
         visitor: visitor,
         currentDepth: currentDepth,
-        maxDepth: maxDepth)
-}
-
-private struct TraversalContext {
-    var visitedElements: Set<Element> = []
-    var nodeCount = 0
-    var didLogTimeout = false
-    let deadline: Date
-
-    init(timeout: TimeInterval) {
-        self.deadline = Date().addingTimeInterval(timeout)
-    }
+        maxDepth: maxDepth,
+        executionPolicy: executionPolicy)
 }
 
 @MainActor
@@ -320,87 +397,40 @@ private func runTraversal(
     element: Element,
     visitor: any ElementVisitor,
     currentDepth: Int,
-    maxDepth: Int) -> Int
-{
-    var context = TraversalContext(timeout: axorcTraversalTimeout)
-    _ = traverseAndSearch(
-        element: element,
-        visitor: visitor,
-        currentDepth: currentDepth,
-        maxDepth: maxDepth,
-        context: &context)
-    return context.nodeCount
-}
-
-@MainActor
-private func traverseAndSearch(
-    element: Element,
-    visitor: any ElementVisitor,
-    currentDepth: Int,
     maxDepth: Int,
-    context: inout TraversalContext) -> Bool
+    executionPolicy: AXTraversalExecutionPolicy) -> Int
 {
-    guard Date() <= context.deadline else {
-        if !context.didLogTimeout {
-            logger.warning("Traverse: search timeout (\(axorcTraversalTimeout)s) reached. Aborting traversal.")
-            context.didLogTimeout = true
-        }
-        return true
-    }
-
-    let elementDescription = element.briefDescription(option: ValueFormatOption.smart)
-
-    guard currentDepth <= maxDepth else {
-        logTraversalDepthExceeded(maxDepth, elementDescription)
-        return false
-    }
-
-    guard context.visitedElements.insert(element).inserted else {
-        return false
-    }
-
-    context.nodeCount += 1
-    let visitResult = visitor.visit(element: element, depth: currentDepth)
-
-    switch visitResult {
-    case .stop:
-        logTraversalEvent("STOP", elementDescription: elementDescription, depth: currentDepth)
-        return true
-    case .skipChildren:
-        logTraversalEvent("SKIP_CHILDREN", elementDescription: elementDescription, depth: currentDepth)
-        return false
-    case .continue:
-        logTraversalEvent(
-            "CONTINUE",
-            elementDescription: elementDescription,
-            depth: currentDepth,
-            extra: "Processing children")
-        // Continue to process children
-    }
-
-    if let children = element.children(strict: false), !children.isEmpty,
-       axorcScanAll || (element.role().map { containerRoles.contains($0) } ?? false)
-    {
-        for child in children {
-            guard !traverseAndSearch(
-                element: child,
-                visitor: visitor,
-                currentDepth: currentDepth + 1,
-                maxDepth: maxDepth,
-                context: &context)
-            else {
-                return true
+    let traversalOptions = executionPolicy.options
+    let result = traverseAXTree(
+        from: element,
+        initialDepth: currentDepth,
+        maxDepth: maxDepth,
+        timeout: traversalOptions.timeout,
+        now: executionPolicy.now,
+        shouldDescend: { element, _ in
+            traversalOptions.scanAll || (element.role().map { containerRoles.contains($0) } ?? false)
+        },
+        onTimeout: {
+            logger.warning("Traverse: search timeout (\(traversalOptions.timeout)s) reached. Aborting traversal.")
+        },
+        visit: { element, depth in
+            let elementDescription = element.briefDescription(option: ValueFormatOption.smart)
+            let visitResult = visitor.visit(element: element, depth: depth)
+            switch visitResult {
+            case .stop:
+                logTraversalEvent("STOP", elementDescription: elementDescription, depth: depth)
+            case .skipChildren:
+                logTraversalEvent("SKIP_CHILDREN", elementDescription: elementDescription, depth: depth)
+            case .continue:
+                logTraversalEvent(
+                    "CONTINUE",
+                    elementDescription: elementDescription,
+                    depth: depth,
+                    extra: "Processing children")
             }
-        }
-    }
-    return false
-}
-
-private func logTraversalDepthExceeded(_ maxDepth: Int, _ elementDescription: String) {
-    logger.debug(
-        logSegments(
-            "Traverse: Max depth \(maxDepth) reached at [\(elementDescription)]",
-            "Stopping this branch"))
+            return visitResult
+        })
+    return result.visitedCount
 }
 
 private func logTraversalEvent(
@@ -582,16 +612,3 @@ private let containerRoles: Set<String> = [
     "AXGeneric", "AXSection", "AXArticle", "AXSplitter", "AXScrollBar", "AXPane",
     AXRoleNames.kAXMenuBarRole,
 ]
-
-// MARK: - Search Timeout Handling
-
-/// Default timeout (seconds) for a full tree traversal. Override at runtime by setting `axorcTraversalTimeout`.
-public nonisolated(unsafe) var axorcTraversalTimeout: TimeInterval = 30
-
-/// When true, traversal will ignore `containerRoles` pruning and descend into *every* child of every element.
-/// Enable via CLI flag `--scan-all`.
-public nonisolated(unsafe) var axorcScanAll: Bool = false
-
-/// Controls whether SearchVisitor should stop at the first element that satisfies the final locator criteria.
-/// CLI flag `--no-stop-first` sets this to `false`.
-public nonisolated(unsafe) var axorcStopAtFirstMatch: Bool = true

--- a/Sources/AXorcist/Search/PathNavigationJSON.swift
+++ b/Sources/AXorcist/Search/PathNavigationJSON.swift
@@ -240,37 +240,29 @@ private func findMatchRecursively(
         message: "PathNav/FMR: Starting recursive search for component '\(pathComponentForLog)' " +
             "with maxDepth \(maxDepth) from [\(rootElement.briefDescription(option: ValueFormatOption.smart))]"))
 
-    var queue: [(element: Element, depth: Int)] = [(rootElement, 0)]
-    var visited = Set<Element>()
-
-    while !queue.isEmpty {
-        let (currentElement, currentDepth) = queue.removeFirst()
-
-        if visited.contains(currentElement) {
-            continue
-        }
-        visited.insert(currentElement)
-
+    var result: Element?
+    traverseAXTree(
+        from: rootElement,
+        maxDepth: maxDepth,
+        order: .breadthFirst)
+    { element, depth in
         if elementMatchesAllCriteriaJSON(
-            currentElement,
+            element,
             criteria: criteria,
             matchType: matchType,
             forPathComponent: pathComponentForLog)
         {
             GlobalAXLogger.shared.log(AXLogEntry(
                 level: .info,
-                message: "PathNav/FMR: Found match at depth \(currentDepth): " +
-                    "[\(currentElement.briefDescription(option: ValueFormatOption.smart))]"))
-            return currentElement
+                message: "PathNav/FMR: Found match at depth \(depth): " +
+                    "[\(element.briefDescription(option: ValueFormatOption.smart))]"))
+            result = element
+            return .stop
         }
-
-        if currentDepth < maxDepth {
-            if let children = currentElement.children() {
-                for child in children {
-                    queue.append((child, currentDepth + 1))
-                }
-            }
-        }
+        return .continue
+    }
+    if let result {
+        return result
     }
 
     GlobalAXLogger.shared.log(AXLogEntry(

--- a/Sources/AXorcist/Search/PathNavigationUtilities.swift
+++ b/Sources/AXorcist/Search/PathNavigationUtilities.swift
@@ -112,8 +112,8 @@ public func getElement(
 func findDescendantAtPath(
     currentRoot: Element,
     pathComponents: [PathStep],
-    maxDepth _: Int,
-    debugSearch _: Bool) -> Element?
+    debugSearch _: Bool,
+    traversalOptions: AXTraversalOptions) -> Element?
 {
     var currentElement = currentRoot
     logPathSearchStart(currentElement: currentElement, componentCount: pathComponents.count)
@@ -125,7 +125,11 @@ func findDescendantAtPath(
             return nil
         }
 
-        let match = findMatch(for: component, among: children, componentIndex: index)
+        let match = findMatch(
+            for: component,
+            among: children,
+            componentIndex: index,
+            traversalOptions: traversalOptions)
         guard let nextElement = match else {
             logNoMatch(component: component, element: currentElement, index: index)
             return nil
@@ -176,7 +180,8 @@ private func childrenForPathComponent(element: Element, componentIndex: Int) -> 
 private func findMatch(
     for component: PathStep,
     among children: [Element],
-    componentIndex: Int) -> Element?
+    componentIndex: Int,
+    traversalOptions: AXTraversalOptions) -> Element?
 {
     let searchVisitor = SearchVisitor(
         criteria: component.criteria,
@@ -191,7 +196,8 @@ private func findMatch(
             element: child,
             visitor: searchVisitor,
             currentDepth: 0,
-            maxDepth: component.maxDepthForStep ?? 1)
+            maxDepth: component.maxDepthForStep ?? 1,
+            traversalOptions: traversalOptions)
         if let foundElement = searchVisitor.foundElement {
             logMatch(component: component, element: foundElement, index: componentIndex)
             return foundElement

--- a/Sources/axorc/AXORCMain.swift
+++ b/Sources/axorc/AXORCMain.swift
@@ -86,7 +86,8 @@ struct AXORCCommand: ParsableCommand {
     @MainActor private func processAndExecuteCommand(
         command: CommandEnvelope,
         axorcist: AXorcist,
-        debugCLI: Bool) throws
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions) throws
     {
         if debugCLI {
             axDebugLog("Successfully parsed command: \(command.command) (ID: \(command.commandId))")
@@ -95,7 +96,8 @@ struct AXORCCommand: ParsableCommand {
         let resultJsonString = CommandExecutor.execute(
             command: command,
             axorcist: axorcist,
-            debugCLI: debugCLI)
+            debugCLI: debugCLI,
+            traversalOptions: traversalOptions)
         print(resultJsonString)
         fflush(stdout)
 
@@ -142,7 +144,7 @@ struct AXORCCommand: ParsableCommand {
     @MainActor
     private mutating func runMain() throws {
         self.configureLogging()
-        self.applyGlobalFlags()
+        let traversalOptions = self.resolvedTraversalOptions()
         self.logDebugVersion()
 
         let inputResult = InputHandler.parseInput(
@@ -171,7 +173,8 @@ struct AXORCCommand: ParsableCommand {
 
         try self.decodeAndExecute(
             jsonString: jsonStringFromInput,
-            axorcist: axorcistInstance)
+            axorcist: axorcistInstance,
+            traversalOptions: traversalOptions)
 
         if self.debug, self.commandShouldPrintLogsAtEnd() {
             self.flushDebugLogs()
@@ -191,12 +194,12 @@ struct AXORCCommand: ParsableCommand {
         }
     }
 
-    private func applyGlobalFlags() {
-        axorcScanAll = self.scanAll
-        axorcStopAtFirstMatch = !self.noStopFirst
-        if let timeout {
-            axorcTraversalTimeout = TimeInterval(timeout)
-        }
+    func resolvedTraversalOptions() -> AXTraversalOptions {
+        let defaults = AXTraversalOptions.standard
+        return AXTraversalOptions(
+            timeout: self.timeout.map(TimeInterval.init) ?? defaults.timeout,
+            scanAll: self.scanAll,
+            stopAtFirstMatch: !self.noStopFirst)
     }
 
     private func logDebugVersion() {
@@ -229,7 +232,11 @@ struct AXORCCommand: ParsableCommand {
         Self.printErrorResponse(commandId: commandId, error: error, logs: logs)
     }
 
-    private mutating func decodeAndExecute(jsonString: String, axorcist: AXorcist) throws {
+    private mutating func decodeAndExecute(
+        jsonString: String,
+        axorcist: AXorcist,
+        traversalOptions: AXTraversalOptions) throws
+    {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         guard let data = jsonString.data(using: .utf8) else {
@@ -267,7 +274,11 @@ struct AXORCCommand: ParsableCommand {
         }
 
         self.suppressFinalLogDump = command.command == .observe
-        try self.processAndExecuteCommand(command: command, axorcist: axorcist, debugCLI: self.debug)
+        try self.processAndExecuteCommand(
+            command: command,
+            axorcist: axorcist,
+            debugCLI: self.debug,
+            traversalOptions: traversalOptions)
     }
 
     private func flushDebugLogs() {

--- a/Sources/axorc/CLIFrontend.swift
+++ b/Sources/axorc/CLIFrontend.swift
@@ -201,7 +201,11 @@ enum CLIFrontend {
         json: Bool,
         renderer: ([String: Any]) throws -> String) throws -> Int32
     {
-        let response = CommandExecutor.execute(command: envelope, axorcist: AXorcist.shared, debugCLI: false)
+        let response = CommandExecutor.execute(
+            command: envelope,
+            axorcist: AXorcist.shared,
+            debugCLI: false,
+            traversalOptions: .standard)
         guard let object = self.object(from: response) else {
             throw UserError("AXorcist returned malformed JSON.", exitCode: 1)
         }

--- a/Sources/axorc/CommandExecutionFunctions.swift
+++ b/Sources/axorc/CommandExecutionFunctions.swift
@@ -6,62 +6,98 @@ import Foundation
 // MARK: - Command Execution Functions (now call AXorcist.runCommand)
 
 @MainActor
-func executeQuery(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executeQuery(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axQueryCommand = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert Query to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for Query")
     }
 
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axQueryCommand))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axQueryCommand),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }
 
 @MainActor
-func executeGetFocusedElement(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executeGetFocusedElement(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axGetFocusedCmd = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert GetFocusedElement to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for GetFocusedElement")
     }
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axGetFocusedCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axGetFocusedCmd),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }
 
 @MainActor
-func executeGetAttributes(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executeGetAttributes(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axGetAttrsCmd = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert GetAttributes to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for GetAttributes")
     }
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axGetAttrsCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axGetAttrsCmd),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }
 
 @MainActor
-func executeDescribeElement(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executeDescribeElement(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axDescribeCmd = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert DescribeElement to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for DescribeElement")
     }
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axDescribeCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axDescribeCmd),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }
 
 @MainActor
-func executeExtractText(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executeExtractText(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axExtractCmd = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert ExtractText to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for ExtractText")
     }
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axExtractCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axExtractCmd),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }
 
 @MainActor
-func executePerformAction(command: CommandEnvelope, axorcist: AXorcist) -> HandlerResponse {
+func executePerformAction(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    traversalOptions: AXTraversalOptions) -> HandlerResponse
+{
     guard let axPerformCmd = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert PerformAction to AXCommand")
         return HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for PerformAction")
     }
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axPerformCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axPerformCmd),
+        traversalOptions: traversalOptions)
     return HandlerResponse(from: axResponse)
 }

--- a/Sources/axorc/CommandExecutor.swift
+++ b/Sources/axorc/CommandExecutor.swift
@@ -12,8 +12,9 @@ struct CommandExecutor {
     static func execute(
         command: CommandEnvelope,
         axorcist: AXorcist,
-        debugCLI: Bool, // This is from the --debug CLI flag
-    ) -> String {
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions = .standard) -> String
+    {
         // The main AXORCCommand.run() now sets the global logging based on --debug.
         // CommandExecutor.setupLogging can adjust detail level if command.debugLogging is true.
         let previousDetailLevel = self.setupDetailLevelForCommand(
@@ -31,7 +32,11 @@ struct CommandExecutor {
             "Executing command: \(command.command) (ID: \(command.commandId)), "
                 + "cmdDebug: \(command.debugLogging), cliDebug: \(debugCLI)")
 
-        return self.processCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
+        return self.processCommand(
+            command: command,
+            axorcist: axorcist,
+            debugCLI: debugCLI,
+            traversalOptions: traversalOptions)
     }
 
     static func stopObservations(axorcist: AXorcist) {
@@ -58,8 +63,15 @@ struct CommandExecutor {
         return previousDetailLevel
     }
 
-    private typealias DirectCommandHandler = @MainActor (CommandEnvelope, AXorcist, Bool) -> String
-    private typealias SimpleCommandExecutor = @MainActor (CommandEnvelope, AXorcist) -> HandlerResponse
+    private typealias DirectCommandHandler = @MainActor (
+        CommandEnvelope,
+        AXorcist,
+        Bool,
+        AXTraversalOptions) -> String
+    private typealias SimpleCommandExecutor = @MainActor (
+        CommandEnvelope,
+        AXorcist,
+        AXTraversalOptions) -> HandlerResponse
 
     private static let simpleExecutors: [CommandType: SimpleCommandExecutor] = [
         .getFocusedElement: executeGetFocusedElement,
@@ -74,14 +86,14 @@ struct CommandExecutor {
         .collectAll: handleCollectAllCommand,
         .getElementAtPoint: handleGetElementAtPointCommand,
         .setFocusedValue: handleSetFocusedValueCommand,
-        .ping: { command, _, debugCLI in handlePingCommand(command: command, debugCLI: debugCLI) },
+        .ping: { command, _, debugCLI, _ in handlePingCommand(command: command, debugCLI: debugCLI) },
         .batch: handleBatchCommand,
         .observe: handleObserveCommand,
-        .stopObservation: { command, axorcist, debugCLI in
+        .stopObservation: { command, axorcist, debugCLI, _ in
             handleStopObservationCommand(command: command, axorcist: axorcist, debugCLI: debugCLI)
         },
-        .isProcessTrusted: { command, _, _ in handleIsProcessTrustedCommand(command: command) },
-        .isAXFeatureEnabled: { command, _, _ in handleIsAXFeatureEnabledCommand(command: command) },
+        .isProcessTrusted: { command, _, _, _ in handleIsProcessTrustedCommand(command: command) },
+        .isAXFeatureEnabled: { command, _, _, _ in handleIsAXFeatureEnabledCommand(command: command) },
     ]
 
     private static let notImplementedCommands: Set<CommandType> = [
@@ -91,17 +103,23 @@ struct CommandExecutor {
     ]
 
     @MainActor
-    private static func processCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI: Bool) -> String {
+    private static func processCommand(
+        command: CommandEnvelope,
+        axorcist: AXorcist,
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions) -> String
+    {
         if let executor = simpleExecutors[command.command] {
             return handleSimpleCommand(
                 command: command,
                 axorcist: axorcist,
                 debugCLI: debugCLI,
+                traversalOptions: traversalOptions,
                 executor: executor)
         }
 
         if let handler = commandHandlers[command.command] {
-            return handler(command, axorcist, debugCLI)
+            return handler(command, axorcist, debugCLI, traversalOptions)
         }
 
         if self.notImplementedCommands.contains(command.command) {
@@ -119,7 +137,8 @@ struct CommandExecutor {
     private static func handleCollectAllCommand(
         command: CommandEnvelope,
         axorcist: AXorcist,
-        debugCLI: Bool) -> String
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions) -> String
     {
         axDebugLog("CollectAll called. debugCLI=\(debugCLI). Passing to axorcist.handleCollectAll.")
         guard let axCommand = command.command.toAXCommand(commandEnvelope: command) else {
@@ -134,7 +153,9 @@ struct CommandExecutor {
                 debugCLI: debugCLI,
                 commandDebugLogging: command.debugLogging)
         }
-        let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axCommand))
+        let axResponse = axorcist.runCommand(
+            AXCommandEnvelope(commandID: command.commandId, command: axCommand),
+            traversalOptions: traversalOptions)
         let handlerResponse = if axResponse.status == "success" {
             HandlerResponse(data: axResponse.payload, error: nil)
         } else {
@@ -152,16 +173,24 @@ struct CommandExecutor {
     private static func handleGetElementAtPointCommand(
         command: CommandEnvelope,
         axorcist: AXorcist,
-        debugCLI: Bool) -> String
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions) -> String
     {
-        handleSimpleCommand(command: command, axorcist: axorcist, debugCLI: debugCLI) { cmd, axorcist in
+        handleSimpleCommand(
+            command: command,
+            axorcist: axorcist,
+            debugCLI: debugCLI,
+            traversalOptions: traversalOptions)
+        { cmd, axorcist, options in
             guard let axCmd = cmd.command.toAXCommand(commandEnvelope: cmd) else {
                 axErrorLog("Failed to convert GetElementAtPoint to AXCommand")
                 return HandlerResponse(
                     data: nil,
                     error: "Internal error: Failed to create AXCommand for GetElementAtPoint")
             }
-            let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: cmd.commandId, command: axCmd))
+            let axResponse = axorcist.runCommand(
+                AXCommandEnvelope(commandID: cmd.commandId, command: axCmd),
+                traversalOptions: options)
             return HandlerResponse(from: axResponse)
         }
     }
@@ -170,16 +199,24 @@ struct CommandExecutor {
     private static func handleSetFocusedValueCommand(
         command: CommandEnvelope,
         axorcist: AXorcist,
-        debugCLI: Bool) -> String
+        debugCLI: Bool,
+        traversalOptions: AXTraversalOptions) -> String
     {
-        handleSimpleCommand(command: command, axorcist: axorcist, debugCLI: debugCLI) { cmd, axorcist in
+        handleSimpleCommand(
+            command: command,
+            axorcist: axorcist,
+            debugCLI: debugCLI,
+            traversalOptions: traversalOptions)
+        { cmd, axorcist, options in
             guard let axCmd = cmd.command.toAXCommand(commandEnvelope: cmd) else {
                 axErrorLog("Failed to convert SetFocusedValue to AXCommand")
                 return HandlerResponse(
                     data: nil,
                     error: "Internal error: Failed to create AXCommand for SetFocusedValue")
             }
-            let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: cmd.commandId, command: axCmd))
+            let axResponse = axorcist.runCommand(
+                AXCommandEnvelope(commandID: cmd.commandId, command: axCmd),
+                traversalOptions: options)
             return HandlerResponse(from: axResponse)
         }
     }

--- a/Sources/axorc/CommandHandlers.swift
+++ b/Sources/axorc/CommandHandlers.swift
@@ -10,7 +10,12 @@ import Foundation
 // MARK: - Command Handlers
 
 @MainActor
-func handlePerformActionCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI: Bool) -> String {
+func handlePerformActionCommand(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    debugCLI: Bool,
+    traversalOptions: AXTraversalOptions) -> String
+{
     guard command.actionName != nil else {
         let errorResponse = HandlerResponse(data: nil, error: "performAction requires actionName")
         return finalizeAndEncodeResponse(
@@ -21,16 +26,28 @@ func handlePerformActionCommand(command: CommandEnvelope, axorcist: AXorcist, de
             commandDebugLogging: command.debugLogging)
     }
 
-    return handleSimpleCommand(command: command, axorcist: axorcist, debugCLI: debugCLI, executor: executePerformAction)
+    return handleSimpleCommand(
+        command: command,
+        axorcist: axorcist,
+        debugCLI: debugCLI,
+        traversalOptions: traversalOptions,
+        executor: executePerformAction)
 }
 
 @MainActor
-func handleBatchCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI: Bool) -> String {
+func handleBatchCommand(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    debugCLI: Bool,
+    traversalOptions: AXTraversalOptions) -> String
+{
     guard let batchCmd = command.command.toAXCommand(commandEnvelope: command) else {
         return encodeBatchConversionFailure(commandId: command.commandId)
     }
 
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: batchCmd))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: batchCmd),
+        traversalOptions: traversalOptions)
     var finalResponseObject = buildBatchResponse(commandId: command.commandId, axResponse: axResponse)
 
     if debugCLI || command.debugLogging {
@@ -110,7 +127,12 @@ func handleNotImplementedCommand(command: CommandEnvelope, message: String, debu
 }
 
 @MainActor
-func handleObserveCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI: Bool) -> String {
+func handleObserveCommand(
+    command: CommandEnvelope,
+    axorcist: AXorcist,
+    debugCLI: Bool,
+    traversalOptions: AXTraversalOptions) -> String
+{
     guard let axObserveCommand = command.command.toAXCommand(commandEnvelope: command) else {
         axErrorLog("Failed to convert Observe to AXCommand")
         let errorResponse = HandlerResponse(data: nil, error: "Internal error: Failed to create AXCommand for Observe")
@@ -122,7 +144,9 @@ func handleObserveCommand(command: CommandEnvelope, axorcist: AXorcist, debugCLI
             commandDebugLogging: command.debugLogging)
     }
 
-    let axResponse = axorcist.runCommand(AXCommandEnvelope(commandID: command.commandId, command: axObserveCommand))
+    let axResponse = axorcist.runCommand(
+        AXCommandEnvelope(commandID: command.commandId, command: axObserveCommand),
+        traversalOptions: traversalOptions)
     let handlerResponse = HandlerResponse(from: axResponse)
 
     return finalizeAndEncodeResponse(
@@ -138,9 +162,10 @@ func handleSimpleCommand(
     command: CommandEnvelope,
     axorcist: AXorcist,
     debugCLI: Bool,
-    executor: (CommandEnvelope, AXorcist) -> HandlerResponse) -> String
+    traversalOptions: AXTraversalOptions,
+    executor: (CommandEnvelope, AXorcist, AXTraversalOptions) -> HandlerResponse) -> String
 {
-    let handlerResponse = executor(command, axorcist)
+    let handlerResponse = executor(command, axorcist, traversalOptions)
     return finalizeAndEncodeResponse(
         commandId: command.commandId,
         commandType: command.command.rawValue,

--- a/Tests/AXorcistTests/TraversalKernelTests.swift
+++ b/Tests/AXorcistTests/TraversalKernelTests.swift
@@ -1,0 +1,224 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Canonical accessibility traversal", .serialized)
+@MainActor
+struct TraversalKernelTests {
+    @Test
+    func `Depth-first traversal terminates cycles and visits diamond identities once`() {
+        let shared = self.element(pid: 2_020_000_004, title: "shared")
+        let left = self.element(pid: 2_020_000_002, title: "left", children: [shared])
+        let right = self.element(pid: 2_020_000_003, title: "right", children: [shared])
+        let diamond = self.element(pid: 2_020_000_001, title: "root", children: [left, right])
+
+        #expect(self.visitedTitles(from: diamond) == ["root", "left", "shared", "right"])
+
+        let cycleIdentity = AXUIElementCreateApplication(2_020_000_010)
+        let rootAlias = self.element(identity: cycleIdentity, title: "root-alias")
+        let child = self.element(pid: 2_020_000_011, title: "child", children: [rootAlias])
+        let cycle = self.element(identity: cycleIdentity, title: "root", children: [child])
+
+        #expect(self.visitedTitles(from: cycle) == ["root", "child"])
+    }
+
+    @Test
+    func `Shallower diamond path re-expands descendants without duplicate visitor emission`() {
+        let leaf = self.element(pid: 2_020_000_016, title: "leaf")
+        let shared = self.element(pid: 2_020_000_015, title: "shared", children: [leaf])
+        let deepParent = self.element(pid: 2_020_000_014, title: "deep-parent", children: [shared])
+        let longBranch = self.element(pid: 2_020_000_013, title: "long", children: [deepParent])
+        let shortBranch = self.element(pid: 2_020_000_012, title: "short", children: [shared])
+        let root = self.element(pid: 2_020_000_017, title: "root", children: [longBranch, shortBranch])
+        let visitor = RecordingVisitor()
+
+        traverseAndSearch(
+            element: root,
+            visitor: visitor,
+            currentDepth: 0,
+            maxDepth: 3,
+            traversalOptions: AXTraversalOptions(scanAll: true))
+
+        #expect(visitor.titles == ["root", "long", "deep-parent", "shared", "short", "leaf"])
+    }
+
+    @Test
+    func `Kernel preserves depth-first breadth-first depth and strict policies`() {
+        let root = self.element(pid: 2_020_000_020, title: "root")
+        let left = self.element(pid: 2_020_000_021, title: "left")
+        let right = self.element(pid: 2_020_000_022, title: "right")
+        let leaf = self.element(pid: 2_020_000_023, title: "leaf")
+        let childrenByElement = [
+            root: [left, right],
+            left: [leaf],
+        ]
+        var strictArguments: [Bool] = []
+
+        var depthFirst: [String] = []
+        traverseAXTree(
+            from: root,
+            maxDepth: 1,
+            strictChildren: true,
+            children: { element, strict in
+                strictArguments.append(strict)
+                return childrenByElement[element]
+            },
+            visit: { element, _ in
+                depthFirst.append(element.title() ?? "")
+                return .continue
+            })
+        #expect(depthFirst == ["root", "left", "right"])
+        #expect(strictArguments == [true])
+
+        var breadthFirst: [String] = []
+        traverseAXTree(
+            from: root,
+            order: .breadthFirst,
+            children: { element, _ in childrenByElement[element] },
+            visit: { element, _ in
+                breadthFirst.append(element.title() ?? "")
+                return .continue
+            })
+        #expect(breadthFirst == ["root", "left", "right", "leaf"])
+    }
+
+    @Test
+    func `Injected clock stops traversal deterministically`() {
+        let grandchild = self.element(pid: 2_020_000_033, title: "grandchild")
+        let child = self.element(pid: 2_020_000_032, title: "child", children: [grandchild])
+        let root = self.element(pid: 2_020_000_031, title: "root", children: [child])
+        var instants: [TimeInterval] = [0, 0, 0.5, 2]
+        let visitor = RecordingVisitor()
+
+        traverseAndSearch(
+            element: root,
+            visitor: visitor,
+            currentDepth: 0,
+            maxDepth: 2,
+            executionPolicy: AXTraversalExecutionPolicy(
+                options: AXTraversalOptions(timeout: 1, scanAll: true),
+                now: { instants.removeFirst() }))
+
+        #expect(visitor.titles == ["root", "child"])
+        #expect(instants.isEmpty)
+    }
+
+    @Test
+    func `Canonical collection and Element search surfaces preserve preorder`() {
+        let shared = self.element(pid: 2_020_000_044, title: "node-shared", identifier: "shared-id")
+        let left = self.element(pid: 2_020_000_042, title: "node-left", children: [shared])
+        let right = self.element(pid: 2_020_000_043, title: "node-right", children: [shared])
+        let root = self.element(pid: 2_020_000_041, title: "node-root", children: [left, right])
+        let expected = [root, left, shared, right]
+
+        #expect(collectAllElements(
+            from: root,
+            maxDepth: 3,
+            includeIgnored: true,
+            traversalOptions: AXTraversalOptions(scanAll: true)) == expected)
+        #expect(root.searchElements(matching: "node-") == expected)
+        #expect(root.findElements() == expected)
+        #expect(root.findElement(byIdentifier: "shared-id") == shared)
+
+        var depthOneOptions = ElementSearchOptions()
+        depthOneOptions.maxDepth = 1
+        #expect(root.searchElements(matching: "node-", options: depthOneOptions) == [root, left, right])
+        #expect(root.findElements(maxDepth: 1) == [root, left, right])
+    }
+
+    @Test
+    func `Search visitor preserves last-match and first-match semantics`() {
+        let first = self.element(pid: 2_020_000_052, title: "first", role: AXRoleNames.kAXButtonRole)
+        let second = self.element(pid: 2_020_000_053, title: "second", role: AXRoleNames.kAXButtonRole)
+        let root = self.element(pid: 2_020_000_051, title: "root", children: [first, second])
+        let criterion = Criterion(attribute: AXAttributeNames.kAXRoleAttribute, value: AXRoleNames.kAXButtonRole)
+
+        let lastMatch = SearchVisitor(criteria: [criterion], stopAtFirstMatch: false, maxDepth: 1)
+        traverseAndSearch(
+            element: root,
+            visitor: lastMatch,
+            currentDepth: 0,
+            maxDepth: 1,
+            traversalOptions: AXTraversalOptions(scanAll: true, stopAtFirstMatch: false))
+        #expect(lastMatch.foundElement == second)
+        #expect(lastMatch.allFoundElements == [first, second])
+
+        let firstMatch = SearchVisitor(criteria: [criterion], stopAtFirstMatch: true, maxDepth: 1)
+        traverseAndSearch(
+            element: root,
+            visitor: firstMatch,
+            currentDepth: 0,
+            maxDepth: 1,
+            traversalOptions: AXTraversalOptions(scanAll: true, stopAtFirstMatch: true))
+        #expect(firstMatch.foundElement == first)
+        #expect(firstMatch.allFoundElements == [first])
+    }
+
+    @Test
+    func `Deep JSON path keeps breadth-first first-match order`() {
+        let deep = self.element(pid: 2_020_000_064, title: "target")
+        let left = self.element(pid: 2_020_000_062, title: "left", children: [deep])
+        let shallow = self.element(pid: 2_020_000_063, title: "target")
+        let root = self.element(pid: 2_020_000_061, title: "root", children: [left, shallow])
+
+        let result = navigateToElementByJSONPathHint(
+            from: root,
+            jsonPathHint: [JSONPathHintComponent(attribute: "TITLE", value: "target", depth: 2)])
+
+        #expect(result == shallow)
+    }
+
+    private func visitedTitles(from root: Element) -> [String] {
+        let visitor = RecordingVisitor()
+        traverseAndSearch(
+            element: root,
+            visitor: visitor,
+            currentDepth: 0,
+            maxDepth: 20,
+            traversalOptions: AXTraversalOptions(scanAll: true))
+        return visitor.titles
+    }
+
+    private func element(
+        pid: pid_t,
+        title: String,
+        role: String = AXRoleNames.kAXGroupRole,
+        identifier: String? = nil,
+        children: [Element] = []) -> Element
+    {
+        self.element(
+            identity: AXUIElementCreateApplication(pid),
+            title: title,
+            role: role,
+            identifier: identifier,
+            children: children)
+    }
+
+    private func element(
+        identity: AXUIElement,
+        title: String,
+        role: String = AXRoleNames.kAXGroupRole,
+        identifier: String? = nil,
+        children: [Element] = []) -> Element
+    {
+        var attributes: [String: AttributeValue] = [
+            AXAttributeNames.kAXRoleAttribute: .string(role),
+            AXAttributeNames.kAXTitleAttribute: .string(title),
+        ]
+        if let identifier {
+            attributes[AXAttributeNames.kAXIdentifierAttribute] = .string(identifier)
+        }
+        return Element(identity, attributes: attributes, children: children, actions: [])
+    }
+}
+
+@MainActor
+private final class RecordingVisitor: ElementVisitor {
+    private(set) var titles: [String] = []
+
+    func visit(element: Element, depth _: Int) -> TreeVisitorResult {
+        self.titles.append(element.title() ?? "")
+        return .continue
+    }
+}

--- a/Tests/AXorcistTests/TraversalOptionsTests.swift
+++ b/Tests/AXorcistTests/TraversalOptionsTests.swift
@@ -1,0 +1,187 @@
+import ApplicationServices
+import Dispatch
+import Foundation
+import os
+import Testing
+@testable import axorc
+@testable import AXorcist
+
+@Suite("Accessibility traversal options", .serialized)
+@MainActor
+struct TraversalOptionsTests {
+    @Test
+    func `Standard options are immutable Sendable values`() {
+        self.requireSendable(AXTraversalOptions.standard)
+        #expect(AXTraversalOptions.standard == AXTraversalOptions(
+            timeout: 30,
+            scanAll: false,
+            stopAtFirstMatch: true))
+    }
+
+    @Test
+    func `Legacy globals remain source compatible and preserve sibling defaults`() {
+        let original = AXTraversalOptions.snapshotDefaults()
+        defer { AXTraversalOptions.replaceDefaults(original) }
+
+        axorcTraversalTimeout = 7
+        axorcScanAll = true
+        axorcStopAtFirstMatch = false
+
+        #expect(axorcTraversalTimeout == 7)
+        #expect(axorcScanAll)
+        #expect(!axorcStopAtFirstMatch)
+        #expect(AXTraversalOptions.snapshotDefaults() == AXTraversalOptions(
+            timeout: 7,
+            scanAll: true,
+            stopAtFirstMatch: false))
+    }
+
+    @Test
+    func `Legacy traversal snapshots defaults before a visitor flips them`() {
+        let original = AXTraversalOptions.snapshotDefaults()
+        defer { AXTraversalOptions.replaceDefaults(original) }
+        AXTraversalOptions.replaceDefaults(AXTraversalOptions(
+            timeout: 30,
+            scanAll: true,
+            stopAtFirstMatch: true))
+
+        let root = self.testTree()
+        let flippingVisitor = TraversalOptionsCountingVisitor { depth in
+            if depth == 0 {
+                axorcScanAll = false
+            }
+        }
+
+        let legacyTraversal: @MainActor (Element, any ElementVisitor, Int, Int) -> Void = traverseAndSearch
+        legacyTraversal(root, flippingVisitor, 0, 2)
+        #expect(flippingVisitor.visitCount == 3)
+
+        let nextVisitor = TraversalOptionsCountingVisitor()
+        legacyTraversal(root, nextVisitor, 0, 2)
+        #expect(nextVisitor.visitCount == 2)
+    }
+
+    @Test
+    func `Opposite explicit options do not consult process defaults`() {
+        let original = AXTraversalOptions.snapshotDefaults()
+        defer { AXTraversalOptions.replaceDefaults(original) }
+        AXTraversalOptions.replaceDefaults(AXTraversalOptions(
+            timeout: -1,
+            scanAll: false,
+            stopAtFirstMatch: false))
+
+        let root = self.testTree()
+        let exhaustiveVisitor = TraversalOptionsCountingVisitor()
+        traverseAndSearch(
+            element: root,
+            visitor: exhaustiveVisitor,
+            currentDepth: 0,
+            maxDepth: 2,
+            traversalOptions: AXTraversalOptions(
+                timeout: 30,
+                scanAll: true,
+                stopAtFirstMatch: true))
+        #expect(exhaustiveVisitor.visitCount == 3)
+
+        let prunedVisitor = TraversalOptionsCountingVisitor()
+        traverseAndSearch(
+            element: root,
+            visitor: prunedVisitor,
+            currentDepth: 0,
+            maxDepth: 2,
+            traversalOptions: AXTraversalOptions(
+                timeout: 30,
+                scanAll: false,
+                stopAtFirstMatch: false))
+        #expect(prunedVisitor.visitCount == 2)
+    }
+
+    @Test
+    func `Concurrent default replacements never expose torn options`() {
+        let original = AXTraversalOptions.snapshotDefaults()
+        defer { AXTraversalOptions.replaceDefaults(original) }
+        let first = AXTraversalOptions(timeout: 1, scanAll: false, stopAtFirstMatch: true)
+        let second = AXTraversalOptions(timeout: 2, scanAll: true, stopAtFirstMatch: false)
+        let failures = OSAllocatedUnfairLock(initialState: [AXTraversalOptions]())
+        AXTraversalOptions.replaceDefaults(first)
+
+        DispatchQueue.concurrentPerform(iterations: 2000) { index in
+            if index.isMultiple(of: 3) {
+                AXTraversalOptions.replaceDefaults(index.isMultiple(of: 2) ? first : second)
+            } else {
+                let snapshot = AXTraversalOptions.snapshotDefaults()
+                if snapshot != first, snapshot != second {
+                    failures.withLock { $0.append(snapshot) }
+                }
+            }
+        }
+
+        #expect(failures.withLock { $0.isEmpty })
+    }
+
+    @Test
+    func `Raw CLI resolves one explicit request snapshot without timeout bleed`() {
+        let original = AXTraversalOptions.snapshotDefaults()
+        defer { AXTraversalOptions.replaceDefaults(original) }
+        AXTraversalOptions.replaceDefaults(AXTraversalOptions(
+            timeout: -1,
+            scanAll: true,
+            stopAtFirstMatch: false))
+
+        var defaultsCommand = AXORCCommand()
+        #expect(defaultsCommand.resolvedTraversalOptions() == .standard)
+
+        defaultsCommand.timeout = 9
+        defaultsCommand.scanAll = true
+        defaultsCommand.noStopFirst = true
+        #expect(defaultsCommand.resolvedTraversalOptions() == AXTraversalOptions(
+            timeout: 9,
+            scanAll: true,
+            stopAtFirstMatch: false))
+    }
+
+    private func requireSendable(_ value: some Sendable) {
+        _ = value
+    }
+
+    private func testTree() -> Element {
+        let grandchild = self.element(
+            pid: 2_100_000_003,
+            role: AXRoleNames.kAXStaticTextRole)
+        let child = self.element(
+            pid: 2_100_000_002,
+            role: AXRoleNames.kAXButtonRole,
+            children: [grandchild])
+        return self.element(
+            pid: 2_100_000_001,
+            role: AXRoleNames.kAXApplicationRole,
+            children: [child])
+    }
+
+    private func element(pid: pid_t, role: String, children: [Element] = []) -> Element {
+        Element(
+            AXUIElementCreateApplication(pid),
+            attributes: [
+                AXAttributeNames.kAXRoleAttribute: .string(role),
+                AXAttributeNames.kAXTitleAttribute: .string("test-\(pid)"),
+            ],
+            children: children,
+            actions: [])
+    }
+}
+
+@MainActor
+private final class TraversalOptionsCountingVisitor: ElementVisitor {
+    private(set) var visitCount = 0
+    private let onVisit: (Int) -> Void
+
+    init(onVisit: @escaping (Int) -> Void = { _ in }) {
+        self.onVisit = onVisit
+    }
+
+    func visit(element _: Element, depth: Int) -> TreeVisitorResult {
+        self.visitCount += 1
+        self.onVisit(depth)
+        return .continue
+    }
+}


### PR DESCRIPTION
## Summary

- replace process-global live traversal configuration with immutable request-scoped `AXTraversalOptions`, while retaining lock-backed deprecated source-compatible globals
- snapshot CLI traversal flags per invocation so concurrent and sequential in-process requests cannot contaminate one another
- consolidate visitor, collect-all, Element search, `UIAutomation.findElements`, and deep JSON path traversal on one identity-aware kernel
- terminate cycles and diamonds, re-expand descendants only when an identity is later reached at a shallower depth, and emit each visitor once
- preserve DFS/BFS order, depth, strict/pruning, stop/skip, first/last-match, timeout, public signature, and exact PID/app fail-closed behavior

## Proof

- focused traversal and targeting tests: 18
- full suite: 111 tests
- Release build
- Swift API breakage diagnosis: none
- native-only source/string/import gates and policy harness
- SwiftFormat and strict SwiftLint: zero violations
- source-blind Release CLI smoke for sequential/concurrent option isolation and timeout recovery
- final whole-branch P0-P2 review clean

`describeElementTree`, recursive text extraction, and upward parent/ancestor walkers are deliberately deferred until exact kernel parity is established.
