### PR TITLE
perf(release): build universal CLI in one pass

### DIFF
--- a/scripts/build-universal-binary.sh
+++ b/scripts/build-universal-binary.sh
@@ -53,7 +53,7 @@ if [[ ! -x "$built_binary" ]]; then
 fi
 
 for architecture in arm64 x86_64; do
-  if ! lipo -verify_arch "$architecture" "$built_binary"; then
+  if ! lipo "$built_binary" -verify_arch "$architecture"; then
     echo "Built axorc binary is missing the $architecture architecture: $built_binary" >&2
     exit 1
   fi

--- a/scripts/build-universal-binary.sh
+++ b/scripts/build-universal-binary.sh
@@ -43,33 +43,24 @@ fi
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-stage_dir="$(mktemp -d "${TMPDIR:-/tmp}/axorc-universal.XXXXXX")"
-cleanup() {
-  rm -rf "$stage_dir"
-}
-trap cleanup EXIT
+build_arguments=(-c release --arch arm64 --arch x86_64 --product axorc)
+swift build "${build_arguments[@]}"
+bin_dir="$(swift build "${build_arguments[@]}" --show-bin-path)"
+built_binary="$bin_dir/axorc"
+if [[ ! -x "$built_binary" ]]; then
+  echo "Built universal axorc binary is missing: $built_binary" >&2
+  exit 1
+fi
 
-build_architecture() {
-  local architecture="$1"
-  local destination="$2"
-  local bin_dir
-
-  swift build -c release --arch "$architecture" --product axorc
-  bin_dir="$(swift build -c release --arch "$architecture" --show-bin-path)"
-  if [[ ! -x "$bin_dir/axorc" ]]; then
-    echo "Built axorc binary is missing for $architecture: $bin_dir/axorc" >&2
+for architecture in arm64 x86_64; do
+  if ! lipo -verify_arch "$architecture" "$built_binary"; then
+    echo "Built axorc binary is missing the $architecture architecture: $built_binary" >&2
     exit 1
   fi
-  install -m 0755 "$bin_dir/axorc" "$destination"
-}
-
-arm64_binary="$stage_dir/axorc-arm64"
-x86_64_binary="$stage_dir/axorc-x86_64"
-build_architecture arm64 "$arm64_binary"
-build_architecture x86_64 "$x86_64_binary"
+done
 
 mkdir -p "$(dirname "$output_path")"
-lipo -create "$arm64_binary" "$x86_64_binary" -output "$output_path"
+install -m 0755 "$built_binary" "$output_path"
 strip -x "$output_path"
 
 if [[ "$adhoc" == true ]]; then


### PR DESCRIPTION
## Summary

- build the arm64 and x86_64 release slices in one SwiftPM invocation
- resolve SwiftPM's actual multi-architecture output with `--show-bin-path`
- verify both required slices before preserving the existing strip, signing, artifact, checksum, and formula flow

## Performance

The previous exact-main CI path compiled release dependencies and sources twice in series: 28.18 seconds for arm64 and 28.05 seconds for x86_64. A cold local Swift 6.4 run of the new path completed the Swift build in 21.56 seconds and the signed output in 25.44 seconds wall time.

## Proof

- `scripts/build-universal-binary.sh <temporary-output>/axorc --adhoc`
  - Mach-O universal binary with x86_64 and arm64 slices
  - strict code-signature verification passed
- `scripts/build-release-artifact.sh 0.1.6 --adhoc`
  - archive contained exactly `axorc`
  - SHA-256 verification passed
  - archived binary retained both slices and a valid signature
  - rendered Homebrew formula passed `ruby -c`
- `make check`
- `swift test` (111 tests across the two test executables passed)
- P0-P2 structured autoreview: no actionable findings

The existing deprecated-global warnings in `TraversalOptionsTests` remain intentionally: those tests exercise the published source-compatibility bridge, and replacing them with request-scoped calls would stop testing that contract.
