### PR TITLE
perf: bound application point lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.
 - Route the visitor, collection, element-search, UI-automation, and deep JSON-path walkers through one identity-aware traversal kernel while preserving their established order, depth, pruning, and match semantics.

--- a/Sources/AXorcist/Core/AppLocator.swift
+++ b/Sources/AXorcist/Core/AppLocator.swift
@@ -7,44 +7,144 @@ import os
 public enum AppLocator {
     private static let logger = Logger(subsystem: "boo.peekaboo.axorcist", category: "AppLocator")
 
-    /// Find the application that owns the window under the given screen point.
-    /// Falls back to the frontmost app if nothing matches.
+    enum ResolutionPolicy: Sendable {
+        case exact
+        case frontmostCompatibility
+    }
+
+    struct WindowSnapshot: Equatable, Sendable {
+        let ownerPID: pid_t
+        let bounds: CGRect
+    }
+
+    struct ScreenCoordinateSpace: Equatable, Sendable {
+        let appKitFrame: CGRect
+        let quartzFrame: CGRect
+    }
+
+    struct ApplicationLookup<Application> {
+        let applicationForPID: (pid_t) -> Application?
+        let isEligible: (Application) -> Bool
+        let frontmostApplication: () -> Application?
+    }
+
+    /// Find the application that owns an on-screen window under the given screen point.
+    ///
+    /// This exact lookup never substitutes the frontmost application when the point does not match. Callers with an
+    /// explicit PID or application selector should resolve that selector directly instead of broadening the request to
+    /// a spatial lookup.
+    ///
+    /// - Parameter screenPoint: A point in Quartz global screen coordinates. When omitted, the current AppKit mouse
+    ///   location is translated into the matching display's Quartz coordinate space.
+    @MainActor
+    public static func exactApp(at screenPoint: CGPoint? = nil) -> NSRunningApplication? {
+        self.locate(at: screenPoint, policy: .exact)
+    }
+
+    /// Compatibility lookup for legacy pointer workflows.
+    ///
+    /// If no on-screen window matches the point, this method preserves the historical behavior of returning the
+    /// frontmost application. Use ``exactApp(at:)`` when a miss must remain a miss.
     @MainActor
     public static func app(at screenPoint: CGPoint? = nil) -> NSRunningApplication? {
-        let mouseLocation = screenPoint ?? NSEvent.mouseLocation
-
-        // Prefer frontmost app first (cheap).
-        if let front = NSWorkspace.shared.frontmostApplication,
-           Self.point(mouseLocation, isInsideWindowOf: front)
-        {
-            return front
-        }
-
-        // Search other visible apps.
-        let visibleApps = NSWorkspace.shared.runningApplications.filter {
-            $0.activationPolicy == .regular && !$0.isHidden && $0.bundleIdentifier != nil
-        }
-
-        for app in visibleApps where Self.point(mouseLocation, isInsideWindowOf: app) {
-            return app
-        }
-
-        // Fallback.
-        let fallback = NSWorkspace.shared.frontmostApplication
-        Self.logger.debug("app(at:): falling back to frontmost \(fallback?.localizedName ?? "unknown")")
-        return fallback
+        self.locate(at: screenPoint, policy: .frontmostCompatibility)
     }
 
     @MainActor
-    private static func point(_ point: CGPoint, isInsideWindowOf app: NSRunningApplication) -> Bool {
-        let axApp = AXUIElementCreateApplication(app.processIdentifier)
-        let appElement = Element(axApp)
-        guard let windows = appElement.windows() else { return false }
+    private static func locate(
+        at screenPoint: CGPoint?,
+        policy: ResolutionPolicy) -> NSRunningApplication?
+    {
+        let mouseLocation = screenPoint ?? self.currentMouseLocationInQuartzCoordinates()
+        let windows = self.onScreenWindowSnapshots()
+
+        return self.locate(
+            at: mouseLocation,
+            windows: windows,
+            policy: policy,
+            applications: ApplicationLookup(
+                applicationForPID: { NSRunningApplication(processIdentifier: $0) },
+                isEligible: {
+                    $0.activationPolicy == .regular && !$0.isHidden && $0.bundleIdentifier != nil
+                },
+                frontmostApplication: {
+                    let fallback = NSWorkspace.shared.frontmostApplication
+                    Self.logger.debug("app(at:): falling back to frontmost \(fallback?.localizedName ?? "unknown")")
+                    return fallback
+                }))
+    }
+
+    @MainActor
+    static func locate<Application>(
+        at point: CGPoint,
+        windows: [WindowSnapshot],
+        policy: ResolutionPolicy,
+        applications: ApplicationLookup<Application>) -> Application?
+    {
+        var inspectedPIDs: Set<pid_t> = []
         for window in windows {
-            if let frame = window.frame(), frame.contains(point) {
-                return true
-            }
+            guard window.bounds.contains(point),
+                  inspectedPIDs.insert(window.ownerPID).inserted,
+                  let application = applications.applicationForPID(window.ownerPID),
+                  applications.isEligible(application)
+            else { continue }
+
+            return application
         }
-        return false
+
+        switch policy {
+        case .exact:
+            return nil
+        case .frontmostCompatibility:
+            return applications.frontmostApplication()
+        }
+    }
+
+    private static func onScreenWindowSnapshots() -> [WindowSnapshot] {
+        let options: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+        guard let windowInfo = CGWindowListCopyWindowInfo(options, kCGNullWindowID) as? [[String: Any]] else {
+            return []
+        }
+
+        return windowInfo.compactMap { info in
+            guard let ownerPID = info[kCGWindowOwnerPID as String] as? pid_t,
+                  let bounds = info[kCGWindowBounds as String] as? [String: Any],
+                  let x = bounds["X"] as? CGFloat,
+                  let y = bounds["Y"] as? CGFloat,
+                  let width = bounds["Width"] as? CGFloat,
+                  let height = bounds["Height"] as? CGFloat
+            else { return nil }
+
+            return WindowSnapshot(
+                ownerPID: ownerPID,
+                bounds: CGRect(x: x, y: y, width: width, height: height))
+        }
+    }
+
+    @MainActor
+    private static func currentMouseLocationInQuartzCoordinates() -> CGPoint {
+        let point = NSEvent.mouseLocation
+        let screens = NSScreen.screens.compactMap { screen -> ScreenCoordinateSpace? in
+            guard let number = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber else {
+                return nil
+            }
+
+            return ScreenCoordinateSpace(
+                appKitFrame: screen.frame,
+                quartzFrame: CGDisplayBounds(CGDirectDisplayID(number.uint32Value)))
+        }
+        return self.quartzPoint(fromAppKit: point, screens: screens) ?? point
+    }
+
+    static func quartzPoint(
+        fromAppKit point: CGPoint,
+        screens: [ScreenCoordinateSpace]) -> CGPoint?
+    {
+        guard let screen = screens.first(where: { $0.appKitFrame.contains(point) }) else { return nil }
+        let localX = point.x - screen.appKitFrame.minX
+        let localY = point.y - screen.appKitFrame.minY
+        return CGPoint(
+            x: screen.quartzFrame.minX + localX,
+            y: screen.quartzFrame.minY + screen.quartzFrame.height - localY)
     }
 }

--- a/Tests/AXorcistTests/AppLocatorTests.swift
+++ b/Tests/AXorcistTests/AppLocatorTests.swift
@@ -5,6 +5,11 @@ import Testing
 
 @Suite("AppLocator")
 struct AppLocatorTests {
+    private struct TestApplication: Equatable {
+        let pid: pid_t
+        let isEligible: Bool
+    }
+
     @Test
     @MainActor
     func `returns frontmost when point is nil and front app has window under mouse`() {
@@ -26,5 +31,129 @@ struct AppLocatorTests {
         let offscreen = CGPoint(x: -10000, y: -10000)
         let app = AppLocator.app(at: offscreen)
         #expect(app?.processIdentifier == front.processIdentifier)
+        #expect(AppLocator.exactApp(at: offscreen) == nil)
+    }
+
+    @Test
+    @MainActor
+    func `exact lookup does not use compatibility fallback on miss`() {
+        var fallbackCount = 0
+
+        let result: TestApplication? = AppLocator.locate(
+            at: CGPoint(x: 50, y: 50),
+            windows: [],
+            policy: .exact,
+            applications: AppLocator.ApplicationLookup(
+                applicationForPID: { TestApplication(pid: $0, isEligible: true) },
+                isEligible: \TestApplication.isEligible,
+                frontmostApplication: {
+                    fallbackCount += 1
+                    return TestApplication(pid: 99, isEligible: true)
+                }))
+
+        #expect(result == nil)
+        #expect(fallbackCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `compatibility lookup falls back only after an exact miss`() {
+        var fallbackCount = 0
+
+        let result: TestApplication? = AppLocator.locate(
+            at: CGPoint(x: 50, y: 50),
+            windows: [],
+            policy: .frontmostCompatibility,
+            applications: AppLocator.ApplicationLookup(
+                applicationForPID: { TestApplication(pid: $0, isEligible: true) },
+                isEligible: \TestApplication.isEligible,
+                frontmostApplication: {
+                    fallbackCount += 1
+                    return TestApplication(pid: 99, isEligible: true)
+                }))
+
+        #expect(result?.pid == 99)
+        #expect(fallbackCount == 1)
+    }
+
+    @Test
+    @MainActor
+    func `ordered window index resolves the first eligible owner`() {
+        let point = CGPoint(x: 50, y: 50)
+        let windows = [
+            AppLocator.WindowSnapshot(ownerPID: 10, bounds: CGRect(x: 0, y: 0, width: 100, height: 100)),
+            AppLocator.WindowSnapshot(ownerPID: 10, bounds: CGRect(x: 0, y: 0, width: 80, height: 80)),
+            AppLocator.WindowSnapshot(ownerPID: 20, bounds: CGRect(x: 0, y: 0, width: 100, height: 100)),
+        ]
+        var inspectedPIDs: [pid_t] = []
+        var fallbackCount = 0
+
+        let result: TestApplication? = AppLocator.locate(
+            at: point,
+            windows: windows,
+            policy: .frontmostCompatibility,
+            applications: AppLocator.ApplicationLookup(
+                applicationForPID: {
+                    inspectedPIDs.append($0)
+                    return TestApplication(pid: $0, isEligible: $0 == 20)
+                },
+                isEligible: \TestApplication.isEligible,
+                frontmostApplication: {
+                    fallbackCount += 1
+                    return TestApplication(pid: 99, isEligible: true)
+                }))
+
+        #expect(result?.pid == 20)
+        #expect(inspectedPIDs == [10, 20])
+        #expect(fallbackCount == 0)
+    }
+
+    @Test
+    @MainActor
+    func `offscreen lookup performs no application queries for a large snapshot`() {
+        let point = CGPoint(x: -10000, y: -10000)
+        let windows = (0..<10000).map {
+            AppLocator.WindowSnapshot(
+                ownerPID: pid_t($0 + 1),
+                bounds: CGRect(x: $0, y: $0, width: 10, height: 10))
+        }
+        var applicationQueryCount = 0
+
+        let result: TestApplication? = AppLocator.locate(
+            at: point,
+            windows: windows,
+            policy: .exact,
+            applications: AppLocator.ApplicationLookup(
+                applicationForPID: {
+                    applicationQueryCount += 1
+                    return TestApplication(pid: $0, isEligible: true)
+                },
+                isEligible: \TestApplication.isEligible,
+                frontmostApplication: { TestApplication(pid: 99, isEligible: true) }))
+
+        #expect(result == nil)
+        #expect(applicationQueryCount == 0)
+    }
+
+    @Test
+    func `AppKit mouse points convert to the matching Quartz display`() {
+        let screens = [
+            AppLocator.ScreenCoordinateSpace(
+                appKitFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+                quartzFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080)),
+            AppLocator.ScreenCoordinateSpace(
+                appKitFrame: CGRect(x: -1280, y: 200, width: 1280, height: 720),
+                quartzFrame: CGRect(x: -1280, y: -200, width: 1280, height: 720)),
+        ]
+
+        #expect(AppLocator.quartzPoint(
+            fromAppKit: CGPoint(x: 100, y: 200),
+            screens: screens) == CGPoint(x: 100, y: 880))
+        #expect(AppLocator.quartzPoint(
+            fromAppKit: CGPoint(x: -1000, y: 500),
+            screens: screens) == CGPoint(x: -1000, y: 220))
+        #expect(AppLocator.quartzPoint(
+            fromAppKit: CGPoint(x: 3000, y: 3000),
+            screens: screens) == nil)
     }
 }


