### PR TITLE
fix(observers): implement native global fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/README.md
+++ b/README.md
@@ -496,6 +496,23 @@ Monitor UI changes with these notifications:
 Observe and `stopObservation` commands executed by the same `AXorcist` instance share one subscription registry, so a
 successful stop clears the observations that instance started.
 
+Accessibility observers are application-scoped on macOS; PID `0` and the system-wide AX element cannot receive
+notifications. `NotificationWatcher(globalNotification:)` implements global watching by registering one observer for
+each running user application and observing native KVO changes to `NSWorkspace.runningApplications` to keep that set
+current, including menu-bar agents and background applications:
+
+```swift
+let watcher = NotificationWatcher(globalNotification: .focusedUIElementChanged) {
+    pid, notification, element, userInfo in
+    print("\(pid): \(notification.rawValue)")
+}
+try watcher.start()
+```
+
+Applications that do not support the requested notification are skipped. Starting fails when running candidate
+applications exist but none accepts the notification. The deprecated nil-PID `AXObserverCenter.subscribe` entry point
+now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer.
+
 ### Observer Example
 
 ```json

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -1,0 +1,89 @@
+import AppKit
+import Foundation
+
+@MainActor
+protocol AXGlobalApplicationMonitoring: AnyObject, Sendable {
+    var runningProcessIdentifiers: [pid_t] { get }
+
+    func start(
+        onLaunch: @escaping @MainActor (pid_t) -> Void,
+        onTermination: @escaping @MainActor (pid_t) -> Void)
+    func stop()
+}
+
+/// Event-driven application lifecycle source for global AX notification fan-out.
+///
+/// Accessibility observers are process scoped. `NSWorkspace` supplies the native
+/// lifecycle events needed to attach and detach those observers without polling.
+@MainActor
+final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
+    var runningProcessIdentifiers: [pid_t] {
+        Self.eligibleApplications(NSWorkspace.shared.runningApplications).map(\.processIdentifier)
+    }
+
+    func start(
+        onLaunch: @escaping @MainActor (pid_t) -> Void,
+        onTermination: @escaping @MainActor (pid_t) -> Void)
+    {
+        guard self.runningApplicationsObservation == nil else { return }
+        self.onLaunch = onLaunch
+        self.onTermination = onTermination
+        self.runningApplicationsObservation = NSWorkspace.shared.observe(
+            \.runningApplications,
+            options: [.initial, .new])
+        { [weak self] _, _ in
+            MainActor.assumeIsolated {
+                self?.reconcile(NSWorkspace.shared.runningApplications)
+            }
+        }
+    }
+
+    func stop() {
+        self.runningApplicationsObservation?.invalidate()
+        self.runningApplicationsObservation = nil
+        self.applicationsByIdentity = [:]
+        self.onLaunch = nil
+        self.onTermination = nil
+    }
+
+    private var runningApplicationsObservation: NSKeyValueObservation?
+    private var applicationsByIdentity: [ObjectIdentifier: pid_t] = [:]
+    private var onLaunch: (@MainActor (pid_t) -> Void)?
+    private var onTermination: (@MainActor (pid_t) -> Void)?
+
+    private func reconcile(_ runningApplications: [NSRunningApplication]) {
+        let currentApplications = Dictionary(
+            uniqueKeysWithValues: Self.eligibleApplications(runningApplications).map {
+                (ObjectIdentifier($0), $0.processIdentifier)
+            })
+        let changes = Self.lifecycleChanges(
+            previous: self.applicationsByIdentity,
+            current: currentApplications)
+        for processIdentifier in changes.terminations {
+            self.onTermination?(processIdentifier)
+        }
+        for processIdentifier in changes.launches {
+            self.onLaunch?(processIdentifier)
+        }
+        self.applicationsByIdentity = currentApplications
+    }
+
+    static func lifecycleChanges<Identity: Hashable>(
+        previous: [Identity: pid_t],
+        current: [Identity: pid_t]) -> (terminations: [pid_t], launches: [pid_t])
+    {
+        let terminations = previous.compactMap { identity, processIdentifier in
+            current[identity] == nil ? processIdentifier : nil
+        }.sorted()
+        let launches = current.compactMap { identity, processIdentifier in
+            previous[identity] == nil ? processIdentifier : nil
+        }.sorted()
+        return (terminations, launches)
+    }
+
+    private static func eligibleApplications(
+        _ runningApplications: [NSRunningApplication]) -> [NSRunningApplication]
+    {
+        runningApplications.filter { !$0.isTerminated && $0.processIdentifier > 0 }
+    }
+}

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -22,11 +22,11 @@ import Foundation
 @MainActor
 public final class AXObserverCenter {
     typealias ObserverSetup = @MainActor (
-        _ pid: pid_t?,
+        _ pid: pid_t,
         _ element: Element?,
         _ notification: AXNotification) -> AXError
     typealias ObserverCleanup = @MainActor (
-        _ pid: pid_t?,
+        _ pid: pid_t,
         _ element: Element,
         _ notification: AXNotification) -> Void
 
@@ -73,11 +73,15 @@ public final class AXObserverCenter {
 @MainActor
 extension AXObserverCenter {
     public func subscribe(
-        pid: pid_t? = nil,
+        pid: pid_t,
         element: Element? = nil,
         notification: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
     {
+        guard pid > 0 else {
+            return .failure(.observerSetupFailed(
+                details: "macOS AXObserver requires an application PID greater than zero"))
+        }
         let elementDescriptionForLog = element?.briefDescription() ?? "N/A"
         axDebugLog(
             logSegments(
@@ -104,6 +108,29 @@ extension AXObserverCenter {
                 "Successfully subscribed handler (token: \(token.id)) for \(describePid(pid))",
                 "notification: \(notification.rawValue)"))
         return .success(token)
+    }
+
+    /// Compatibility entry point for the former nil-PID global observer API.
+    ///
+    /// macOS AX observers require an application PID and the system-wide element does
+    /// not support notifications. Use `NotificationWatcher(globalNotification:)` for
+    /// native event-driven fan-out across running applications.
+    @available(
+        *,
+        deprecated,
+        message: "A nil PID cannot create a macOS AXObserver; use NotificationWatcher(globalNotification:handler:)")
+    public func subscribe(
+        pid: pid_t? = nil,
+        element: Element? = nil,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        guard let pid else {
+            let details = "macOS AXObserver requires an application PID; " +
+                "use NotificationWatcher(globalNotification:) for native global fan-out"
+            return .failure(.observerSetupFailed(details: details))
+        }
+        return self.subscribe(pid: pid, element: element, notification: notification, handler: handler)
     }
 
     public func unsubscribe(token: SubscriptionToken) throws {
@@ -151,7 +178,8 @@ extension AXObserverCenter {
     }
 
     public func isKeyRegistered(pid: pid_t?, notification: AXNotification) -> Bool {
-        self.subscriptionStore.contains(pid: pid, notification: notification)
+        guard let pid else { return false }
+        return self.subscriptionStore.contains(pid: pid, notification: notification)
     }
 }
 
@@ -167,14 +195,12 @@ extension AXObserverCenter {
     // MARK: - Internal AXObserver Management (previously addObserver / removeObserver)
 
     private func registrationKey(
-        pid: pid_t?,
+        pid: pid_t,
         element: Element?,
         notification: AXNotification) -> AXObserverRegistrationKey
     {
-        let targetPid = pid ?? 0
         let observedElement = Element(self.elementForObservation(
             pid: pid,
-            targetPid: targetPid,
             element: element,
             notification: notification))
         return AXObserverRegistrationKey(
@@ -183,8 +209,7 @@ extension AXObserverCenter {
             scope: self.registrationScope(pid: pid, observedElement: observedElement))
     }
 
-    private func registrationScope(pid: pid_t?, observedElement: Element) -> AXObserverRegistrationKey.Scope {
-        guard let pid else { return .process }
+    private func registrationScope(pid: pid_t, observedElement: Element) -> AXObserverRegistrationKey.Scope {
         let applicationElement = Element(AXUIElement.application(pid: pid))
         return observedElement == applicationElement ? .process : .element
     }
@@ -196,7 +221,7 @@ extension AXObserverCenter {
             return observerSetupOverride(subscription.pid, registration.element, subscription.notification)
         }
 
-        let targetPid = subscription.pid ?? 0
+        let targetPid = subscription.pid
         self.logObserverSetup(
             targetPid: targetPid,
             element: registration.element,
@@ -230,34 +255,25 @@ extension AXObserverCenter {
     }
 
     private func elementForObservation(
-        pid: pid_t?,
-        targetPid: pid_t,
+        pid: pid_t,
         element: Element?,
         notification: AXNotification) -> AXUIElement
     {
         if let specificElement = element {
             axDebugLog(
                 logSegments(
-                    "Observer for \(describePid(targetPid))",
+                    "Observer for \(describePid(pid))",
                     "using provided specific element \(specificElement.briefDescription())",
                     "notification \(notification.rawValue)"))
             return specificElement.underlyingElement
         }
 
-        if pid == nil {
-            axDebugLog(
-                logSegments(
-                    "Global observer: Using system-wide element",
-                    "notification \(notification.rawValue)"))
-            return AXUIElementCreateSystemWide()
-        }
-
         axDebugLog(
             logSegments(
-                "Application observer \(describePid(targetPid))",
+                "Application observer \(describePid(pid))",
                 "Using application element",
                 "notification \(notification.rawValue)"))
-        return AXUIElement.application(pid: targetPid)
+        return AXUIElement.application(pid: pid)
     }
 
     private func logObserverAddResult(targetPid: pid_t, notification: AXNotification, error: AXError) {
@@ -279,7 +295,7 @@ extension AXObserverCenter {
             return
         }
 
-        let targetPid = subscription.pid ?? 0
+        let targetPid = subscription.pid
         axDebugLog(
             logSegments(
                 "Cleanup check for underlying AXObserver notification for \(describePid(targetPid))",

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -250,6 +250,10 @@ public class AXorcist {
         notification: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
     {
+        guard let pid = pid ?? element.pid() else {
+            return .failure(.observerSetupFailed(
+                details: "Observed accessibility element has no owning application PID"))
+        }
         let result = self.observationRegistry.subscribe(
             pid: pid,
             element: element,

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -34,6 +34,7 @@ public class NotificationWatcher {
         self.notification = notification
         self.handler = handler
         self.registry = AXObserverCenter.shared
+        self.globalApplicationMonitor = nil
         let logMessage = "NotificationWatcher initialized for element, notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
@@ -48,6 +49,7 @@ public class NotificationWatcher {
         self.notification = notification
         self.handler = handler
         self.registry = registry
+        self.globalApplicationMonitor = nil
     }
 
     /// Initializes a watcher for a specific process ID (PID).
@@ -56,6 +58,7 @@ public class NotificationWatcher {
         self.notification = notification
         self.handler = handler
         self.registry = AXObserverCenter.shared
+        self.globalApplicationMonitor = nil
         let logMessage = "NotificationWatcher initialized for PID \(pid), notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
@@ -70,6 +73,7 @@ public class NotificationWatcher {
         self.notification = notification
         self.handler = handler
         self.registry = registry
+        self.globalApplicationMonitor = nil
     }
 
     /// Initializes a watcher for a global notification (any application).
@@ -78,16 +82,38 @@ public class NotificationWatcher {
         self.notification = notification
         self.handler = handler
         self.registry = AXObserverCenter.shared
+        self.globalApplicationMonitor = AXWorkspaceApplicationMonitor()
         let logMessage = "NotificationWatcher initialized for global notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
 
+    init(
+        globalNotification notification: AXNotification,
+        registry: any AXObservationRegistry,
+        applicationMonitor: any AXGlobalApplicationMonitoring,
+        handler: @escaping AXNotificationSubscriptionHandler)
+    {
+        self.target = .global
+        self.notification = notification
+        self.handler = handler
+        self.registry = registry
+        self.globalApplicationMonitor = applicationMonitor
+    }
+
     deinit {
         axDebugLog("NotificationWatcher deinit")
-        guard let token = self.subscriptionToken else { return }
+        let token = self.subscriptionToken
+        let globalTokens = Array(self.globalSubscriptionTokens.values)
         let registry = self.registry
+        let applicationMonitor = self.globalApplicationMonitor
         Task { @MainActor in
-            try? registry.unsubscribe(token: token)
+            applicationMonitor?.stop()
+            if let token {
+                try? registry.unsubscribe(token: token)
+            }
+            for token in globalTokens {
+                try? registry.unsubscribe(token: token)
+            }
         }
     }
 
@@ -112,7 +138,12 @@ public class NotificationWatcher {
             return
         }
 
-        var effectivePid: pid_t? // For global, pid is nil for subscribe
+        if case .global = self.target {
+            try self.startGlobalObservation()
+            return
+        }
+
+        var effectivePid: pid_t = 0
         var elementForSubscription: Element? // For element-specific, pass the element to subscribe
         var targetDescription: String
 
@@ -120,8 +151,7 @@ public class NotificationWatcher {
         case let .element(element):
             targetDescription = element.briefDescription()
             elementForSubscription = element
-            let pidForSubscription = element.pid()
-            if pidForSubscription == nil {
+            guard let pidForSubscription = element.pid() else {
                 let elBrief = element.briefDescription()
                 let logMessage = "Cannot start watcher: Element has no PID. Element: \(elBrief)"
                 axErrorLog(logMessage)
@@ -132,14 +162,12 @@ public class NotificationWatcher {
             targetDescription = "PID: \(pid)"
             effectivePid = pid
         case .global:
-            targetDescription = "Global"
-            effectivePid = nil // AXObserverCenter handles pid: nil for global
+            preconditionFailure("Global observation must use native process fan-out")
         }
 
-        let pidToLog = effectivePid ?? 0
         let logStart =
             "NotificationWatcher starting for target: \(targetDescription) " +
-            "(PID: \(pidToLog)), notification: \(self.notification.rawValue)"
+            "(PID: \(effectivePid)), notification: \(self.notification.rawValue)"
         axInfoLog(logStart)
 
         let subscribeResult = self.registry.subscribe(
@@ -164,6 +192,10 @@ public class NotificationWatcher {
     /// Stops observing the notification.
     @MainActor
     public func stop() {
+        if case .global = self.target {
+            self.stopGlobalObservation()
+            return
+        }
         guard self.isObserving, let token = subscriptionToken else {
             // let logMessage = "NotificationWatcher for \(self.notification.rawValue) on \(self.target) is not
             // observing or no token."
@@ -196,6 +228,81 @@ public class NotificationWatcher {
     private let notification: AXNotification
     private let handler: AXNotificationSubscriptionHandler
     private let registry: any AXObservationRegistry
+    private let globalApplicationMonitor: (any AXGlobalApplicationMonitoring)?
     private var subscriptionToken: SubscriptionToken?
+    private var globalSubscriptionTokens: [pid_t: SubscriptionToken] = [:]
     private var isObserving: Bool = false
+}
+
+@MainActor
+extension NotificationWatcher {
+    private func startGlobalObservation() throws {
+        guard let globalApplicationMonitor else {
+            throw AccessibilityError.observerSetupFailed(details: "Global application lifecycle monitor unavailable")
+        }
+
+        globalApplicationMonitor.start(
+            onLaunch: { [weak self] pid in
+                guard let self, let error = self.subscribeGlobalProcess(pid) else { return }
+                axWarningLog("Global observer skipped launched PID \(pid): \(error.localizedDescription)")
+            },
+            onTermination: { [weak self] pid in
+                self?.unsubscribeGlobalProcess(pid)
+            })
+
+        let processIdentifiers = Array(Set(globalApplicationMonitor.runningProcessIdentifiers)).sorted()
+        var failures: [AccessibilityError] = []
+        for pid in processIdentifiers {
+            if let error = self.subscribeGlobalProcess(pid) {
+                failures.append(error)
+                axWarningLog("Global observer skipped running PID \(pid): \(error.localizedDescription)")
+            }
+        }
+
+        if !processIdentifiers.isEmpty, self.globalSubscriptionTokens.isEmpty {
+            globalApplicationMonitor.stop()
+            throw failures.first ?? AccessibilityError.observerSetupFailed(
+                details: "No running application accepted \(self.notification.rawValue)")
+        }
+
+        self.isObserving = true
+        axInfoLog(
+            "Global observer started with \(self.globalSubscriptionTokens.count) process registrations for " +
+                self.notification.rawValue)
+    }
+
+    private func stopGlobalObservation() {
+        guard self.isObserving || !self.globalSubscriptionTokens.isEmpty else { return }
+        self.globalApplicationMonitor?.stop()
+        for pid in self.globalSubscriptionTokens.keys.sorted() {
+            self.unsubscribeGlobalProcess(pid)
+        }
+        self.isObserving = false
+        axInfoLog("Global observer stopped for \(self.notification.rawValue)")
+    }
+
+    private func subscribeGlobalProcess(_ pid: pid_t) -> AccessibilityError? {
+        guard pid > 0, self.globalSubscriptionTokens[pid] == nil else { return nil }
+        switch self.registry.subscribe(
+            pid: pid,
+            element: nil,
+            notification: self.notification,
+            handler: self.handler)
+        {
+        case let .success(token):
+            self.globalSubscriptionTokens[pid] = token
+            return nil
+        case let .failure(error):
+            return error
+        }
+    }
+
+    private func unsubscribeGlobalProcess(_ pid: pid_t) {
+        guard let token = self.globalSubscriptionTokens.removeValue(forKey: pid) else { return }
+        do {
+            try self.registry.unsubscribe(token: token)
+        } catch {
+            axWarningLog("Global observer cleanup failed for PID \(pid): \(error.localizedDescription)")
+        }
+    }
 }

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -19,7 +19,7 @@ public typealias AXNotificationSubscriptionHandler = @MainActor ( /* element: El
 @MainActor
 protocol AXObservationRegistry: AnyObject, Sendable {
     func subscribe(
-        pid: pid_t?,
+        pid: pid_t,
         element: Element?,
         notification: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
@@ -29,11 +29,10 @@ protocol AXObservationRegistry: AnyObject, Sendable {
 
 /// Key for tracking accessibility notification subscriptions.
 ///
-/// Allows for both process-specific and global notification observers.
-/// When `pid` is nil, the subscription applies globally for that notification type.
+/// Accessibility notification subscription for one exact process.
 public struct AXNotificationSubscriptionKey: Hashable {
-    /// Process ID to monitor, or nil for global monitoring.
-    let pid: pid_t?
+    /// Process ID to monitor.
+    let pid: pid_t
 
     /// The accessibility notification type to observe.
     let notification: AXNotification
@@ -148,7 +147,7 @@ final class AXObserverSubscriptionStore {
         }
     }
 
-    func contains(pid: pid_t?, notification: AXNotification) -> Bool {
+    func contains(pid: pid_t, notification: AXNotification) -> Bool {
         self.subscriptions.contains { registration, handlers in
             registration.subscription.pid == pid &&
                 registration.subscription.notification == notification &&
@@ -162,7 +161,7 @@ final class AXObserverSubscriptionStore {
 
     func containsSubscriptions(forEffectivePID pid: pid_t) -> Bool {
         self.subscriptions.contains { registration, handlers in
-            (registration.subscription.pid ?? 0) == pid && !handlers.isEmpty
+            registration.subscription.pid == pid && !handlers.isEmpty
         }
     }
 
@@ -175,19 +174,17 @@ final class AXObserverSubscriptionStore {
         let specificKey = AXNotificationSubscriptionKey(
             pid: pid,
             notification: notification)
-        let globalKey = AXNotificationSubscriptionKey(pid: nil, notification: notification)
         var handlersToCall: [AXNotificationSubscriptionHandler] = []
         let eventElement = Element(rawElement)
         for (registration, handlers) in self.subscriptions {
             let subscription = registration.subscription
-            let matchesGlobal = subscription == globalKey
             let matchesProcess = subscription == specificKey && registration.scope == .process
             // AXObserver registrations are object-specific. Only application registrations use process scope;
             // element registrations must not fan the callback out to sibling accessibility objects.
             let matchesElement = subscription == specificKey &&
                 registration.scope == .element &&
                 registration.element == eventElement
-            if matchesGlobal || matchesProcess || matchesElement {
+            if matchesProcess || matchesElement {
                 handlersToCall.append(contentsOf: handlers.values)
             }
         }

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -17,6 +17,36 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `PID zero cannot create a native global AX observer`() {
+        var observer: AXObserver?
+        let callback: AXObserverCallbackWithInfo = { _, _, _, _, _ in }
+
+        let error = AXObserverCreateWithInfoCallback(0, callback, &observer)
+
+        #expect(error != .success)
+        #expect(observer == nil)
+    }
+
+    @Test
+    func `observer center rejects PID zero before native setup`() {
+        var setupCalled = false
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCalled = true
+                return .success
+            },
+            observerCleanup: { _, _, _ in })
+
+        let result = center.subscribe(pid: 0, notification: .focusedUIElementChanged) { _, _, _, _ in }
+
+        if case .failure = result {
+            #expect(!setupCalled)
+        } else {
+            Issue.record("Expected PID zero to be refused")
+        }
+    }
+
+    @Test
     func `CLI recognizes the current observe success response`() {
         #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"success\"}"))
         #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"error\"}") == false)
@@ -25,7 +55,7 @@ struct ObserverLifecycleTests {
     @Test
     func `observe and stop use the same registry without clearing unrelated subscriptions`() throws {
         let registry = RecordingObservationRegistry()
-        let target = Element(AXUIElementCreateSystemWide())
+        let target = Element(AXUIElementCreateApplication(getpid()))
         let unrelatedToken = try registry.subscribe(
             pid: 7,
             element: nil,
@@ -59,6 +89,23 @@ struct ObserverLifecycleTests {
         #expect(registry.unsubscribeCallCount == 1)
         #expect(registry.activeSubscriptionCount == 1)
         #expect(registry.contains(unrelatedToken))
+    }
+
+    @Test
+    func `application observation derives its PID when the caller omits it`() throws {
+        let registry = RecordingObservationRegistry()
+        let target = Element(AXUIElementCreateApplication(getpid()))
+        let axorcist = AXorcist(
+            observationRegistry: registry,
+            observationTargetResolver: { _, _, _ in (target, nil) })
+
+        _ = try axorcist.subscribeToObservation(
+            pid: nil,
+            element: target,
+            notification: .valueChanged)
+        { _, _, _, _ in }.get()
+
+        #expect(registry.subscribedProcessIdentifiers == [getpid()])
     }
 
     @Test
@@ -192,9 +239,65 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `global watcher fans out by PID and follows native application lifecycle`() throws {
+        let registry = RecordingObservationRegistry()
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [42, 41])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor)
+        { _, _, _, _ in }
+
+        try watcher.start()
+
+        #expect(watcher.isActive)
+        #expect(registry.subscribedProcessIdentifiers == [41, 42])
+        #expect(!registry.subscribedProcessIdentifiers.contains(0))
+
+        applicationMonitor.launch(processIdentifier: 43)
+        applicationMonitor.launch(processIdentifier: 43)
+        #expect(registry.subscribedProcessIdentifiers == [41, 42, 43])
+
+        applicationMonitor.terminate(processIdentifier: 42)
+        #expect(registry.activeProcessIdentifiers == [41, 43])
+
+        watcher.stop()
+        #expect(!watcher.isActive)
+        #expect(registry.activeProcessIdentifiers.isEmpty)
+        #expect(applicationMonitor.stopCount == 1)
+    }
+
+    @Test
+    func `global watcher fails when every current application rejects registration`() {
+        let registry = RecordingObservationRegistry(failingProcessIdentifiers: [41, 42])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor)
+        { _, _, _, _ in }
+
+        #expect(throws: AccessibilityError.self) {
+            try watcher.start()
+        }
+        #expect(!watcher.isActive)
+        #expect(applicationMonitor.stopCount == 1)
+    }
+
+    @Test
+    func `workspace application diff preserves replacement events when a PID is reused`() {
+        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
+            previous: ["stable": pid_t(7), "old-generation": pid_t(42)],
+            current: ["stable": pid_t(7), "agent": pid_t(9), "new-generation": pid_t(42)])
+
+        #expect(changes.terminations == [42])
+        #expect(changes.launches == [9, 42])
+    }
+
+    @Test
     func `AXorcist deinit unregisters its owned tokens`() async {
         let registry = RecordingObservationRegistry()
-        let target = Element(AXUIElementCreateSystemWide())
+        let target = Element(AXUIElementCreateApplication(getpid()))
         var axorcist: AXorcist? = AXorcist(
             observationRegistry: registry,
             observationTargetResolver: { _, _, _ in (target, nil) })
@@ -229,11 +332,22 @@ private final class WeakReference<Value: AnyObject> {
 @MainActor
 private final class RecordingObservationRegistry: AXObservationRegistry {
     private var subscriptions: [SubscriptionToken: AXNotificationSubscriptionHandler] = [:]
+    private var processIdentifiersByToken: [SubscriptionToken: pid_t] = [:]
+    private let failingProcessIdentifiers: Set<pid_t>
 
     private(set) var unsubscribeCallCount = 0
+    private(set) var subscribedProcessIdentifiers: [pid_t] = []
+
+    init(failingProcessIdentifiers: Set<pid_t> = []) {
+        self.failingProcessIdentifiers = failingProcessIdentifiers
+    }
 
     var activeSubscriptionCount: Int {
         self.subscriptions.count
+    }
+
+    var activeProcessIdentifiers: [pid_t] {
+        self.processIdentifiersByToken.values.sorted()
     }
 
     func contains(_ token: SubscriptionToken) -> Bool {
@@ -241,13 +355,18 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
     }
 
     func subscribe(
-        pid _: pid_t?,
+        pid: pid_t,
         element _: Element?,
         notification _: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
     {
+        self.subscribedProcessIdentifiers.append(pid)
+        guard !self.failingProcessIdentifiers.contains(pid) else {
+            return .failure(.observerSetupFailed(details: "Fixture rejected PID \(pid)"))
+        }
         let token = SubscriptionToken(id: UUID())
         self.subscriptions[token] = handler
+        self.processIdentifiersByToken[token] = pid
         return .success(token)
     }
 
@@ -256,5 +375,44 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
         guard self.subscriptions.removeValue(forKey: token) != nil else {
             throw AccessibilityError.tokenNotFound(tokenId: token.id)
         }
+        self.processIdentifiersByToken.removeValue(forKey: token)
+    }
+}
+
+@MainActor
+private final class RecordingGlobalApplicationMonitor: AXGlobalApplicationMonitoring {
+    private(set) var runningProcessIdentifiers: [pid_t]
+    private(set) var stopCount = 0
+    private var onLaunch: (@MainActor (pid_t) -> Void)?
+    private var onTermination: (@MainActor (pid_t) -> Void)?
+
+    init(runningProcessIdentifiers: [pid_t]) {
+        self.runningProcessIdentifiers = runningProcessIdentifiers
+    }
+
+    func start(
+        onLaunch: @escaping @MainActor (pid_t) -> Void,
+        onTermination: @escaping @MainActor (pid_t) -> Void)
+    {
+        self.onLaunch = onLaunch
+        self.onTermination = onTermination
+    }
+
+    func stop() {
+        self.stopCount += 1
+        self.onLaunch = nil
+        self.onTermination = nil
+    }
+
+    func launch(processIdentifier: pid_t) {
+        if !self.runningProcessIdentifiers.contains(processIdentifier) {
+            self.runningProcessIdentifiers.append(processIdentifier)
+        }
+        self.onLaunch?(processIdentifier)
+    }
+
+    func terminate(processIdentifier: pid_t) {
+        self.runningProcessIdentifiers.removeAll { $0 == processIdentifier }
+        self.onTermination?(processIdentifier)
     }
 }


### PR DESCRIPTION
## Summary

- replace the impossible PID-zero global AX observer with one shared observer registration per running application
- track all `NSWorkspace.runningApplications` changes through KVO, including menu-bar agents and background applications, without polling
- diff application object identities so PID reuse removes the old registration before attaching the replacement
- reject nil and zero PIDs before native observer setup while preserving the former optional-PID call as a deprecated compatibility entry point
- keep global registration lifecycle token-scoped so process and global watchers share native registrations and clean up independently

## Why

macOS Accessibility observers are application scoped. A native probe confirms that `AXObserverCreateWithInfoCallback(0, ...)` cannot create an observer, and Apple documents that the system-wide accessibility element does not support notifications. Global watching therefore has to fan out across application PIDs and follow the complete `runningApplications` lifecycle.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (121 safe tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- native PID-zero observer probe and deterministic KVO lifecycle/PID-reuse tests
- structured P0-P2 autoreview converged with no actionable findings
