### PR TITLE
fix(observers): retry transient global registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, with bounded recovery for transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/README.md
+++ b/README.md
@@ -511,7 +511,9 @@ try watcher.start()
 
 Applications that do not support the requested notification are skipped. Starting fails when running candidate
 applications exist but none accepts the notification. The deprecated nil-PID `AXObserverCenter.subscribe` entry point
-now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer.
+now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer. A transient
+registration failure after an application lifecycle event receives three bounded retries; termination cancels pending
+retry work, so this recovery never becomes a polling loop.
 
 ### Observer Example
 

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -3,6 +3,15 @@
 import ApplicationServices
 import Foundation
 
+private enum AXGlobalObserverRetryPolicy {
+    static let maximumAttempts = 3
+
+    static func sleep(beforeAttempt attempt: Int) async throws {
+        let delayMilliseconds = 100 * (1 << (attempt - 1))
+        try await Task.sleep(for: .milliseconds(delayMilliseconds))
+    }
+}
+
 /// Provides a high-level interface for observing accessibility notifications on UI elements or processes.
 ///
 /// NotificationWatcher simplifies the process of:
@@ -35,6 +44,7 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = AXObserverCenter.shared
         self.globalApplicationMonitor = nil
+        self.globalRetrySleep = AXGlobalObserverRetryPolicy.sleep
         let logMessage = "NotificationWatcher initialized for element, notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
@@ -50,6 +60,7 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = registry
         self.globalApplicationMonitor = nil
+        self.globalRetrySleep = AXGlobalObserverRetryPolicy.sleep
     }
 
     /// Initializes a watcher for a specific process ID (PID).
@@ -59,6 +70,7 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = AXObserverCenter.shared
         self.globalApplicationMonitor = nil
+        self.globalRetrySleep = AXGlobalObserverRetryPolicy.sleep
         let logMessage = "NotificationWatcher initialized for PID \(pid), notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
@@ -74,6 +86,7 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = registry
         self.globalApplicationMonitor = nil
+        self.globalRetrySleep = AXGlobalObserverRetryPolicy.sleep
     }
 
     /// Initializes a watcher for a global notification (any application).
@@ -83,6 +96,7 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = AXObserverCenter.shared
         self.globalApplicationMonitor = AXWorkspaceApplicationMonitor()
+        self.globalRetrySleep = AXGlobalObserverRetryPolicy.sleep
         let logMessage = "NotificationWatcher initialized for global notification: \(notification.rawValue)"
         axDebugLog(logMessage)
     }
