### PR TITLE
fix(observers): wait for application readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, retain semantic application identity across wrapper churn, reset shared observers across PID generation reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications`, retain semantic application identity across wrapper churn, reset shared observers across PID generation reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, retain semantic application identity across wrapper churn, reset shared observers across PID generation reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/README.md
+++ b/README.md
@@ -512,8 +512,9 @@ try watcher.start()
 Applications that do not support the requested notification are skipped. Starting fails when running candidate
 applications exist but none accepts the notification. The source-compatible nil-PID `AXObserverCenter.subscribe`
 entry point now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer. A
-transient registration failure after an application lifecycle event receives three bounded retries; termination cancels pending
-retry work, so this recovery never becomes a polling loop.
+transient registration failure after an application lifecycle event receives three bounded retries over 10.5 seconds,
+and an `isFinishedLaunching` readiness transition triggers an immediate fresh attempt. Termination cancels pending retry
+work, so this recovery never becomes a polling loop.
 
 ### Observer Example
 

--- a/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
+++ b/Sources/AXorcist/Core/AXGlobalApplicationMonitor.swift
@@ -41,12 +41,17 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
     func stop() {
         self.runningApplicationsObservation?.invalidate()
         self.runningApplicationsObservation = nil
+        for observation in self.readinessObservations.values {
+            observation.invalidate()
+        }
+        self.readinessObservations = [:]
         self.applicationsByIdentity = [:]
         self.onLaunch = nil
         self.onTermination = nil
     }
 
     private var runningApplicationsObservation: NSKeyValueObservation?
+    private var readinessObservations: [NSRunningApplication: NSKeyValueObservation] = [:]
     // Retain AppKit's semantic application keys: separate wrappers for one process instance
     // compare equal, while a replacement process remains a distinct application identity.
     private var applicationsByIdentity: [NSRunningApplication: pid_t] = [:]
@@ -61,13 +66,54 @@ final class AXWorkspaceApplicationMonitor: AXGlobalApplicationMonitoring {
         let changes = Self.lifecycleChanges(
             previous: self.applicationsByIdentity,
             current: currentApplications)
+        let removedApplications = self.applicationsByIdentity.keys.filter { currentApplications[$0] == nil }
+        let addedApplications = currentApplications.keys.filter { self.applicationsByIdentity[$0] == nil }
+        for application in removedApplications {
+            self.readinessObservations.removeValue(forKey: application)?.invalidate()
+        }
         for processIdentifier in changes.terminations {
             self.onTermination?(processIdentifier)
+        }
+        self.applicationsByIdentity = currentApplications
+        for application in addedApplications {
+            self.observeReadiness(of: application)
         }
         for processIdentifier in changes.launches {
             self.onLaunch?(processIdentifier)
         }
-        self.applicationsByIdentity = currentApplications
+    }
+
+    private func observeReadiness(of application: NSRunningApplication) {
+        guard !application.isFinishedLaunching else { return }
+        let observation = application.observe(\.isFinishedLaunching, options: [.new]) { [weak self] app, change in
+            guard change.newValue == true else { return }
+            MainActor.assumeIsolated {
+                self?.applicationBecameReady(app)
+            }
+        }
+        self.readinessObservations[application] = observation
+        if application.isFinishedLaunching {
+            self.applicationBecameReady(application)
+        }
+    }
+
+    private func applicationBecameReady(_ application: NSRunningApplication) {
+        guard let observation = Self.claimReadiness(
+            for: application,
+            activeApplications: Set(self.applicationsByIdentity.keys),
+            observations: &self.readinessObservations)
+        else { return }
+        observation.invalidate()
+        self.onLaunch?(application.processIdentifier)
+    }
+
+    static func claimReadiness<Identity: Hashable, Observation>(
+        for identity: Identity,
+        activeApplications: Set<Identity>,
+        observations: inout [Identity: Observation]) -> Observation?
+    {
+        guard activeApplications.contains(identity) else { return nil }
+        return observations.removeValue(forKey: identity)
     }
 
     static func lifecycleChanges<Identity: Hashable>(

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -36,6 +36,18 @@ public final class AXObserverCenter {
         let startIdentity: UInt64
     }
 
+    /// Layout from XNU's API-stable `proc_uniqidentifierinfo`.
+    private struct ProcessUniqueIdentifierInfo {
+        var executableUUIDHigh: UInt64 = 0
+        var executableUUIDLow: UInt64 = 0
+        var uniqueIdentifier: UInt64 = 0
+        var parentUniqueIdentifier: UInt64 = 0
+        var identifierVersion: Int32 = 0
+        var originalParentIdentifierVersion: Int32 = 0
+        var reserved2: UInt64 = 0
+        var reserved3: UInt64 = 0
+    }
+
     // MARK: - Public State
 
     /// Shared instance
@@ -65,7 +77,7 @@ public final class AXObserverCenter {
     private init() {
         self.observerSetupOverride = nil
         self.observerCleanupOverride = nil
-        self.processIdentityProvider = Self.nativeProcessStartIdentity
+        self.processIdentityProvider = Self.nativeProcessUniqueIdentity
     }
 
     init(
@@ -504,27 +516,21 @@ extension AXObserverCenter {
         axDebugLog("Removed AXObserver instance for effective PID \(pid).")
     }
 
-    private static func nativeProcessStartIdentity(_ processIdentifier: pid_t) -> UInt64? {
+    static func nativeProcessUniqueIdentity(_ processIdentifier: pid_t) -> UInt64? {
         guard processIdentifier > 0 else { return nil }
-        var info = proc_bsdinfo()
-        let expectedSize = Int32(MemoryLayout<proc_bsdinfo>.stride)
+        var info = ProcessUniqueIdentifierInfo()
+        let expectedSize = Int32(MemoryLayout<ProcessUniqueIdentifierInfo>.stride)
         guard proc_pidinfo(
             processIdentifier,
-            PROC_PIDTBSDINFO,
+            17, // PROC_PIDUNIQIDENTIFIERINFO from XNU's proc_info_private.h
             0,
             &info,
             expectedSize) == expectedSize,
-            info.pbi_start_tvsec >= 0,
-            info.pbi_start_tvusec >= 0
+            info.uniqueIdentifier != 0
         else {
             return nil
         }
-        let seconds = UInt64(info.pbi_start_tvsec)
-        let microseconds = UInt64(info.pbi_start_tvusec)
-        let (scaledSeconds, scalingOverflow) = seconds.multipliedReportingOverflow(by: 1_000_000)
-        let (identity, additionOverflow) = scaledSeconds.addingReportingOverflow(microseconds)
-        guard !scalingOverflow, !additionOverflow else { return nil }
-        return identity
+        return info.uniqueIdentifier
     }
 
     // MARK: - Main Notification Processing (Called by global callbacks)

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -279,6 +279,9 @@ extension NotificationWatcher {
         let processIdentifiers = Array(Set(globalApplicationMonitor.runningProcessIdentifiers)).sorted()
         var failures: [AccessibilityError] = []
         for pid in processIdentifiers {
+            guard self.globalSubscriptionTokens[pid] == nil,
+                  self.globalRetryTasks[pid] == nil
+            else { continue }
             if let error = self.subscribeGlobalProcess(pid) {
                 failures.append(error)
                 axWarningLog("Global observer skipped running PID \(pid): \(error.localizedDescription)")

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -3,12 +3,13 @@
 import ApplicationServices
 import Foundation
 
-private enum AXGlobalObserverRetryPolicy {
-    static let maximumAttempts = 3
+enum AXGlobalObserverRetryPolicy {
+    static let delays: [Duration] = [.milliseconds(500), .seconds(2), .seconds(8)]
+    static let maximumAttempts = AXGlobalObserverRetryPolicy.delays.count
 
     static func sleep(beforeAttempt attempt: Int) async throws {
-        let delayMilliseconds = 100 * (1 << (attempt - 1))
-        try await Task.sleep(for: .milliseconds(delayMilliseconds))
+        guard self.delays.indices.contains(attempt - 1) else { return }
+        try await Task.sleep(for: self.delays[attempt - 1])
     }
 }
 

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -446,6 +446,53 @@ extension ObserverLifecycleTests {
     }
 
     @Test
+    func `slow application readiness triggers registration before fallback retry`() async throws {
+        let registry = RecordingObservationRegistry(remainingFailureCounts: [42: 1])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            handler: { _, _, _, _ in })
+        try watcher.start()
+
+        applicationMonitor.launch(processIdentifier: 42)
+        applicationMonitor.ready(processIdentifier: 42)
+        for _ in 0..<10 where !registry.activeProcessIdentifiers.contains(42) {
+            await Task.yield()
+        }
+
+        #expect(registry.attemptCount(for: 42) == 2)
+        #expect(registry.activeProcessIdentifiers.contains(42))
+        watcher.stop()
+    }
+
+    @Test
+    func `global observer retry schedule spans slow application startup`() {
+        #expect(AXGlobalObserverRetryPolicy.delays == [.milliseconds(500), .seconds(2), .seconds(8)])
+        #expect(AXGlobalObserverRetryPolicy.maximumAttempts == 3)
+    }
+
+    @Test
+    func `application readiness can be claimed exactly once`() {
+        var observations = ["slow-app": 42]
+        let activeApplications: Set = ["slow-app"]
+
+        let firstClaim = AXWorkspaceApplicationMonitor.claimReadiness(
+            for: "slow-app",
+            activeApplications: activeApplications,
+            observations: &observations)
+        let duplicateClaim = AXWorkspaceApplicationMonitor.claimReadiness(
+            for: "slow-app",
+            activeApplications: activeApplications,
+            observations: &observations)
+
+        #expect(firstClaim == 42)
+        #expect(duplicateClaim == nil)
+    }
+
+    @Test
     func `global watcher bounds persistent launched application retries`() async throws {
         let registry = RecordingObservationRegistry(failingProcessIdentifiers: [42])
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41])
@@ -707,6 +754,10 @@ private final class RecordingGlobalApplicationMonitor: AXGlobalApplicationMonito
     func terminate(processIdentifier: pid_t) {
         self.runningProcessIdentifiers.removeAll { $0 == processIdentifier }
         self.onTermination?(processIdentifier)
+    }
+
+    func ready(processIdentifier: pid_t) {
+        self.onLaunch?(processIdentifier)
     }
 }
 

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -469,6 +469,24 @@ extension ObserverLifecycleTests {
     }
 
     @Test
+    func `failed initial application waits for its first backoff`() throws {
+        let registry = RecordingObservationRegistry(failingProcessIdentifiers: [42])
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in try await Task.sleep(for: .seconds(60)) },
+            handler: { _, _, _, _ in })
+
+        try watcher.start()
+
+        #expect(registry.attemptCount(for: 41) == 1)
+        #expect(registry.attemptCount(for: 42) == 1)
+        watcher.stop()
+    }
+
+    @Test
     func `global observer retry schedule spans slow application startup`() {
         #expect(AXGlobalObserverRetryPolicy.delays == [.milliseconds(500), .seconds(2), .seconds(8)])
         #expect(AXGlobalObserverRetryPolicy.maximumAttempts == 3)
@@ -736,6 +754,9 @@ private final class RecordingGlobalApplicationMonitor: AXGlobalApplicationMonito
     {
         self.onLaunch = onLaunch
         self.onTermination = onTermination
+        for processIdentifier in self.runningProcessIdentifiers.sorted() {
+            onLaunch(processIdentifier)
+        }
     }
 
     func stop() {

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -28,6 +28,14 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `native process identity can inspect root launchd without BSD info privilege`() throws {
+        let firstIdentity = try #require(AXObserverCenter.nativeProcessUniqueIdentity(1))
+        let secondIdentity = try #require(AXObserverCenter.nativeProcessUniqueIdentity(1))
+
+        #expect(firstIdentity == secondIdentity)
+    }
+
+    @Test
     func `observer center rejects PID zero before native setup`() {
         var setupCalled = false
         let center = AXObserverCenter(


### PR DESCRIPTION
## Summary

- observe each unfinished application's native `isFinishedLaunching` transition and immediately retry global AX registration when it becomes ready
- spread the three finite fallback retries across 0.5s, 2s, and 8s while preserving termination, stop, startup-failure, and deinit cancellation
- atomically claim readiness observation tokens so overlapping KVO/post-install paths cannot emit duplicate registration attempts
- deduplicate synchronous initial KVO callbacks from the subsequent snapshot pass
- use XNU's unprivileged process-unique identifier so generation safety does not impose same-UID BSD-info permissions on valid AX targets

## Why

The initial 100ms/200ms/400ms retry window could expire before a normally slow application became AX-ready, permanently omitting it. The previous process-start lookup could also reject root or different-UID targets even when Accessibility itself allowed observation.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (138 safe tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- focused coverage for held-timer slow launch, readiness double-claim, initial-attempt deduplication, retry schedule, root PID 1 identity, wrapper/address/PID reuse, retry/deinit cancellation, and process-generation races
- scoped P0-P2 autoreviews converged clean
- complete `684693095215cccfaacba92e4e77cae9033b8f3e..HEAD` P0-P2 autoreview clean