### PR DESCRIPTION
## Summary

- replace `AppLocator`'s synchronous all-application Accessibility scan with one ordered native on-screen window snapshot and direct PID resolution
- add `exactApp(at:)`, which never broadens a miss to the frontmost application, while keeping the historical fallback only in `app(at:)`
- translate omitted AppKit mouse locations into the matching display's Quartz coordinate space, including multi-display layouts
- bound candidate resolution to unique window-owner PIDs and add deterministic ordering, fallback, performance, and coordinate tests

## Performance

- baseline off-screen compatibility miss: 5.008 seconds
- updated focused test: 0.04-0.08 seconds on the same desktop
- source-blind live validation: eight fresh exact, compatibility, on-screen, and mouse runs completed in 39-76 ms

## Proof

- `swift test --filter AppLocatorTests` (7/7)
- `PEEKABOO_INCLUDE_AMBIENT_STATE_TESTS=false swift test` (116/116 across both test targets)
- `swift build -c release`
- `make check`
- source-blind behavior contract: 12 passed, 0 failed, 0 blocked
- final P0-P2 autoreview: clean

## Exact-head closeout

- rebased onto AXorcist `main` at `2f490388e6cb2c1b63092f92d1c2ef0b84d1f177` after the Peekaboo dependency consolidation landed
- reran focused and full tests, Release, strict checks, native-only gates, and P0-P2 autoreview on rebased head `68f4da760c4a951b326b3089d8ede65250b8cd90`
- rebuilt the source-blind probe from the rebased head; eight fresh exact, compatibility, on-screen, and live-mouse runs completed in 43-67 ms with every expected PID and coordinate contract satisfied
- exact-head hosted CI passed; Peekaboo's gitlink remains untouched for a separate final pin