@@ -91,6 +105,7 @@ public class NotificationWatcher {
         globalNotification notification: AXNotification,
         registry: any AXObservationRegistry,
         applicationMonitor: any AXGlobalApplicationMonitoring,
+        retrySleep: @escaping @Sendable (Int) async throws -> Void = AXGlobalObserverRetryPolicy.sleep,
         handler: @escaping AXNotificationSubscriptionHandler)
     {
         self.target = .global
@@ -98,14 +113,19 @@ public class NotificationWatcher {
         self.handler = handler
         self.registry = registry
         self.globalApplicationMonitor = applicationMonitor
+        self.globalRetrySleep = retrySleep
     }
 
     deinit {
         axDebugLog("NotificationWatcher deinit")
         let token = self.subscriptionToken
         let globalTokens = Array(self.globalSubscriptionTokens.values)
+        let globalRetryTasks = Array(self.globalRetryTasks.values)
         let registry = self.registry
         let applicationMonitor = self.globalApplicationMonitor
+        for task in globalRetryTasks {
+            task.cancel()
+        }
         Task { @MainActor in
             applicationMonitor?.stop()
             if let token {
@@ -229,8 +249,11 @@ public class NotificationWatcher {
     private let handler: AXNotificationSubscriptionHandler
     private let registry: any AXObservationRegistry
     private let globalApplicationMonitor: (any AXGlobalApplicationMonitoring)?
+    private let globalRetrySleep: @Sendable (Int) async throws -> Void
     private var subscriptionToken: SubscriptionToken?
     private var globalSubscriptionTokens: [pid_t: SubscriptionToken] = [:]
+    private var globalRetryTasks: [pid_t: Task<Void, Never>] = [:]
+    private var globalObservationStarting = false
     private var isObserving: Bool = false
 }
 
@@ -241,12 +264,14 @@ extension NotificationWatcher {
             throw AccessibilityError.observerSetupFailed(details: "Global application lifecycle monitor unavailable")
         }
 
+        self.globalObservationStarting = true
+        defer { self.globalObservationStarting = false }
         globalApplicationMonitor.start(
             onLaunch: { [weak self] pid in
-                guard let self, let error = self.subscribeGlobalProcess(pid) else { return }
-                axWarningLog("Global observer skipped launched PID \(pid): \(error.localizedDescription)")
+                self?.handleGlobalLaunch(pid)
             },
             onTermination: { [weak self] pid in
+                self?.cancelGlobalRetry(pid)
                 self?.unsubscribeGlobalProcess(pid)
             })
 
@@ -256,10 +281,14 @@ extension NotificationWatcher {
             if let error = self.subscribeGlobalProcess(pid) {
                 failures.append(error)
                 axWarningLog("Global observer skipped running PID \(pid): \(error.localizedDescription)")
+                self.scheduleGlobalRetry(pid, attempt: 1, lastError: error)
+            } else {
+                self.cancelGlobalRetry(pid)
             }
         }
 
         if !processIdentifiers.isEmpty, self.globalSubscriptionTokens.isEmpty {
+            self.cancelAllGlobalRetries()
             globalApplicationMonitor.stop()
             throw failures.first ?? AccessibilityError.observerSetupFailed(
                 details: "No running application accepted \(self.notification.rawValue)")
@@ -274,6 +303,7 @@ extension NotificationWatcher {
     private func stopGlobalObservation() {
         guard self.isObserving || !self.globalSubscriptionTokens.isEmpty else { return }
         self.globalApplicationMonitor?.stop()
+        self.cancelAllGlobalRetries()
         for pid in self.globalSubscriptionTokens.keys.sorted() {
             self.unsubscribeGlobalProcess(pid)
         }
@@ -295,6 +325,51 @@ extension NotificationWatcher {
         case let .failure(error):
             return error
         }
+    }
+
+    private func handleGlobalLaunch(_ pid: pid_t) {
+        self.cancelGlobalRetry(pid)
+        guard let error = self.subscribeGlobalProcess(pid) else { return }
+        axWarningLog("Global observer skipped launched PID \(pid): \(error.localizedDescription)")
+        self.scheduleGlobalRetry(pid, attempt: 1, lastError: error)
+    }
+
+    private func scheduleGlobalRetry(_ pid: pid_t, attempt: Int, lastError: AccessibilityError) {
+        guard self.isObserving || self.globalObservationStarting else { return }
+        guard attempt <= AXGlobalObserverRetryPolicy.maximumAttempts else {
+            axWarningLog(
+                "Global observer exhausted retries for PID \(pid): \(lastError.localizedDescription)")
+            return
+        }
+        guard self.globalRetryTasks[pid] == nil else { return }
+
+        let retrySleep = self.globalRetrySleep
+        self.globalRetryTasks[pid] = Task { @MainActor [weak self] in
+            do {
+                try await retrySleep(attempt)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.globalRetryTasks.removeValue(forKey: pid)
+            guard self.isObserving || self.globalObservationStarting else { return }
+            if let error = self.subscribeGlobalProcess(pid) {
+                self.scheduleGlobalRetry(pid, attempt: attempt + 1, lastError: error)
+            } else {
+                axInfoLog("Global observer recovered registration for PID \(pid) on retry \(attempt)")
+            }
+        }
+    }
+
+    private func cancelGlobalRetry(_ pid: pid_t) {
+        self.globalRetryTasks.removeValue(forKey: pid)?.cancel()
+    }
+
+    private func cancelAllGlobalRetries() {
+        for task in self.globalRetryTasks.values {
+            task.cancel()
+        }
+        self.globalRetryTasks = [:]
     }
 
     private func unsubscribeGlobalProcess(_ pid: pid_t) {

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -268,6 +268,104 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `global watcher retries a transient launched application failure`() async throws {
+        let registry = RecordingObservationRegistry(remainingFailureCounts: [42: 1])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in },
+            handler: { _, _, _, _ in })
+        try watcher.start()
+
+        applicationMonitor.launch(processIdentifier: 42)
+        for _ in 0..<20 where !registry.activeProcessIdentifiers.contains(42) {
+            await Task.yield()
+        }
+
+        #expect(registry.attemptCount(for: 42) == 2)
+        #expect(registry.activeProcessIdentifiers.contains(42))
+        watcher.stop()
+    }
+
+    @Test
+    func `global watcher bounds persistent launched application retries`() async throws {
+        let registry = RecordingObservationRegistry(failingProcessIdentifiers: [42])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in },
+            handler: { _, _, _, _ in })
+        try watcher.start()
+
+        applicationMonitor.launch(processIdentifier: 42)
+        for _ in 0..<50 where registry.attemptCount(for: 42) < 4 {
+            await Task.yield()
+        }
+        let boundedAttemptCount = registry.attemptCount(for: 42)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        #expect(boundedAttemptCount == 4)
+        #expect(registry.attemptCount(for: 42) == boundedAttemptCount)
+        #expect(!registry.activeProcessIdentifiers.contains(42))
+        watcher.stop()
+    }
+
+    @Test
+    func `termination cancels retry before a replacement reuses the PID`() async throws {
+        let registry = RecordingObservationRegistry(remainingFailureCounts: [42: 1])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            handler: { _, _, _, _ in })
+        try watcher.start()
+
+        applicationMonitor.launch(processIdentifier: 42)
+        applicationMonitor.terminate(processIdentifier: 42)
+        applicationMonitor.launch(processIdentifier: 42)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+
+        #expect(registry.attemptCount(for: 42) == 2)
+        #expect(registry.activeProcessIdentifiers.contains(42))
+        watcher.stop()
+    }
+
+    @Test
+    func `watcher deinit cancels a sleeping global registration retry`() async throws {
+        let registry = RecordingObservationRegistry(remainingFailureCounts: [42: 1])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
+        var watcher: NotificationWatcher? = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            handler: { _, _, _, _ in })
+        try watcher?.start()
+        applicationMonitor.launch(processIdentifier: 42)
+
+        let weakWatcher = WeakReference(watcher)
+        watcher = nil
+        for _ in 0..<20 where applicationMonitor.stopCount == 0 {
+            await Task.yield()
+        }
+
+        #expect(weakWatcher.value == nil)
+        #expect(applicationMonitor.stopCount == 1)
+        #expect(registry.attemptCount(for: 42) == 1)
+        #expect(registry.activeProcessIdentifiers.isEmpty)
+    }
+
+    @Test
     func `global watcher fails when every current application rejects registration`() {
         let registry = RecordingObservationRegistry(failingProcessIdentifiers: [41, 42])
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
@@ -334,12 +432,17 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
     private var subscriptions: [SubscriptionToken: AXNotificationSubscriptionHandler] = [:]
     private var processIdentifiersByToken: [SubscriptionToken: pid_t] = [:]
     private let failingProcessIdentifiers: Set<pid_t>
+    private var remainingFailureCounts: [pid_t: Int]
 
     private(set) var unsubscribeCallCount = 0
     private(set) var subscribedProcessIdentifiers: [pid_t] = []
 
-    init(failingProcessIdentifiers: Set<pid_t> = []) {
+    init(
+        failingProcessIdentifiers: Set<pid_t> = [],
+        remainingFailureCounts: [pid_t: Int] = [:])
+    {
         self.failingProcessIdentifiers = failingProcessIdentifiers
+        self.remainingFailureCounts = remainingFailureCounts
     }
 
     var activeSubscriptionCount: Int {
@@ -354,6 +457,10 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
         self.subscriptions[token] != nil
     }
 
+    func attemptCount(for processIdentifier: pid_t) -> Int {
+        self.subscribedProcessIdentifiers.count { $0 == processIdentifier }
+    }
+
     func subscribe(
         pid: pid_t,
         element _: Element?,
@@ -361,7 +468,11 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
     {
         self.subscribedProcessIdentifiers.append(pid)
-        guard !self.failingProcessIdentifiers.contains(pid) else {
+        let remainingFailures = self.remainingFailureCounts[pid, default: 0]
+        if remainingFailures > 0 {
+            self.remainingFailureCounts[pid] = remainingFailures - 1
+        }
+        guard !self.failingProcessIdentifiers.contains(pid), remainingFailures == 0 else {
             return .failure(.observerSetupFailed(details: "Fixture rejected PID \(pid)"))
         }
         let token = SubscriptionToken(id: UUID())


### PR DESCRIPTION
## Summary

- retry transient global AX registration failures three times with finite exponential backoff
- trigger recovery only from application lifecycle registration attempts; no recurring poller is introduced
- cancel pending retry work on termination, explicit stop, failed startup, and watcher deinitialization
- reacquire the watcher only after the delay so sleeping retry tasks cannot extend its lifetime
- treat a replacement application reusing the same PID as a fresh immediate registration after old-generation cancellation

## Why

PR #40 fixed global observation by following the native `NSWorkspace.runningApplications` lifecycle, but a newly launched app could still be permanently skipped when its first AX registration raced startup and returned a transient failure such as `cannotComplete`. This follow-up makes that recovery bounded and lifecycle-owned.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (125 safe tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- focused tests cover transient recovery, persistent retry exhaustion, termination plus PID reuse, and deinit during a sleeping retry
- structured P0-P2 autoreview converged with no actionable findings
