### PR TITLE
fix: fail closed on AX timeout setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Refuse per-element Accessibility reads when macOS cannot arm their messaging deadline, and report any failure to clear an armed deadline after the protected operation.
 - Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, keep observer creation, registration, and cleanup deadline-bounded off the main actor so a wedged app cannot block startup or teardown, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.

--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -15,29 +15,109 @@ extension Element {
     /// Set a messaging timeout for this element to prevent hangs.
     @MainActor
     public func setMessagingTimeout(_ timeout: Float) {
+        _ = self.applyMessagingTimeout(timeout)
+    }
+
+    @MainActor
+    private func applyMessagingTimeout(_ timeout: Float) -> AXError {
         let error = AXUIElementSetMessagingTimeout(self.underlyingElement, timeout)
         if error != .success {
             Logger(subsystem: "boo.peekaboo.axorcist", category: "AXTimeout")
                 .warning("Failed to set messaging timeout: \(error.rawValue)")
         }
+        return error
+    }
+
+    /// Run one synchronous operation with a checked per-element AX messaging deadline.
+    ///
+    /// The operation is never called if macOS refuses the deadline. The deadline is
+    /// cleared after a dispatched operation, including when the operation throws. A
+    /// native failure to clear the deadline is reported instead of returning success.
+    @MainActor
+    public func withMessagingTimeout<Result>(
+        _ timeout: Float,
+        operation: (Element) throws -> Result) throws -> Result
+    {
+        guard AXMessagingTimeoutRegistry.begin(self) else {
+            throw AXMessagingTimeoutError.nestedScope
+        }
+        defer { AXMessagingTimeoutRegistry.end(self) }
+        return try AXMessagingTimeoutScope.perform(
+            timeout: timeout,
+            applyTimeout: self.applyMessagingTimeout,
+            operation: { try operation(self) })
     }
 
     /// Get windows with timeout protection.
     @MainActor
     public func windowsWithTimeout(timeout: Float = 2.0) -> [Element]? {
-        self.setMessagingTimeout(timeout)
-        let windows = self.windows()
-        self.setMessagingTimeout(0)
-        return windows
+        try? self.withMessagingTimeout(timeout) { $0.windows() }
     }
 
     /// Get menu bar with timeout protection.
     @MainActor
     public func menuBarWithTimeout(timeout: Float = 2.0) -> Element? {
-        self.setMessagingTimeout(timeout)
-        let menuBar = self.menuBar()
-        self.setMessagingTimeout(0)
-        return menuBar
+        try? self.withMessagingTimeout(timeout) { $0.menuBar() }
+    }
+}
+
+/// A failure to establish a bounded native Accessibility call.
+public enum AXMessagingTimeoutError: Error, Equatable, Sendable, CustomStringConvertible {
+    case invalidTimeout
+    case nestedScope
+    case systemFailure(code: Int32)
+    case resetFailure(code: Int32)
+
+    public var description: String {
+        switch self {
+        case .invalidTimeout:
+            "AX messaging timeout must be finite and greater than zero."
+        case .nestedScope:
+            "An AX messaging timeout scope is already active for this element."
+        case let .systemFailure(code):
+            "macOS refused the AX messaging timeout (AXError \(code))."
+        case let .resetFailure(code):
+            "macOS refused to clear the AX messaging timeout (AXError \(code))."
+        }
+    }
+}
+
+@MainActor
+private enum AXMessagingTimeoutRegistry {
+    private static var activeElements: Set<Element> = []
+
+    static func begin(_ element: Element) -> Bool {
+        self.activeElements.insert(element).inserted
+    }
+
+    static func end(_ element: Element) {
+        self.activeElements.remove(element)
+    }
+}
+
+enum AXMessagingTimeoutScope {
+    static func perform<Value>(
+        timeout: Float,
+        applyTimeout: (Float) -> AXError,
+        operation: () throws -> Value) throws -> Value
+    {
+        guard timeout.isFinite, timeout > 0 else {
+            throw AXMessagingTimeoutError.invalidTimeout
+        }
+
+        let armResult = applyTimeout(timeout)
+        guard armResult == .success else {
+            throw AXMessagingTimeoutError.systemFailure(code: armResult.rawValue)
+        }
+
+        let operationResult: Result<Value, any Error> = Result {
+            try operation()
+        }
+        let resetResult = applyTimeout(0)
+        guard resetResult == .success else {
+            throw AXMessagingTimeoutError.resetFailure(code: resetResult.rawValue)
+        }
+        return try operationResult.get()
     }
 }
 

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -1,3 +1,5 @@
+import ApplicationServices
+import Darwin
 import Foundation
 import Testing
 @testable import AXorcist
