### PR TITLE
fix(observers): stabilize shared process identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, with bounded recovery for transient registration failures, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, retain semantic application identity across wrapper churn, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, retain semantic application identity across wrapper churn, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, retain semantic application identity across wrapper churn, reset shared observers across PID generation reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/README.md
+++ b/README.md
@@ -510,9 +510,9 @@ try watcher.start()
 ```
 
 Applications that do not support the requested notification are skipped. Starting fails when running candidate
-applications exist but none accepts the notification. The deprecated nil-PID `AXObserverCenter.subscribe` entry point
-now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer. A transient
-registration failure after an application lifecycle event receives three bounded retries; termination cancels pending
+applications exist but none accepts the notification. The source-compatible nil-PID `AXObserverCenter.subscribe`
+entry point now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer. A
+transient registration failure after an application lifecycle event receives three bounded retries; termination cancels pending
 retry work, so this recovery never becomes a polling loop.
 
 ### Observer Example

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -47,14 +47,16 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
     }
 
     private var runningApplicationsObservation: NSKeyValueObservation?
-    private var applicationsByIdentity: [ObjectIdentifier: pid_t] = [:]
+    // Retain AppKit's semantic application keys: separate wrappers for one process instance
+    // compare equal, while a replacement process remains a distinct application identity.
+    private var applicationsByIdentity: [NSRunningApplication: pid_t] = [:]
     private var onLaunch: (@MainActor (pid_t) -> Void)?
     private var onTermination: (@MainActor (pid_t) -> Void)?
 
     private func reconcile(_ runningApplications: [NSRunningApplication]) {
         let currentApplications = Dictionary(
             uniqueKeysWithValues: Self.eligibleApplications(runningApplications).map {
-                (ObjectIdentifier($0), $0.processIdentifier)
+                ($0, $0.processIdentifier)
             })
         let changes = Self.lifecycleChanges(
             previous: self.applicationsByIdentity,

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -6,6 +6,7 @@
 //
 
 import ApplicationServices
+import Darwin
 import Foundation
 
 /// Centralized manager for AXObserver instances that coordinates accessibility notifications.
@@ -29,6 +30,11 @@ public final class AXObserverCenter {
         _ pid: pid_t,
         _ element: Element,
         _ notification: AXNotification) -> Void
+    typealias ProcessIdentityProvider = @MainActor (_ pid: pid_t) -> UInt64?
+
+    private struct ObserverGeneration {
+        let startIdentity: UInt64
+    }
 
     // MARK: - Public State
 
@@ -49,14 +55,17 @@ public final class AXObserverCenter {
 
     private let subscriptionStore = AXObserverSubscriptionStore()
     private var observers: [AXObserverObjAndPID] = []
+    private var observerGenerations: [pid_t: ObserverGeneration] = [:]
     private let observerSetupOverride: ObserverSetup?
     private let observerCleanupOverride: ObserverCleanup?
+    private let processIdentityProvider: ProcessIdentityProvider
 
     // MARK: - Lifecycle
 
     private init() {
         self.observerSetupOverride = nil
         self.observerCleanupOverride = nil
+        self.processIdentityProvider = Self.nativeProcessStartIdentity
     }
 
     init(
@@ -65,6 +74,17 @@ public final class AXObserverCenter {
     {
         self.observerSetupOverride = observerSetup
         self.observerCleanupOverride = observerCleanup
+        self.processIdentityProvider = { UInt64(UInt32(bitPattern: $0)) }
+    }
+
+    init(
+        observerSetup: @escaping ObserverSetup,
+        observerCleanup: @escaping ObserverCleanup,
+        processIdentityProvider: @escaping ProcessIdentityProvider)
+    {
+        self.observerSetupOverride = observerSetup
+        self.observerCleanupOverride = observerCleanup
+        self.processIdentityProvider = processIdentityProvider
     }
 }
 
@@ -72,7 +92,26 @@ public final class AXObserverCenter {
 
 @MainActor
 extension AXObserverCenter {
+    /// Subscribe to one application or element notification.
+    ///
+    /// A nil PID is retained for source compatibility but fails explicitly because
+    /// macOS has no global AX observer. Use `NotificationWatcher(globalNotification:)`
+    /// for native per-application fan-out.
     public func subscribe(
+        pid: pid_t? = nil,
+        element: Element? = nil,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        guard let pid else {
+            let details = "macOS AXObserver requires an application PID; " +
+                "use NotificationWatcher(globalNotification:) for native global fan-out"
+            return .failure(.observerSetupFailed(details: details))
+        }
+        return self.subscribeProcess(pid: pid, element: element, notification: notification, handler: handler)
+    }
+
+    func subscribeProcess(
         pid: pid_t,
         element: Element? = nil,
         notification: AXNotification,
@@ -82,6 +121,11 @@ extension AXObserverCenter {
             return .failure(.observerSetupFailed(
                 details: "macOS AXObserver requires an application PID greater than zero"))
         }
+        guard let expectedGeneration = self.processIdentityProvider(pid) else {
+            return .failure(.observerSetupFailed(
+                details: "Could not resolve the process generation for PID \(pid)"))
+        }
+        self.prepareObserverGeneration(for: pid, currentIdentity: expectedGeneration)
         let elementDescriptionForLog = element?.briefDescription() ?? "N/A"
         axDebugLog(
             logSegments(
@@ -93,7 +137,7 @@ extension AXObserverCenter {
         let setupError = if self.subscriptionStore.contains(registration: registration) {
             AXError.success
         } else {
-            self.setupUnderlyingObserver(registration)
+            self.setupUnderlyingObserver(registration, expectedGeneration: expectedGeneration)
         }
         guard setupError == .success else {
             let errorMessage = "Failed to setup underlying AXObserver for \(describePid(pid)) " +
@@ -108,29 +152,6 @@ extension AXObserverCenter {
                 "Successfully subscribed handler (token: \(token.id)) for \(describePid(pid))",
                 "notification: \(notification.rawValue)"))
         return .success(token)
-    }
-
-    /// Compatibility entry point for the former nil-PID global observer API.
-    ///
-    /// macOS AX observers require an application PID and the system-wide element does
-    /// not support notifications. Use `NotificationWatcher(globalNotification:)` for
-    /// native event-driven fan-out across running applications.
-    @available(
-        *,
-        deprecated,
-        message: "A nil PID cannot create a macOS AXObserver; use NotificationWatcher(globalNotification:handler:)")
-    public func subscribe(
-        pid: pid_t? = nil,
-        element: Element? = nil,
-        notification: AXNotification,
-        handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
-    {
-        guard let pid else {
-            let details = "macOS AXObserver requires an application PID; " +
-                "use NotificationWatcher(globalNotification:) for native global fan-out"
-            return .failure(.observerSetupFailed(details: details))
-        }
-        return self.subscribe(pid: pid, element: element, notification: notification, handler: handler)
     }
 
     public func unsubscribe(token: SubscriptionToken) throws {
@@ -167,6 +188,7 @@ extension AXObserverCenter {
             CFRunLoopSourceInvalidate(source)
         }
         self.observers.removeAll()
+        self.observerGenerations.removeAll()
         axInfoLog("All observers and subscriptions have been cleared.")
     }
 
@@ -215,10 +237,24 @@ extension AXObserverCenter {
     }
 
     /// Ensures an AXObserver is created for the exact registration target.
-    private func setupUnderlyingObserver(_ registration: AXObserverRegistrationKey) -> AXError {
+    private func setupUnderlyingObserver(
+        _ registration: AXObserverRegistrationKey,
+        expectedGeneration: UInt64) -> AXError
+    {
         let subscription = registration.subscription
         if let observerSetupOverride {
-            return observerSetupOverride(subscription.pid, registration.element, subscription.notification)
+            let error = observerSetupOverride(subscription.pid, registration.element, subscription.notification)
+            let finalGeneration = self.processIdentityProvider(subscription.pid)
+            guard finalGeneration == expectedGeneration else {
+                if finalGeneration != nil {
+                    self.resetObserverGeneration(for: subscription.pid)
+                }
+                return .cannotComplete
+            }
+            if error == .success {
+                self.recordObserverGeneration(for: subscription.pid, startIdentity: expectedGeneration)
+            }
+            return error
         }
 
         let targetPid = subscription.pid
@@ -226,7 +262,7 @@ extension AXObserverCenter {
             targetPid: targetPid,
             element: registration.element,
             notification: subscription.notification)
-        guard let observer = getOrCreateObserver(for: targetPid) else {
+        guard let observer = getOrCreateObserver(for: targetPid, expectedGeneration: expectedGeneration) else {
             axErrorLog("Failed to get/create AXObserver for effective PID \(targetPid) during setup.")
             return .failure
         }
@@ -237,6 +273,22 @@ extension AXObserverCenter {
             registration.element.underlyingElement,
             subscription.notification.rawValue as CFString,
             selfPtr)
+
+        let finalGeneration = self.processIdentityProvider(targetPid)
+        guard finalGeneration == expectedGeneration else {
+            if error == .success {
+                _ = AXObserverRemoveNotification(
+                    observer,
+                    registration.element.underlyingElement,
+                    subscription.notification.rawValue as CFString)
+            }
+            if finalGeneration == nil {
+                self.removeObserverIfUnused(targetPid: targetPid)
+            } else {
+                self.resetObserverGeneration(for: targetPid)
+            }
+            return .cannotComplete
+        }
 
         self.logObserverAddResult(targetPid: targetPid, notification: subscription.notification, error: error)
         if error != .success {
@@ -348,30 +400,58 @@ extension AXObserverCenter {
 
     // MARK: - Private Methods
 
+    private func prepareObserverGeneration(for pid: pid_t, currentIdentity: UInt64) {
+        guard let storedGeneration = self.observerGenerations[pid] else { return }
+        guard storedGeneration.startIdentity != currentIdentity else { return }
+
+        self.resetObserverGeneration(for: pid)
+    }
+
+    private func resetObserverGeneration(for pid: pid_t) {
+        if let observer = getObserver(for: pid) {
+            let source = AXObserverGetRunLoopSource(observer)
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
+            CFRunLoopSourceInvalidate(source)
+        }
+        self.removePidObserverInstance(pid: pid)
+        let removedSubscriptionCount = self.subscriptionStore.removeAll(for: pid)
+        axInfoLog(
+            "Reset stale AXObserver generation for PID \(pid); removed " +
+                "\(removedSubscriptionCount) logical subscriptions")
+    }
+
+    private func recordObserverGeneration(for pid: pid_t, startIdentity: UInt64) {
+        self.observerGenerations[pid] = ObserverGeneration(startIdentity: startIdentity)
+    }
+
     private func getObserver(for pid: pid_t) -> AXObserver? {
         self.observers.first { $0.pid == pid }?.observer
     }
 
-    private func getOrCreateObserver(for pid: pid_t) -> AXObserver? {
+    private func getOrCreateObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
         if let existing = getObserver(for: pid) {
             return existing
         }
-        return self.createObserver(for: pid)
+        return self.createObserver(for: pid, expectedGeneration: expectedGeneration)
     }
 
-    private func createObserver(for pid: pid_t) -> AXObserver? {
+    private func createObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
         var observer: AXObserver?
         let callback = self.makeObserverCallback()
 
         let error = AXObserverCreateWithInfoCallback(pid, callback, &observer)
 
-        if error == .success, let newObserver = observer {
+        if error == .success,
+           let newObserver = observer,
+           self.processIdentityProvider(pid) == expectedGeneration
+        {
             // Add to run loop ONCE when observer is created.
             CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(newObserver), .defaultMode)
             axDebugLog("Added run loop source for new observer PID \(pid)")
 
             let obj = AXObserverObjAndPID(observer: newObserver, pid: pid)
             self.observers.append(obj)
+            self.recordObserverGeneration(for: pid, startIdentity: expectedGeneration)
             axDebugLog("Created observer for PID \(pid)")
             return newObserver
         } else {
@@ -420,7 +500,31 @@ extension AXObserverCenter {
 
     private func removePidObserverInstance(pid: pid_t) {
         self.observers.removeAll { $0.pid == pid }
+        self.observerGenerations.removeValue(forKey: pid)
         axDebugLog("Removed AXObserver instance for effective PID \(pid).")
+    }
+
+    private static func nativeProcessStartIdentity(_ processIdentifier: pid_t) -> UInt64? {
+        guard processIdentifier > 0 else { return nil }
+        var info = proc_bsdinfo()
+        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        guard proc_pidinfo(
+            processIdentifier,
+            PROC_PIDTBSDINFO,
+            0,
+            &info,
+            expectedSize) == expectedSize,
+            info.pbi_start_tvsec >= 0,
+            info.pbi_start_tvusec >= 0
+        else {
+            return nil
+        }
+        let seconds = UInt64(info.pbi_start_tvsec)
+        let microseconds = UInt64(info.pbi_start_tvusec)
+        let (scaledSeconds, scalingOverflow) = seconds.multipliedReportingOverflow(by: 1_000_000)
+        let (identity, additionOverflow) = scaledSeconds.addingReportingOverflow(microseconds)
+        guard !scalingOverflow, !additionOverflow else { return nil }
+        return identity
     }
 
     // MARK: - Main Notification Processing (Called by global callbacks)

--- a/Sources/AXorcist/Core/AXorcist.swift
+++ b/Sources/AXorcist/Core/AXorcist.swift
@@ -254,7 +254,7 @@ public class AXorcist {
             return .failure(.observerSetupFailed(
                 details: "Observed accessibility element has no owning application PID"))
         }
-        let result = self.observationRegistry.subscribe(
+        let result = self.observationRegistry.subscribeProcess(
             pid: pid,
             element: element,
             notification: notification,

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -190,7 +190,7 @@ public class NotificationWatcher {
             "(PID: \(effectivePid)), notification: \(self.notification.rawValue)"
         axInfoLog(logStart)
 
-        let subscribeResult = self.registry.subscribe(
+        let subscribeResult = self.registry.subscribeProcess(
             pid: effectivePid,
             element: elementForSubscription, // Pass element if target is .element
             notification: self.notification,
@@ -313,7 +313,7 @@ extension NotificationWatcher {
 
     private func subscribeGlobalProcess(_ pid: pid_t) -> AccessibilityError? {
         guard pid > 0, self.globalSubscriptionTokens[pid] == nil else { return nil }
-        switch self.registry.subscribe(
+        switch self.registry.subscribeProcess(
             pid: pid,
             element: nil,
             notification: self.notification,

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -18,7 +18,7 @@ public typealias AXNotificationSubscriptionHandler = @MainActor ( /* element: El
 /// The single registration boundary used by AXorcist's observer APIs.
 @MainActor
 protocol AXObservationRegistry: AnyObject, Sendable {
-    func subscribe(
+    func subscribeProcess(
         pid: pid_t,
         element: Element?,
         notification: AXNotification,
@@ -139,6 +139,15 @@ final class AXObserverSubscriptionStore {
     func removeAll() {
         self.subscriptions.removeAll()
         self.subscriptionTokens.removeAll()
+    }
+
+    @discardableResult
+    func removeAll(for pid: pid_t) -> Int {
+        let tokens = self.tokens(for: pid)
+        for token in tokens {
+            _ = try? self.remove(token: token)
+        }
+        return tokens.count
     }
 
     func tokens(for pid: pid_t) -> [SubscriptionToken] {

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -47,6 +47,159 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `observer center subscribe method reference remains unambiguous`() {
+        typealias Subscribe = (
+            pid_t?,
+            Element?,
+            AXNotification,
+            @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in .success },
+            observerCleanup: { _, _, _ in })
+        let subscribe: Subscribe = center.subscribe
+
+        let result = subscribe(nil, nil, .focusedUIElementChanged) { _, _, _, _ in }
+
+        if case .failure = result {} else {
+            Issue.record("Expected the source-compatible nil PID call to fail explicitly")
+        }
+    }
+
+    @Test
+    func `observer center resets shared registrations when a PID generation changes`() throws {
+        let processGeneration = ProcessGenerationBox(100)
+        var setupCount = 0
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, _, _ in },
+            processIdentityProvider: { _ in processGeneration.value })
+        let first = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+        let second = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+        #expect(setupCount == 1)
+
+        processGeneration.value = 101
+        let replacement = try center.subscribe(
+            pid: 42,
+            notification: .focusedUIElementChanged)
+        { _, _, _, _ in }.get()
+
+        #expect(setupCount == 2)
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: first)
+        }
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: second)
+        }
+        try center.unsubscribe(token: replacement)
+    }
+
+    @Test
+    func `unknown process generation refuses setup without purging existing subscriptions`() throws {
+        let processGeneration = ProcessGenerationBox(100)
+        var setupCount = 0
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, _, _ in },
+            processIdentityProvider: { _ in processGeneration.value })
+        let existing = try center.subscribe(
+            pid: 42,
+            notification: .focusedUIElementChanged)
+        { _, _, _, _ in }.get()
+
+        processGeneration.value = nil
+        let unavailable = center.subscribe(pid: 42, notification: .titleChanged) { _, _, _, _ in }
+
+        if case .failure = unavailable {} else {
+            Issue.record("Expected unavailable process identity to refuse setup")
+        }
+        #expect(setupCount == 1)
+        #expect(center.isKeyRegistered(pid: 42, notification: .focusedUIElementChanged))
+        try center.unsubscribe(token: existing)
+    }
+
+    @Test
+    func `observer creation refuses a process generation change during setup`() {
+        let processGenerations = ProcessGenerationSequence([100, 101])
+        var setupCount = 0
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, _, _ in },
+            processIdentityProvider: { _ in processGenerations.next() })
+
+        let result = center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }
+
+        if case .failure = result {} else {
+            Issue.record("Expected a mid-setup generation change to refuse the observer")
+        }
+        #expect(setupCount == 1)
+        #expect(!center.isKeyRegistered(pid: 42, notification: .focusedUIElementChanged))
+    }
+
+    @Test
+    func `post-setup generation change purges shared stale registrations`() throws {
+        let processGenerations = ProcessGenerationSequence([100, 100, 100, 100, 101])
+        var setupCount = 0
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, _, _ in },
+            processIdentityProvider: { _ in processGenerations.next() })
+        let first = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+        let second = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+
+        let replacement = center.subscribe(pid: 42, notification: .titleChanged) { _, _, _, _ in }
+
+        if case .failure = replacement {} else {
+            Issue.record("Expected post-setup generation drift to refuse registration")
+        }
+        #expect(setupCount == 2)
+        #expect(!center.isKeyRegistered(pid: 42, notification: .focusedUIElementChanged))
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: first)
+        }
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: second)
+        }
+    }
+
+    @Test
+    func `failed setup still purges a confirmed stale generation`() throws {
+        let processGenerations = ProcessGenerationSequence([100, 100, 100, 100, 101])
+        let center = AXObserverCenter(
+            observerSetup: { _, _, notification in
+                notification == .titleChanged ? .cannotComplete : .success
+            },
+            observerCleanup: { _, _, _ in },
+            processIdentityProvider: { _ in processGenerations.next() })
+        let first = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+        let second = try center.subscribe(pid: 42, notification: .focusedUIElementChanged) { _, _, _, _ in }.get()
+
+        let replacement = center.subscribe(pid: 42, notification: .titleChanged) { _, _, _, _ in }
+
+        if case .failure = replacement {} else {
+            Issue.record("Expected failed setup with generation drift to refuse registration")
+        }
+        #expect(!center.isKeyRegistered(pid: 42, notification: .focusedUIElementChanged))
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: first)
+        }
+        #expect(throws: AccessibilityError.self) {
+            try center.unsubscribe(token: second)
+        }
+    }
+
+    @Test
     func `CLI recognizes the current observe success response`() {
         #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"success\"}"))
         #expect(CLIFrontend.responseSucceeded("{\"command_id\":\"observe\",\"status\":\"error\"}") == false)
@@ -56,7 +209,7 @@ struct ObserverLifecycleTests {
     func `observe and stop use the same registry without clearing unrelated subscriptions`() throws {
         let registry = RecordingObservationRegistry()
         let target = Element(AXUIElementCreateApplication(getpid()))
-        let unrelatedToken = try registry.subscribe(
+        let unrelatedToken = try registry.subscribeProcess(
             pid: 7,
             element: nil,
             notification: .titleChanged)
@@ -487,7 +640,7 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
         self.subscribedProcessIdentifiers.count { $0 == processIdentifier }
     }
 
-    func subscribe(
+    func subscribeProcess(
         pid: pid_t,
         element _: Element?,
         notification _: AXNotification,
@@ -564,5 +717,27 @@ private struct RunningApplicationIdentityDouble: Hashable {
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(self.processInstance)
+    }
+}
+
+@MainActor
+private final class ProcessGenerationBox {
+    var value: UInt64?
+
+    init(_ value: UInt64?) {
+        self.value = value
+    }
+}
+
+@MainActor
+private final class ProcessGenerationSequence {
+    private var values: [UInt64?]
+
+    init(_ values: [UInt64?]) {
+        self.values = values
+    }
+
+    func next() -> UInt64? {
+        self.values.isEmpty ? nil : self.values.removeFirst()
     }
 }

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -390,7 +390,10 @@ struct ObserverLifecycleTests {
         #expect(registry.unsubscribeCallCount == 1)
         #expect(registry.activeSubscriptionCount == 0)
     }
+}
 
+@MainActor
+extension ObserverLifecycleTests {
     @Test
     func `global watcher fans out by PID and follows native application lifecycle`() throws {
         let registry = RecordingObservationRegistry()

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -393,6 +393,32 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `workspace application diff ignores wrapper churn for one semantic application`() {
+        let oldWrapper = RunningApplicationIdentityDouble(processInstance: "stable", wrapperAddress: 100)
+        let newWrapper = RunningApplicationIdentityDouble(processInstance: "stable", wrapperAddress: 200)
+
+        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
+            previous: [oldWrapper: pid_t(42)],
+            current: [newWrapper: pid_t(42)])
+
+        #expect(changes.terminations.isEmpty)
+        #expect(changes.launches.isEmpty)
+    }
+
+    @Test
+    func `workspace application diff detects semantic replacement despite address reuse`() {
+        let oldApplication = RunningApplicationIdentityDouble(processInstance: "old", wrapperAddress: 100)
+        let replacement = RunningApplicationIdentityDouble(processInstance: "new", wrapperAddress: 100)
+
+        let changes = AXWorkspaceApplicationMonitor.lifecycleChanges(
+            previous: [oldApplication: pid_t(42)],
+            current: [replacement: pid_t(42)])
+
+        #expect(changes.terminations == [42])
+        #expect(changes.launches == [42])
+    }
+
+    @Test
     func `AXorcist deinit unregisters its owned tokens`() async {
         let registry = RecordingObservationRegistry()
         let target = Element(AXUIElementCreateApplication(getpid()))
@@ -525,5 +551,18 @@ private final class RecordingGlobalApplicationMonitor: AXGlobalApplicationMonito
     func terminate(processIdentifier: pid_t) {
         self.runningProcessIdentifiers.removeAll { $0 == processIdentifier }
         self.onTermination?(processIdentifier)
+    }
+}
+
+private struct RunningApplicationIdentityDouble: Hashable {
+    let processInstance: String
+    let wrapperAddress: Int
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.processInstance == rhs.processInstance
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.processInstance)
     }
 }


### PR DESCRIPTION
## Summary

- retain `NSRunningApplication` semantic keys across KVO reconciliation instead of wrapper allocation addresses
- keep wrapper churn stable while preserving terminate-then-launch behavior for semantic replacement, PID reuse, and address reuse
- bind each shared native AX observer to the process start generation captured before setup and verified after every setup attempt
- invalidate stale native observers and purge all PID-scoped logical tokens on confirmed generation reuse, while refusing unknown identity without cancelling existing handlers
- restore one source-compatible public optional-PID `subscribe` signature and route internal validated calls through `subscribeProcess`

## Why

The global observer work in PRs #40 and #41 exposed two deeper identity boundaries. `NSRunningApplication` wrappers are not guaranteed pointer-stable, and a native observer cached only by numeric PID can survive into a replacement process generation when another watcher still owns a token. Both cases can silently lose notifications or create false lifecycle transitions.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (133 safe tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- deterministic coverage for wrapper churn, allocator-address reuse, PID reuse, shared-token generation reset, unknown identity, successful/failed mid-setup drift, method-reference compatibility, bounded retries, and deinit cancellation
- scoped P0-P2 autoreviews converged clean
- complete `684693095215cccfaacba92e4e77cae9033b8f3e..HEAD` P0-P2 autoreview clean