@@ -28,5 +30,183 @@ struct AXTimeoutHelperTests {
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
+    }
+
+    @Test(arguments: ["windows", "menu bar", "child element"])
+    func `checked messaging scope skips protected AX reads when deadline cannot be armed`(read: String) {
+        var timeoutHistory: [Float] = []
+        var dispatchedReads: [String] = []
+
+        #expect(throws: AXMessagingTimeoutError.systemFailure(code: AXError.failure.rawValue)) {
+            try AXMessagingTimeoutScope.perform(
+                timeout: 0.25,
+                applyTimeout: { timeout in
+                    timeoutHistory.append(timeout)
+                    return .failure
+                },
+                operation: {
+                    dispatchedReads.append(read)
+                })
+        }
+
+        #expect(timeoutHistory == [0.25])
+        #expect(dispatchedReads.isEmpty)
+    }
+
+    @Test
+    func `checked messaging scope clears an armed deadline after success`() throws {
+        var timeoutHistory: [Float] = []
+
+        let result = try AXMessagingTimeoutScope.perform(
+            timeout: 0.5,
+            applyTimeout: { timeout in
+                timeoutHistory.append(timeout)
+                return .success
+            },
+            operation: { 42 })
+
+        #expect(result == 42)
+        #expect(timeoutHistory == [0.5, 0])
+    }
+
+    @Test
+    func `checked messaging scope clears an armed deadline after operation failure`() {
+        enum ProbeError: Error {
+            case failed
+        }
+
+        var timeoutHistory: [Float] = []
+        #expect(throws: ProbeError.self) {
+            try AXMessagingTimeoutScope.perform(
+                timeout: 0.5,
+                applyTimeout: { timeout in
+                    timeoutHistory.append(timeout)
+                    return .success
+                },
+                operation: {
+                    throw ProbeError.failed
+                })
+        }
+
+        #expect(timeoutHistory == [0.5, 0])
+    }
+
+    @Test
+    func `checked messaging scope reports reset failure instead of returning success`() {
+        var timeoutHistory: [Float] = []
+
+        #expect(throws: AXMessagingTimeoutError.resetFailure(code: AXError.failure.rawValue)) {
+            try AXMessagingTimeoutScope.perform(
+                timeout: 0.5,
+                applyTimeout: { timeout in
+                    timeoutHistory.append(timeout)
+                    return timeout == 0 ? .failure : .success
+                },
+                operation: { 42 })
+        }
+
+        #expect(timeoutHistory == [0.5, 0])
+    }
+
+    @Test
+    func `checked messaging scope prioritizes reset failure after operation failure`() {
+        enum ProbeError: Error {
+            case failed
+        }
+
+        var timeoutHistory: [Float] = []
+        #expect(throws: AXMessagingTimeoutError.resetFailure(code: AXError.failure.rawValue)) {
+            try AXMessagingTimeoutScope.perform(
+                timeout: 0.5,
+                applyTimeout: { timeout in
+                    timeoutHistory.append(timeout)
+                    return timeout == 0 ? .failure : .success
+                },
+                operation: {
+                    throw ProbeError.failed
+                })
+        }
+
+        #expect(timeoutHistory == [0.5, 0])
+    }
+
+    @Test(arguments: [Float.zero, -0.1, -.infinity, .infinity, .nan])
+    func `checked messaging scope rejects invalid deadlines before the system call`(timeout: Float) {
+        var appliedTimeouts: [Float] = []
+        var dispatched = false
+
+        #expect(throws: AXMessagingTimeoutError.invalidTimeout) {
+            try AXMessagingTimeoutScope.perform(
+                timeout: timeout,
+                applyTimeout: { value in
+                    appliedTimeouts.append(value)
+                    return .success
+                },
+                operation: {
+                    dispatched = true
+                })
+        }
+
+        #expect(appliedTimeouts.isEmpty)
+        #expect(!dispatched)
+    }
+
+    @Test
+    @MainActor
+    func `element messaging scope refuses dispatch when the native deadline fails`() {
+        let invalidApplication = Element(AXUIElementCreateApplication(-1))
+        var dispatched = false
+
+        #expect(throws: AXMessagingTimeoutError.systemFailure(code: AXError.invalidUIElement.rawValue)) {
+            try invalidApplication.withMessagingTimeout(0.5) { _ in
+                dispatched = true
+            }
+        }
+
+        #expect(!dispatched)
+    }
+
+    @Test
+    @MainActor
+    func `element messaging scope refuses same-element reentrancy`() throws {
+        let element = Element(AXUIElementCreateApplication(getpid()))
+
+        _ = try element.withMessagingTimeout(0.5) { outerElement in
+            #expect(throws: AXMessagingTimeoutError.nestedScope) {
+                try outerElement.withMessagingTimeout(0.25) { _ in
+                    Issue.record("Nested operation must not run")
+                }
+            }
+        }
+    }
+
+    @Test
+    @MainActor
+    func `element messaging scope releases ownership after a thrown operation`() throws {
+        enum ProbeError: Error {
+            case failed
+        }
+
+        let element = Element(AXUIElementCreateApplication(getpid()))
+        #expect(throws: ProbeError.self) {
+            try element.withMessagingTimeout(0.5) { _ in
+                throw ProbeError.failed
+            }
+        }
+
+        let result = try element.withMessagingTimeout(0.5) { _ in 42 }
+        #expect(result == 42)
+    }
+
+    @Test
+    @MainActor
+    func `different elements keep independent messaging scopes`() throws {
+        let application = Element(AXUIElementCreateApplication(getpid()))
+        let systemWide = Element(AXUIElementCreateSystemWide())
+
+        let result = try application.withMessagingTimeout(0.5) { _ in
+            try systemWide.withMessagingTimeout(0.5) { _ in 42 }
+        }
+        #expect(result == 42)
     }
 }


### PR DESCRIPTION
## Summary

- add a checked per-element Accessibility messaging-timeout scope that refuses to dispatch when macOS cannot arm the deadline
- always attempt to clear an armed deadline, surface reset failures, and reject same-element reentrancy before one scope can overwrite another
- route the existing window and menu-bar timeout helpers through the checked scope without breaking their optional-returning API
- drop the former process-generation and exact-window receipt proposal because current `main` now owns process identity in the observer stack

## Why

`AXUIElementSetMessagingTimeout` can fail, but the existing helpers only logged that error and continued with the supposedly protected AX read. That converted a refused deadline into an unbounded background Accessibility call. The checked scope treats timeout setup and cleanup as part of the operation result, so callers cannot mistake an unbounded or uncleared operation for success.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (161 library tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- deterministic native invalid-element refusal plus synthetic window, menu-bar, child-read, reset, reentrancy, and independent-element coverage
- structured P0-P2 autoreview clean after accepting and fixing one reset-failure finding
