### PR TITLE
fix(observers): bound global registration work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to AXorcist will be documented in this file.
 - Add immutable per-request accessibility traversal options while keeping the legacy process defaults source-compatible and thread-safe.
 
 ### Fixed
-- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
+- Implement global accessibility notification watching as native per-application observers driven by KVO changes to `NSWorkspace.runningApplications` and application readiness, keep observer creation, registration, and cleanup deadline-bounded off the main actor so a wedged app cannot block startup or teardown, retain semantic application identity across wrapper churn, reset shared observers with unprivileged process-unique identities across PID reuse, recover boundedly from transient registration failures, and reject the invalid PID-zero observer path.
 - Resolve point-owned applications from one native on-screen window snapshot, avoiding synchronous all-app Accessibility queries while keeping frontmost fallback limited to the compatibility API.
 - Preserve exact PID targets across CLI command conversion, reject conflicting application and PID selectors, and report point lookup misses as errors.
 - Refuse element-scoped typing when native focus cannot be established, preventing keyboard events from reaching an unrelated focused app.

--- a/README.md
+++ b/README.md
@@ -509,12 +509,14 @@ let watcher = NotificationWatcher(globalNotification: .focusedUIElementChanged) 
 try watcher.start()
 ```
 
-Applications that do not support the requested notification are skipped. Starting fails when running candidate
-applications exist but none accepts the notification. The source-compatible nil-PID `AXObserverCenter.subscribe`
-entry point now returns an explicit setup failure instead of attempting to construct an invalid PID-zero observer. A
-transient registration failure after an application lifecycle event receives three bounded retries over 10.5 seconds,
-and an `isFinishedLaunching` readiness transition triggers an immediate fresh attempt. Termination cancels pending retry
-work, so this recovery never becomes a polling loop.
+Applications that do not support the requested notification are skipped. Starting installs lifecycle tracking and
+returns without waiting for per-application Accessibility endpoints; observer creation, registration, and cleanup run
+off the main actor with bounded native messaging timeouts, so one wedged app cannot block startup or teardown. The
+source-compatible
+nil-PID `AXObserverCenter.subscribe` entry point returns an explicit setup failure instead of attempting to construct an
+invalid PID-zero observer. A transient registration failure after an application lifecycle event receives three bounded
+retries over 10.5 seconds, and an `isFinishedLaunching` readiness transition triggers an immediate fresh attempt.
+Termination cancels pending registration and retry work, so this recovery never becomes a polling loop.
 
 ### Observer Example
 

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -36,12 +36,6 @@ public final class AXObserverCenter {
         let startIdentity: UInt64
     }
 
-    private struct PendingObserverCreation {
-        let id: UUID
-        let expectedGeneration: UInt64
-        let task: Task<NativeObserverCreation, Never>
-    }
-
     private struct PendingRegistration {
         let id: UUID
         let expectedGeneration: UInt64
@@ -825,7 +819,37 @@ extension AXObserverCenter {
         if let existing = getObserver(for: pid) {
             return existing
         }
-        return self.createObserver(for: pid, expectedGeneration: expectedGeneration)
+        _ = self.pendingObserverCreation(for: pid, expectedGeneration: expectedGeneration)
+        return self.finishPendingObserverCreationSynchronously(
+            for: pid,
+            expectedGeneration: expectedGeneration)
+    }
+
+    private func finishPendingObserverCreationSynchronously(
+        for pid: pid_t,
+        expectedGeneration: UInt64) -> AXObserver?
+    {
+        guard let pending = self.pendingObserverCreations[pid],
+              pending.expectedGeneration == expectedGeneration
+        else { return nil }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .milliseconds(750))
+        while pending.completion.currentResult() == nil, clock.now < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+        }
+        guard let outcome = pending.completion.currentResult() else { return nil }
+        guard self.pendingObserverCreations[pid]?.id == pending.id else {
+            return self.observer(for: pid, matching: expectedGeneration)
+        }
+        guard self.processIdentityProvider(pid) == expectedGeneration else {
+            self.pendingObserverCreations.removeValue(forKey: pid)
+            return nil
+        }
+        self.pendingObserverCreations.removeValue(forKey: pid)
+        if let existing = self.observer(for: pid, matching: expectedGeneration) {
+            return existing
+        }
+        return self.commitNativeObserver(outcome, for: pid, expectedGeneration: expectedGeneration)
     }
 
     private func getOrCreateObserverAsync(for pid: pid_t, expectedGeneration: UInt64) async -> AXObserver? {
@@ -867,22 +891,19 @@ extension AXObserverCenter {
         }
         self.pendingObserverCreations.removeValue(forKey: pid)?.task.cancel()
         let id = UUID()
+        let completion = NativeObserverCreationCompletion()
         let workerKey = ObserverWorkerKey(pid: pid, processGeneration: expectedGeneration)
         if self.nativeObserverWorkers[workerKey] != nil {
-            let task = Task<NativeObserverCreation, Never> { .timedOut }
-            let pending = PendingObserverCreation(
+            let pending = PendingObserverCreation.timedOut(
                 id: id,
-                expectedGeneration: expectedGeneration,
-                task: task)
+                expectedGeneration: expectedGeneration)
             self.pendingObserverCreations[pid] = pending
             return pending
         }
         guard self.nativeWorkAdmission.tryAcquire() else {
-            let task = Task<NativeObserverCreation, Never> { .timedOut }
-            let pending = PendingObserverCreation(
+            let pending = PendingObserverCreation.timedOut(
                 id: id,
-                expectedGeneration: expectedGeneration,
-                task: task)
+                expectedGeneration: expectedGeneration)
             self.pendingObserverCreations[pid] = pending
             return pending
         }
@@ -897,16 +918,19 @@ extension AXObserverCenter {
             }
         }
         let task = Task.detached(priority: .utility) {
-            await Self.createNativeObserver(
+            let outcome = await Self.createNativeObserver(
                 for: pid,
                 callback: callback,
                 timeout: .milliseconds(500),
                 workerFinished: workerFinished)
+            completion.finish(with: outcome)
+            return outcome
         }
         let pending = PendingObserverCreation(
             id: id,
             expectedGeneration: expectedGeneration,
-            task: task)
+            task: task,
+            completion: completion)
         self.pendingObserverCreations[pid] = pending
         return pending
     }
@@ -1001,31 +1025,6 @@ extension AXObserverCenter {
         ObserverStateEpoch(
             global: self.globalStateEpoch,
             process: self.processStateEpochs[pid, default: 0])
-    }
-
-    private func createObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
-        var observer: AXObserver?
-        let callback = self.makeObserverCallback()
-
-        let error = AXObserverCreateWithInfoCallback(pid, callback, &observer)
-
-        if error == .success,
-           let newObserver = observer,
-           self.processIdentityProvider(pid) == expectedGeneration
-        {
-            // Add to run loop ONCE when observer is created.
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(newObserver), .defaultMode)
-            axDebugLog("Added run loop source for new observer PID \(pid)")
-
-            let obj = AXObserverObjAndPID(observer: newObserver, pid: pid)
-            self.observers.append(obj)
-            self.recordObserverGeneration(for: pid, startIdentity: expectedGeneration)
-            axDebugLog("Created observer for PID \(pid)")
-            return newObserver
-        } else {
-            axErrorLog("Failed to create observer for PID \(pid), error: \(error.rawValue)")
-            return nil
-        }
     }
 
     private func makeObserverCallback() -> AXObserverCallbackWithInfo {

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -36,18 +36,6 @@ public final class AXObserverCenter {
         let startIdentity: UInt64
     }
 
-    /// Layout from XNU's API-stable `proc_uniqidentifierinfo`.
-    private nonisolated struct ProcessUniqueIdentifierInfo {
-        var executableUUIDHigh: UInt64 = 0
-        var executableUUIDLow: UInt64 = 0
-        var uniqueIdentifier: UInt64 = 0
-        var parentUniqueIdentifier: UInt64 = 0
-        var identifierVersion: Int32 = 0
-        var originalParentIdentifierVersion: Int32 = 0
-        var reserved2: UInt64 = 0
-        var reserved3: UInt64 = 0
-    }
-
     private struct PendingObserverCreation {
         let id: UUID
         let expectedGeneration: UInt64
@@ -104,6 +92,7 @@ public final class AXObserverCenter {
     // MARK: - Stored State
 
     private let subscriptionStore = AXObserverSubscriptionStore()
+    private nonisolated let nativeWorkAdmission = ObserverNativeWorkerAdmission()
     private var observers: [AXObserverObjAndPID] = []
     private var observerGenerations: [pid_t: ObserverGeneration] = [:]
     private var pendingObserverCreations: [pid_t: PendingObserverCreation] = [:]
@@ -187,7 +176,11 @@ extension AXObserverCenter {
 
         let registration = self.registrationKey(pid: pid, element: element, notification: notification)
         let awaitedRemoval = self.finishPendingRemovalSynchronously(registration)
-        guard !awaitedRemoval || self.processIdentityProvider(pid) == expectedGeneration else {
+        guard awaitedRemoval != false else {
+            return .failure(.observerSetupFailed(
+                details: "Timed out awaiting observer cleanup for PID \(pid)"))
+        }
+        guard awaitedRemoval != true || self.processIdentityProvider(pid) == expectedGeneration else {
             self.resetObserverGeneration(for: pid, ifMatching: expectedGeneration)
             return .failure(.observerSetupFailed(
                 details: "Process generation changed while awaiting observer cleanup for PID \(pid)"))
@@ -222,8 +215,7 @@ extension AXObserverCenter {
             self.asynchronousNativeRegistrations.remove(registration)
         }
 
-        let token = self.subscriptionStore.add(registration: registration, handler: handler)
-        return .success(token)
+        return .success(self.subscriptionStore.add(registration: registration, handler: handler))
     }
 
     func subscribeProcessAsync(
@@ -243,7 +235,10 @@ extension AXObserverCenter {
             return .failure(.observerSetupFailed(
                 details: "macOS AXObserver requires an application PID greater than zero"))
         }
-        guard let expectedGeneration = await Self.boundedNativeProcessUniqueIdentity(pid) else {
+        guard let expectedGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
+            pid,
+            admission: self.nativeWorkAdmission)
+        else {
             return .failure(.observerSetupFailed(
                 details: "Could not resolve the process generation for PID \(pid)"))
         }
@@ -273,17 +268,24 @@ extension AXObserverCenter {
                   self.currentStateEpoch(for: pid) == expectedEpoch,
                   self.observerGenerations[pid]?.startIdentity == expectedGeneration
             else {
-                let errorMessage = "Failed to setup bounded AXObserver for \(describePid(pid)) " +
-                    "notification \(notification.rawValue) (AXError \(setupResult.error.rawValue))"
-                return .failure(.observerSetupFailed(details: errorMessage))
+                return self.asyncSetupFailure(pid: pid, notification: notification, error: setupResult.error)
             }
             guard let state = setupResult.state,
                   self.nativeRegistrationStates[registration] == state
             else { continue }
             self.asynchronousNativeRegistrations.insert(registration)
-            let token = self.subscriptionStore.add(registration: registration, handler: handler)
-            return .success(token)
+            return .success(self.subscriptionStore.add(registration: registration, handler: handler))
         }
+    }
+
+    private func asyncSetupFailure(
+        pid: pid_t,
+        notification: AXNotification,
+        error: AXError) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        let details = "Failed to setup bounded AXObserver for \(describePid(pid)) " +
+            "notification \(notification.rawValue) (AXError \(error.rawValue))"
+        return .failure(.observerSetupFailed(details: details))
     }
 
     public func unsubscribe(token: SubscriptionToken) throws {
@@ -487,8 +489,12 @@ extension AXObserverCenter {
             return .failure
         }
         let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
+        let nativeWorkAdmission = self.nativeWorkAdmission
         let registrationTask = Task.detached(priority: .utility) {
-            await Self.performBlockingNativeCall {
+            await ObserverNativeWork.perform(
+                admission: nativeWorkAdmission,
+                refusalValue: AXError.cannotComplete)
+            {
                 registrationWork.add()
             }
         }
@@ -497,17 +503,19 @@ extension AXObserverCenter {
               !Task.isCancelled
         else {
             if error == .success {
-                _ = await Self.removeNativeRegistration(registrationWork)
+                _ = await self.removeNativeRegistration(registrationWork)
             }
             return .cannotComplete
         }
-        let finalGeneration = await Self.boundedNativeProcessUniqueIdentity(targetPid)
+        let finalGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
+            targetPid,
+            admission: self.nativeWorkAdmission)
         guard self.pendingRegistrations[registration]?.id == operationID,
               !Task.isCancelled,
               finalGeneration == expectedGeneration
         else {
             if error == .success {
-                _ = await Self.removeNativeRegistration(registrationWork)
+                _ = await self.removeNativeRegistration(registrationWork)
             }
             self.resetObserverGeneration(for: targetPid, ifMatching: expectedGeneration)
             return .cannotComplete
@@ -521,6 +529,12 @@ extension AXObserverCenter {
             self.removeObserverIfUnused(targetPid: targetPid)
         }
         return error
+    }
+
+    private func removeNativeRegistration(_ registration: NativeNotificationRegistration) async -> AXError {
+        await ObserverNativeWork.performCleanup(admission: self.nativeWorkAdmission) {
+            registration.remove()
+        }
     }
 
     private func setupUnderlyingObserver(
@@ -544,22 +558,28 @@ extension AXObserverCenter {
         }
 
         let targetPid = subscription.pid
-        self.logObserverSetup(
-            targetPid: targetPid,
-            element: registration.element,
-            notification: subscription.notification)
         guard let observer = getOrCreateObserver(for: targetPid, expectedGeneration: expectedGeneration) else {
             axErrorLog("Failed to get/create AXObserver for effective PID \(targetPid) during setup.")
             return .failure
         }
 
         let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
-        let error = registrationWork.add()
+        let error = ObserverNativeWork.performSynchronously(
+            admission: self.nativeWorkAdmission,
+            refusalValue: AXError.cannotComplete)
+        {
+            registrationWork.add()
+        }
 
         let finalGeneration = self.processIdentityProvider(targetPid)
         guard finalGeneration == expectedGeneration else {
             if error == .success {
-                _ = registrationWork.remove()
+                let removalError = ObserverNativeWork.tryPerformCleanupSynchronously(
+                    admission: self.nativeWorkAdmission,
+                    operation: { registrationWork.remove() })
+                if removalError == nil {
+                    self.scheduleNativeRemoval(registration, cleanup: registrationWork)
+                }
             }
             if finalGeneration == nil {
                 self.removeObserverIfUnused(targetPid: targetPid)
@@ -574,15 +594,6 @@ extension AXObserverCenter {
             self.removeObserverIfUnused(targetPid: targetPid)
         }
         return error
-    }
-
-    private func logObserverSetup(targetPid: pid_t, element: Element?, notification: AXNotification) {
-        let elementDescriptionForLog = element?.briefDescription() ?? "N/A"
-        axDebugLog(
-            logSegments(
-                "Setting up underlying AXObserver for effective \(describePid(targetPid))",
-                "Element: \(elementDescriptionForLog)",
-                "notification: \(notification.rawValue)"))
     }
 
     private func elementForObservation(
@@ -672,16 +683,36 @@ extension AXObserverCenter {
 
         let cleanup = self.nativeNotificationRegistration(for: registration, observer: observer)
         guard self.asynchronousNativeRegistrations.contains(registration) else {
-            self.finalizeNativeRemoval(registration, error: cleanup.remove())
+            guard let error = ObserverNativeWork.tryPerformCleanupSynchronously(
+                admission: self.nativeWorkAdmission,
+                operation: {
+                    cleanup.remove()
+                })
+            else {
+                self.asynchronousNativeRegistrations.insert(registration)
+                self.scheduleNativeRemoval(registration, cleanup: cleanup)
+                return
+            }
+            self.finalizeNativeRemoval(registration, error: error)
             return
         }
+        self.scheduleNativeRemoval(registration, cleanup: cleanup)
+    }
+
+    private func scheduleNativeRemoval(
+        _ registration: AXObserverRegistrationKey,
+        cleanup: NativeNotificationRegistration)
+    {
         let id = UUID()
         let completion = NativeRemovalCompletion()
         self.pendingRemovals[registration] = PendingRemoval(id: id, completion: completion)
-        Thread.detachNewThread {
-            let error = autoreleasepool { cleanup.remove() }
+        let nativeWorkAdmission = self.nativeWorkAdmission
+        Task.detached(priority: .utility) {
+            let error = await ObserverNativeWork.performCleanup(admission: nativeWorkAdmission) {
+                cleanup.remove()
+            }
             completion.finish(with: error)
-            Task { @MainActor in
+            await MainActor.run {
                 self.completePendingRemoval(registration, id: id, error: error)
             }
         }
@@ -693,9 +724,12 @@ extension AXObserverCenter {
         self.completePendingRemoval(registration, id: pending.id, error: error)
     }
 
-    private func finishPendingRemovalSynchronously(_ registration: AXObserverRegistrationKey) -> Bool {
-        guard let pending = self.pendingRemovals[registration] else { return false }
-        let error = pending.completion.wait()
+    private func finishPendingRemovalSynchronously(_ registration: AXObserverRegistrationKey) -> Bool? {
+        guard let pending = self.pendingRemovals[registration] else { return nil }
+        let clock = ContinuousClock()
+        guard let error = pending.completion.wait(until: clock.now.advanced(by: .milliseconds(750))) else {
+            return false
+        }
         self.completePendingRemoval(registration, id: pending.id, error: error)
         return true
     }
@@ -804,7 +838,9 @@ extension AXObserverCenter {
         guard self.pendingObserverCreations[pid]?.id == pending.id else {
             return self.observer(for: pid, matching: expectedGeneration)
         }
-        let finalGeneration = await Self.boundedNativeProcessUniqueIdentity(pid)
+        let finalGeneration = await ObserverNativeWork.boundedProcessUniqueIdentity(
+            pid,
+            admission: self.nativeWorkAdmission)
         guard self.pendingObserverCreations[pid]?.id == pending.id else {
             return self.observer(for: pid, matching: expectedGeneration)
         }
@@ -841,9 +877,7 @@ extension AXObserverCenter {
             self.pendingObserverCreations[pid] = pending
             return pending
         }
-        guard ObserverNativeWorkerAdmission.allowsStartingWorker(
-            activeWorkerCount: self.nativeObserverWorkers.count)
-        else {
+        guard self.nativeWorkAdmission.tryAcquire() else {
             let task = Task<NativeObserverCreation, Never> { .timedOut }
             let pending = PendingObserverCreation(
                 id: id,
@@ -855,7 +889,9 @@ extension AXObserverCenter {
 
         self.nativeObserverWorkers[workerKey] = id
         let callback = SendableObserverCallback(value: self.makeObserverCallback())
+        let nativeWorkAdmission = self.nativeWorkAdmission
         let workerFinished: @Sendable () -> Void = { [weak self] in
+            nativeWorkAdmission.release()
             Task { @MainActor in
                 self?.finishNativeObserverWorker(workerKey, id: id)
             }
@@ -916,71 +952,21 @@ extension AXObserverCenter {
         await withCheckedContinuation { continuation in
             let gate = FirstResultGate(continuation: continuation)
             Thread.detachNewThread {
-                defer { workerFinished() }
-                autoreleasepool {
+                let outcome = autoreleasepool { () -> NativeObserverCreation in
                     var observer: AXObserver?
                     let error = AXObserverCreateWithInfoCallback(pid, callback.value, &observer)
                     guard error == .success, let observer else {
-                        gate.finish(with: .failed(error))
-                        return
+                        return .failed(error)
                     }
-                    gate.finish(with: .created(SendableObserver(value: observer)))
+                    return .created(SendableObserver(value: observer))
                 }
+                workerFinished()
+                gate.finish(with: outcome)
             }
             Task.detached(priority: .utility) {
                 try? await Task.sleep(for: timeout)
                 gate.finish(with: .timedOut)
             }
-        }
-    }
-
-    private nonisolated static func boundedNativeProcessUniqueIdentity(
-        _ processIdentifier: pid_t) async -> UInt64?
-    {
-        await self.firstResult(
-            timeout: .milliseconds(100),
-            timeoutValue: UInt64?.none)
-        {
-            self.nativeProcessUniqueIdentity(processIdentifier)
-        }
-    }
-
-    private nonisolated static func firstResult<Value: Sendable>(
-        timeout: Duration,
-        timeoutValue: Value,
-        operation: @escaping @Sendable () -> Value) async -> Value
-    {
-        await withCheckedContinuation { continuation in
-            let gate = FirstResultGate(continuation: continuation)
-            Thread.detachNewThread {
-                autoreleasepool {
-                    gate.finish(with: operation())
-                }
-            }
-            Task.detached(priority: .utility) {
-                try? await Task.sleep(for: timeout)
-                gate.finish(with: timeoutValue)
-            }
-        }
-    }
-
-    private nonisolated static func performBlockingNativeCall<Value: Sendable>(
-        _ operation: @escaping @Sendable () -> Value) async -> Value
-    {
-        await withCheckedContinuation { continuation in
-            Thread.detachNewThread {
-                autoreleasepool {
-                    continuation.resume(returning: operation())
-                }
-            }
-        }
-    }
-
-    private nonisolated static func removeNativeRegistration(
-        _ registration: NativeNotificationRegistration) async -> AXError
-    {
-        await self.performBlockingNativeCall {
-            registration.remove()
         }
     }
 
@@ -1093,20 +1079,7 @@ extension AXObserverCenter {
     }
 
     nonisolated static func nativeProcessUniqueIdentity(_ processIdentifier: pid_t) -> UInt64? {
-        guard processIdentifier > 0 else { return nil }
-        var info = ProcessUniqueIdentifierInfo()
-        let expectedSize = Int32(MemoryLayout<ProcessUniqueIdentifierInfo>.stride)
-        guard proc_pidinfo(
-            processIdentifier,
-            17, // PROC_PIDUNIQIDENTIFIERINFO from XNU's proc_info_private.h
-            0,
-            &info,
-            expectedSize) == expectedSize,
-            info.uniqueIdentifier != 0
-        else {
-            return nil
-        }
-        return info.uniqueIdentifier
+        ObserverNativeWork.processUniqueIdentity(processIdentifier)
     }
 
     // MARK: - Main Notification Processing (Called by global callbacks)

--- a/Sources/AXorcist/Core/AXObserverCenter.swift
+++ b/Sources/AXorcist/Core/AXObserverCenter.swift
@@ -37,7 +37,7 @@ public final class AXObserverCenter {
     }
 
     /// Layout from XNU's API-stable `proc_uniqidentifierinfo`.
-    private struct ProcessUniqueIdentifierInfo {
+    private nonisolated struct ProcessUniqueIdentifierInfo {
         var executableUUIDHigh: UInt64 = 0
         var executableUUIDLow: UInt64 = 0
         var uniqueIdentifier: UInt64 = 0
@@ -46,6 +46,44 @@ public final class AXObserverCenter {
         var originalParentIdentifierVersion: Int32 = 0
         var reserved2: UInt64 = 0
         var reserved3: UInt64 = 0
+    }
+
+    private struct PendingObserverCreation {
+        let id: UUID
+        let expectedGeneration: UInt64
+        let task: Task<NativeObserverCreation, Never>
+    }
+
+    private struct PendingRegistration {
+        let id: UUID
+        let expectedGeneration: UInt64
+        let task: Task<NativeRegistrationSetupResult, Never>
+        let completion: NativeRemovalCompletion
+    }
+
+    private struct NativeRegistrationState: Equatable {
+        let operationID: UUID
+        let processGeneration: UInt64
+    }
+
+    private struct NativeRegistrationSetupResult {
+        let error: AXError
+        let state: NativeRegistrationState?
+    }
+
+    private struct PendingRemoval {
+        let id: UUID
+        let completion: NativeRemovalCompletion
+    }
+
+    private struct ObserverWorkerKey: Hashable {
+        let pid: pid_t
+        let processGeneration: UInt64
+    }
+
+    private struct ObserverStateEpoch: Equatable {
+        let global: UInt64
+        let process: UInt64
     }
 
     // MARK: - Public State
@@ -68,6 +106,14 @@ public final class AXObserverCenter {
     private let subscriptionStore = AXObserverSubscriptionStore()
     private var observers: [AXObserverObjAndPID] = []
     private var observerGenerations: [pid_t: ObserverGeneration] = [:]
+    private var pendingObserverCreations: [pid_t: PendingObserverCreation] = [:]
+    private var nativeObserverWorkers: [ObserverWorkerKey: UUID] = [:]
+    private var pendingRegistrations: [AXObserverRegistrationKey: PendingRegistration] = [:]
+    private var pendingRemovals: [AXObserverRegistrationKey: PendingRemoval] = [:]
+    private var nativeRegistrationStates: [AXObserverRegistrationKey: NativeRegistrationState] = [:]
+    private var asynchronousNativeRegistrations: Set<AXObserverRegistrationKey> = []
+    private var globalStateEpoch: UInt64 = 0
+    private var processStateEpochs: [pid_t: UInt64] = [:]
     private let observerSetupOverride: ObserverSetup?
     private let observerCleanupOverride: ObserverCleanup?
     private let processIdentityProvider: ProcessIdentityProvider
@@ -138,15 +184,23 @@ extension AXObserverCenter {
                 details: "Could not resolve the process generation for PID \(pid)"))
         }
         self.prepareObserverGeneration(for: pid, currentIdentity: expectedGeneration)
-        let elementDescriptionForLog = element?.briefDescription() ?? "N/A"
-        axDebugLog(
-            logSegments(
-                "Subscribe request for \(describePid(pid))",
-                "Element: \(elementDescriptionForLog)",
-                "notification: \(notification.rawValue)"))
 
         let registration = self.registrationKey(pid: pid, element: element, notification: notification)
-        let setupError = if self.subscriptionStore.contains(registration: registration) {
+        let awaitedRemoval = self.finishPendingRemovalSynchronously(registration)
+        guard !awaitedRemoval || self.processIdentityProvider(pid) == expectedGeneration else {
+            self.resetObserverGeneration(for: pid, ifMatching: expectedGeneration)
+            return .failure(.observerSetupFailed(
+                details: "Process generation changed while awaiting observer cleanup for PID \(pid)"))
+        }
+        let expectedEpoch = self.currentStateEpoch(for: pid)
+        let joinedRegistration = self.finishPendingRegistrationSynchronously(
+            registration,
+            expectedGeneration: expectedGeneration,
+            expectedEpoch: expectedEpoch)
+        let hasNativeRegistration = self.nativeRegistrationStates[registration]?.processGeneration == expectedGeneration
+        let setupError = if let joinedRegistration {
+            joinedRegistration
+        } else if hasNativeRegistration {
             AXError.success
         } else {
             self.setupUnderlyingObserver(registration, expectedGeneration: expectedGeneration)
@@ -157,13 +211,79 @@ extension AXObserverCenter {
             axErrorLog(errorMessage)
             return .failure(.observerSetupFailed(details: errorMessage))
         }
+        if joinedRegistration == nil, !hasNativeRegistration {
+            self.nativeRegistrationStates[registration] = NativeRegistrationState(
+                operationID: UUID(),
+                processGeneration: expectedGeneration)
+        }
+        if joinedRegistration != nil {
+            self.asynchronousNativeRegistrations.insert(registration)
+        } else if !hasNativeRegistration {
+            self.asynchronousNativeRegistrations.remove(registration)
+        }
 
         let token = self.subscriptionStore.add(registration: registration, handler: handler)
-        axInfoLog(
-            logSegments(
-                "Successfully subscribed handler (token: \(token.id)) for \(describePid(pid))",
-                "notification: \(notification.rawValue)"))
         return .success(token)
+    }
+
+    func subscribeProcessAsync(
+        pid: pid_t,
+        element: Element? = nil,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) async -> Result<SubscriptionToken, AccessibilityError>
+    {
+        if self.observerSetupOverride != nil {
+            return self.subscribeProcess(
+                pid: pid,
+                element: element,
+                notification: notification,
+                handler: handler)
+        }
+        guard pid > 0 else {
+            return .failure(.observerSetupFailed(
+                details: "macOS AXObserver requires an application PID greater than zero"))
+        }
+        guard let expectedGeneration = await Self.boundedNativeProcessUniqueIdentity(pid) else {
+            return .failure(.observerSetupFailed(
+                details: "Could not resolve the process generation for PID \(pid)"))
+        }
+        let expectedEpoch = self.prepareObserverEpoch(for: pid, currentIdentity: expectedGeneration)
+
+        let registration = self.registrationKey(pid: pid, element: element, notification: notification)
+        while true {
+            await self.finishPendingRemoval(registration)
+            guard self.currentStateEpoch(for: pid) == expectedEpoch else {
+                return .failure(.observerSetupFailed(
+                    details: "Observer state changed while registering PID \(pid)"))
+            }
+
+            let setupResult = if let state = self.nativeRegistrationStates[registration],
+                                 state.processGeneration == expectedGeneration
+            {
+                NativeRegistrationSetupResult(error: .success, state: state)
+            } else {
+                await self.setupRegistrationAsync(
+                    registration,
+                    expectedGeneration: expectedGeneration)
+            }
+            if self.pendingRemovals[registration] != nil {
+                continue
+            }
+            guard setupResult.error == .success,
+                  self.currentStateEpoch(for: pid) == expectedEpoch,
+                  self.observerGenerations[pid]?.startIdentity == expectedGeneration
+            else {
+                let errorMessage = "Failed to setup bounded AXObserver for \(describePid(pid)) " +
+                    "notification \(notification.rawValue) (AXError \(setupResult.error.rawValue))"
+                return .failure(.observerSetupFailed(details: errorMessage))
+            }
+            guard let state = setupResult.state,
+                  self.nativeRegistrationStates[registration] == state
+            else { continue }
+            self.asynchronousNativeRegistrations.insert(registration)
+            let token = self.subscriptionStore.add(registration: registration, handler: handler)
+            return .success(token)
+        }
     }
 
     public func unsubscribe(token: SubscriptionToken) throws {
@@ -192,6 +312,19 @@ extension AXObserverCenter {
 
     public func removeAllObservers() {
         axInfoLog("Removing all observers and subscriptions globally.")
+        self.advanceStateEpoch()
+        for pending in self.pendingObserverCreations.values {
+            pending.task.cancel()
+        }
+        for pending in self.pendingRegistrations.values {
+            pending.task.cancel()
+        }
+        self.pendingObserverCreations.removeAll()
+        self.pendingRegistrations.removeAll()
+        self.pendingRemovals.removeAll()
+        self.nativeRegistrationStates.removeAll()
+        self.asynchronousNativeRegistrations.removeAll()
+        self.processStateEpochs.removeAll()
         self.subscriptionStore.removeAll()
 
         for record in self.observers {
@@ -206,9 +339,12 @@ extension AXObserverCenter {
 
     public func removeAllObservers(for pid: pid_t) {
         axInfoLog("Removing all observers and subscriptions for PID \(pid)")
+        self.advanceStateEpoch(for: pid)
+        self.cancelPendingWork(for: pid)
         for token in self.subscriptionStore.tokens(for: pid) {
             try? self.unsubscribe(token: token)
         }
+        self.removeObserverIfUnused(targetPid: pid)
     }
 
     public func isKeyRegistered(pid: pid_t?, notification: AXNotification) -> Bool {
@@ -237,10 +373,13 @@ extension AXObserverCenter {
             pid: pid,
             element: element,
             notification: notification))
+        let scope: AXObserverRegistrationKey.Scope = element == nil
+            ? .process
+            : self.registrationScope(pid: pid, observedElement: observedElement)
         return AXObserverRegistrationKey(
             subscription: AXNotificationSubscriptionKey(pid: pid, notification: notification),
             element: observedElement,
-            scope: self.registrationScope(pid: pid, observedElement: observedElement))
+            scope: scope)
     }
 
     private func registrationScope(pid: pid_t, observedElement: Element) -> AXObserverRegistrationKey.Scope {
@@ -249,6 +388,141 @@ extension AXObserverCenter {
     }
 
     /// Ensures an AXObserver is created for the exact registration target.
+    private func setupRegistrationAsync(
+        _ registration: AXObserverRegistrationKey,
+        expectedGeneration: UInt64) async -> NativeRegistrationSetupResult
+    {
+        if let pending = self.pendingRegistrations[registration],
+           pending.expectedGeneration == expectedGeneration
+        {
+            return await pending.task.value
+        }
+        if let stalePending = self.pendingRegistrations.removeValue(forKey: registration) {
+            stalePending.task.cancel()
+        }
+        let id = UUID()
+        let completion = NativeRemovalCompletion()
+        let task = Task { @MainActor in
+            let error = await self.setupUnderlyingObserverAsync(
+                registration,
+                operationID: id,
+                expectedGeneration: expectedGeneration)
+            let state = error == .success
+                ? NativeRegistrationState(operationID: id, processGeneration: expectedGeneration)
+                : nil
+            if let state {
+                self.nativeRegistrationStates[registration] = state
+            }
+            completion.finish(with: error)
+            return NativeRegistrationSetupResult(error: error, state: state)
+        }
+        self.pendingRegistrations[registration] = PendingRegistration(
+            id: id,
+            expectedGeneration: expectedGeneration,
+            task: task,
+            completion: completion)
+        let result = await task.value
+        if self.pendingRegistrations[registration]?.id == id {
+            self.pendingRegistrations.removeValue(forKey: registration)
+        }
+        if result.error != AXError.success {
+            self.removeObserverIfUnused(targetPid: registration.subscription.pid)
+        }
+        return result
+    }
+
+    private func finishPendingRegistrationSynchronously(
+        _ registration: AXObserverRegistrationKey,
+        expectedGeneration: UInt64,
+        expectedEpoch: ObserverStateEpoch) -> AXError?
+    {
+        guard let pending = self.pendingRegistrations[registration] else { return nil }
+        guard pending.expectedGeneration == expectedGeneration else { return .cannotComplete }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while pending.completion.currentResult() == nil, clock.now < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+        }
+        guard let error = pending.completion.currentResult() else { return .cannotComplete }
+        let stillOwnsPending = self.pendingRegistrations[registration]?.id == pending.id
+        let expectedState = NativeRegistrationState(
+            operationID: pending.id,
+            processGeneration: expectedGeneration)
+        let alreadyCommitted = self.nativeRegistrationStates[registration] == expectedState
+        guard self.currentStateEpoch(for: registration.subscription.pid) == expectedEpoch else {
+            return .cannotComplete
+        }
+        if error == .success {
+            guard self.observerGenerations[registration.subscription.pid]?.startIdentity == expectedGeneration else {
+                return .cannotComplete
+            }
+            guard alreadyCommitted else {
+                if stillOwnsPending {
+                    self.pendingRegistrations.removeValue(forKey: registration)
+                }
+                return nil
+            }
+        } else if !stillOwnsPending {
+            return .cannotComplete
+        }
+        if stillOwnsPending {
+            self.pendingRegistrations.removeValue(forKey: registration)
+        }
+        if error != .success {
+            self.removeObserverIfUnused(targetPid: registration.subscription.pid)
+        }
+        return error
+    }
+
+    private func setupUnderlyingObserverAsync(
+        _ registration: AXObserverRegistrationKey,
+        operationID: UUID,
+        expectedGeneration: UInt64) async -> AXError
+    {
+        let targetPid = registration.subscription.pid
+        guard let observer = await self.getOrCreateObserverAsync(
+            for: targetPid,
+            expectedGeneration: expectedGeneration)
+        else {
+            return .failure
+        }
+        let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
+        let registrationTask = Task.detached(priority: .utility) {
+            await Self.performBlockingNativeCall {
+                registrationWork.add()
+            }
+        }
+        let error = await registrationTask.value
+        guard self.pendingRegistrations[registration]?.id == operationID,
+              !Task.isCancelled
+        else {
+            if error == .success {
+                _ = await Self.removeNativeRegistration(registrationWork)
+            }
+            return .cannotComplete
+        }
+        let finalGeneration = await Self.boundedNativeProcessUniqueIdentity(targetPid)
+        guard self.pendingRegistrations[registration]?.id == operationID,
+              !Task.isCancelled,
+              finalGeneration == expectedGeneration
+        else {
+            if error == .success {
+                _ = await Self.removeNativeRegistration(registrationWork)
+            }
+            self.resetObserverGeneration(for: targetPid, ifMatching: expectedGeneration)
+            return .cannotComplete
+        }
+
+        self.logObserverAddResult(
+            targetPid: targetPid,
+            notification: registration.subscription.notification,
+            error: error)
+        if error != .success {
+            self.removeObserverIfUnused(targetPid: targetPid)
+        }
+        return error
+    }
+
     private func setupUnderlyingObserver(
         _ registration: AXObserverRegistrationKey,
         expectedGeneration: UInt64) -> AXError
@@ -279,20 +553,13 @@ extension AXObserverCenter {
             return .failure
         }
 
-        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
-        let error = AXObserverAddNotification(
-            observer,
-            registration.element.underlyingElement,
-            subscription.notification.rawValue as CFString,
-            selfPtr)
+        let registrationWork = self.nativeNotificationRegistration(for: registration, observer: observer)
+        let error = registrationWork.add()
 
         let finalGeneration = self.processIdentityProvider(targetPid)
         guard finalGeneration == expectedGeneration else {
             if error == .success {
-                _ = AXObserverRemoveNotification(
-                    observer,
-                    registration.element.underlyingElement,
-                    subscription.notification.rawValue as CFString)
+                _ = registrationWork.remove()
             }
             if finalGeneration == nil {
                 self.removeObserverIfUnused(targetPid: targetPid)
@@ -340,6 +607,22 @@ extension AXObserverCenter {
         return AXUIElement.application(pid: pid)
     }
 
+    private func nativeNotificationRegistration(
+        for registration: AXObserverRegistrationKey,
+        observer: AXObserver) -> NativeNotificationRegistration
+    {
+        let processScoped = registration.scope == .process
+        let element = processScoped
+            ? AXUIElement.application(pid: registration.subscription.pid)
+            : registration.element.underlyingElement
+        return NativeNotificationRegistration(
+            observer: observer,
+            element: element,
+            notification: registration.subscription.notification.rawValue as CFString,
+            refcon: Unmanaged.passUnretained(self).toOpaque(),
+            appliesMessagingTimeout: processScoped)
+    }
+
     private func logObserverAddResult(targetPid: pid_t, notification: AXNotification, error: AXError) {
         let message = logSegments(
             "AXObserver notification \(notification.rawValue) for \(describePid(targetPid))",
@@ -356,6 +639,8 @@ extension AXObserverCenter {
         let subscription = registration.subscription
         if let observerCleanupOverride {
             observerCleanupOverride(subscription.pid, registration.element, subscription.notification)
+            self.nativeRegistrationStates.removeValue(forKey: registration)
+            self.asynchronousNativeRegistrations.remove(registration)
             return
         }
 
@@ -374,6 +659,8 @@ extension AXObserverCenter {
         }
 
         guard let observer = getObserver(for: targetPid) else {
+            self.nativeRegistrationStates.removeValue(forKey: registration)
+            self.asynchronousNativeRegistrations.remove(registration)
             axWarningLog(
                 logSegments(
                     "No AXObserver found for \(describePid(targetPid)) during cleanup",
@@ -381,29 +668,77 @@ extension AXObserverCenter {
             return
         }
 
-        let error = AXObserverRemoveNotification(
-            observer,
-            registration.element.underlyingElement,
-            subscription.notification.rawValue as CFString)
+        guard self.pendingRemovals[registration] == nil else { return }
 
-        if error == .success {
+        let cleanup = self.nativeNotificationRegistration(for: registration, observer: observer)
+        guard self.asynchronousNativeRegistrations.contains(registration) else {
+            self.finalizeNativeRemoval(registration, error: cleanup.remove())
+            return
+        }
+        let id = UUID()
+        let completion = NativeRemovalCompletion()
+        self.pendingRemovals[registration] = PendingRemoval(id: id, completion: completion)
+        Thread.detachNewThread {
+            let error = autoreleasepool { cleanup.remove() }
+            completion.finish(with: error)
+            Task { @MainActor in
+                self.completePendingRemoval(registration, id: id, error: error)
+            }
+        }
+    }
+
+    private func finishPendingRemoval(_ registration: AXObserverRegistrationKey) async {
+        guard let pending = self.pendingRemovals[registration] else { return }
+        let error = await pending.completion.value()
+        self.completePendingRemoval(registration, id: pending.id, error: error)
+    }
+
+    private func finishPendingRemovalSynchronously(_ registration: AXObserverRegistrationKey) -> Bool {
+        guard let pending = self.pendingRemovals[registration] else { return false }
+        let error = pending.completion.wait()
+        self.completePendingRemoval(registration, id: pending.id, error: error)
+        return true
+    }
+
+    private func completePendingRemoval(
+        _ registration: AXObserverRegistrationKey,
+        id: UUID,
+        error: AXError)
+    {
+        guard self.pendingRemovals[registration]?.id == id else { return }
+        self.pendingRemovals.removeValue(forKey: registration)
+        self.finalizeNativeRemoval(registration, error: error)
+    }
+
+    private func finalizeNativeRemoval(_ registration: AXObserverRegistrationKey, error: AXError) {
+        let targetPid = registration.subscription.pid
+        let notification = registration.subscription.notification
+        self.nativeRegistrationStates.removeValue(forKey: registration)
+        self.asynchronousNativeRegistrations.remove(registration)
+        if NativeNotificationRegistration.removalConfirmsRegistrationAbsent(error) {
             axInfoLog(
                 logSegments(
                     "Successfully removed notification from AXObserver for \(describePid(targetPid))",
-                    "key: \(subscription.notification.rawValue) during cleanup"))
-            self.removeObserverIfUnused(targetPid: targetPid)
+                    "key: \(notification.rawValue) during cleanup"))
         } else {
             axErrorLog(
                 logSegments(
                     "Failed to remove notification from AXObserver for \(describePid(targetPid))",
-                    "key: \(subscription.notification.rawValue)",
+                    "key: \(notification.rawValue)",
                     "error: \(error.rawValue)"))
         }
+        self.removeObserverIfUnused(targetPid: targetPid)
     }
 
     private func removeObserverIfUnused(targetPid: pid_t) {
         let hasAnySubscription = self.subscriptionStore.containsSubscriptions(forEffectivePID: targetPid)
-        guard !hasAnySubscription, let observer = getObserver(for: targetPid) else { return }
+        let hasPendingRegistration = self.pendingRegistrations.keys.contains {
+            $0.subscription.pid == targetPid
+        }
+        guard !hasAnySubscription,
+              !hasPendingRegistration,
+              let observer = getObserver(for: targetPid)
+        else { return }
         let source = AXObserverGetRunLoopSource(observer)
         CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
         CFRunLoopSourceInvalidate(source)
@@ -419,7 +754,19 @@ extension AXObserverCenter {
         self.resetObserverGeneration(for: pid)
     }
 
-    private func resetObserverGeneration(for pid: pid_t) {
+    private func prepareObserverEpoch(for pid: pid_t, currentIdentity: UInt64) -> ObserverStateEpoch {
+        self.prepareObserverGeneration(for: pid, currentIdentity: currentIdentity)
+        return self.currentStateEpoch(for: pid)
+    }
+
+    private func resetObserverGeneration(for pid: pid_t, ifMatching expectedGeneration: UInt64? = nil) {
+        if let expectedGeneration,
+           self.observerGenerations[pid]?.startIdentity != expectedGeneration
+        {
+            return
+        }
+        self.advanceStateEpoch(for: pid)
+        self.cancelPendingWork(for: pid, matching: expectedGeneration)
         if let observer = getObserver(for: pid) {
             let source = AXObserverGetRunLoopSource(observer)
             CFRunLoopRemoveSource(CFRunLoopGetCurrent(), source, .defaultMode)
@@ -445,6 +792,229 @@ extension AXObserverCenter {
             return existing
         }
         return self.createObserver(for: pid, expectedGeneration: expectedGeneration)
+    }
+
+    private func getOrCreateObserverAsync(for pid: pid_t, expectedGeneration: UInt64) async -> AXObserver? {
+        if let existing = self.getObserver(for: pid) {
+            return existing
+        }
+
+        let pending = self.pendingObserverCreation(for: pid, expectedGeneration: expectedGeneration)
+        let outcome = await pending.task.value
+        guard self.pendingObserverCreations[pid]?.id == pending.id else {
+            return self.observer(for: pid, matching: expectedGeneration)
+        }
+        let finalGeneration = await Self.boundedNativeProcessUniqueIdentity(pid)
+        guard self.pendingObserverCreations[pid]?.id == pending.id else {
+            return self.observer(for: pid, matching: expectedGeneration)
+        }
+        self.pendingObserverCreations.removeValue(forKey: pid)
+        if let existing = self.observer(for: pid, matching: expectedGeneration) {
+            return existing
+        }
+        guard finalGeneration == expectedGeneration else {
+            axWarningLog("Discarded AXObserver creation for reused or terminated PID \(pid)")
+            return nil
+        }
+
+        return self.commitNativeObserver(outcome, for: pid, expectedGeneration: expectedGeneration)
+    }
+
+    private func pendingObserverCreation(
+        for pid: pid_t,
+        expectedGeneration: UInt64) -> PendingObserverCreation
+    {
+        if let pending = self.pendingObserverCreations[pid],
+           pending.expectedGeneration == expectedGeneration
+        {
+            return pending
+        }
+        self.pendingObserverCreations.removeValue(forKey: pid)?.task.cancel()
+        let id = UUID()
+        let workerKey = ObserverWorkerKey(pid: pid, processGeneration: expectedGeneration)
+        if self.nativeObserverWorkers[workerKey] != nil {
+            let task = Task<NativeObserverCreation, Never> { .timedOut }
+            let pending = PendingObserverCreation(
+                id: id,
+                expectedGeneration: expectedGeneration,
+                task: task)
+            self.pendingObserverCreations[pid] = pending
+            return pending
+        }
+        guard ObserverNativeWorkerAdmission.allowsStartingWorker(
+            activeWorkerCount: self.nativeObserverWorkers.count)
+        else {
+            let task = Task<NativeObserverCreation, Never> { .timedOut }
+            let pending = PendingObserverCreation(
+                id: id,
+                expectedGeneration: expectedGeneration,
+                task: task)
+            self.pendingObserverCreations[pid] = pending
+            return pending
+        }
+
+        self.nativeObserverWorkers[workerKey] = id
+        let callback = SendableObserverCallback(value: self.makeObserverCallback())
+        let workerFinished: @Sendable () -> Void = { [weak self] in
+            Task { @MainActor in
+                self?.finishNativeObserverWorker(workerKey, id: id)
+            }
+        }
+        let task = Task.detached(priority: .utility) {
+            await Self.createNativeObserver(
+                for: pid,
+                callback: callback,
+                timeout: .milliseconds(500),
+                workerFinished: workerFinished)
+        }
+        let pending = PendingObserverCreation(
+            id: id,
+            expectedGeneration: expectedGeneration,
+            task: task)
+        self.pendingObserverCreations[pid] = pending
+        return pending
+    }
+
+    private func observer(for pid: pid_t, matching expectedGeneration: UInt64) -> AXObserver? {
+        guard self.observerGenerations[pid]?.startIdentity == expectedGeneration else { return nil }
+        return self.getObserver(for: pid)
+    }
+
+    private func finishNativeObserverWorker(_ workerKey: ObserverWorkerKey, id: UUID) {
+        guard self.nativeObserverWorkers[workerKey] == id else { return }
+        self.nativeObserverWorkers.removeValue(forKey: workerKey)
+    }
+
+    private func commitNativeObserver(
+        _ outcome: NativeObserverCreation,
+        for pid: pid_t,
+        expectedGeneration: UInt64) -> AXObserver?
+    {
+        switch outcome {
+        case let .created(observer):
+            let source = AXObserverGetRunLoopSource(observer.value)
+            CFRunLoopAddSource(CFRunLoopGetMain(), source, .defaultMode)
+            self.observers.append(AXObserverObjAndPID(observer: observer.value, pid: pid))
+            self.recordObserverGeneration(for: pid, startIdentity: expectedGeneration)
+            axDebugLog("Created bounded observer for PID \(pid)")
+            return observer.value
+        case let .failed(error):
+            axErrorLog("Failed to create observer for PID \(pid), error: \(error.rawValue)")
+            return nil
+        case .timedOut:
+            axWarningLog("Timed out creating observer for PID \(pid)")
+            return nil
+        }
+    }
+
+    private nonisolated static func createNativeObserver(
+        for pid: pid_t,
+        callback: SendableObserverCallback,
+        timeout: Duration,
+        workerFinished: @escaping @Sendable () -> Void) async -> NativeObserverCreation
+    {
+        await withCheckedContinuation { continuation in
+            let gate = FirstResultGate(continuation: continuation)
+            Thread.detachNewThread {
+                defer { workerFinished() }
+                autoreleasepool {
+                    var observer: AXObserver?
+                    let error = AXObserverCreateWithInfoCallback(pid, callback.value, &observer)
+                    guard error == .success, let observer else {
+                        gate.finish(with: .failed(error))
+                        return
+                    }
+                    gate.finish(with: .created(SendableObserver(value: observer)))
+                }
+            }
+            Task.detached(priority: .utility) {
+                try? await Task.sleep(for: timeout)
+                gate.finish(with: .timedOut)
+            }
+        }
+    }
+
+    private nonisolated static func boundedNativeProcessUniqueIdentity(
+        _ processIdentifier: pid_t) async -> UInt64?
+    {
+        await self.firstResult(
+            timeout: .milliseconds(100),
+            timeoutValue: UInt64?.none)
+        {
+            self.nativeProcessUniqueIdentity(processIdentifier)
+        }
+    }
+
+    private nonisolated static func firstResult<Value: Sendable>(
+        timeout: Duration,
+        timeoutValue: Value,
+        operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        await withCheckedContinuation { continuation in
+            let gate = FirstResultGate(continuation: continuation)
+            Thread.detachNewThread {
+                autoreleasepool {
+                    gate.finish(with: operation())
+                }
+            }
+            Task.detached(priority: .utility) {
+                try? await Task.sleep(for: timeout)
+                gate.finish(with: timeoutValue)
+            }
+        }
+    }
+
+    private nonisolated static func performBlockingNativeCall<Value: Sendable>(
+        _ operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        await withCheckedContinuation { continuation in
+            Thread.detachNewThread {
+                autoreleasepool {
+                    continuation.resume(returning: operation())
+                }
+            }
+        }
+    }
+
+    private nonisolated static func removeNativeRegistration(
+        _ registration: NativeNotificationRegistration) async -> AXError
+    {
+        await self.performBlockingNativeCall {
+            registration.remove()
+        }
+    }
+
+    private func cancelPendingWork(for pid: pid_t, matching expectedGeneration: UInt64? = nil) {
+        if let pending = self.pendingObserverCreations[pid],
+           expectedGeneration == nil || pending.expectedGeneration == expectedGeneration
+        {
+            self.pendingObserverCreations.removeValue(forKey: pid)?.task.cancel()
+        }
+        let registrations = self.pendingRegistrations.filter { registration, pending in
+            registration.subscription.pid == pid &&
+                (expectedGeneration == nil || pending.expectedGeneration == expectedGeneration)
+        }.map(\.key)
+        for registration in registrations {
+            self.pendingRegistrations.removeValue(forKey: registration)?.task.cancel()
+        }
+        let removals = self.pendingRemovals.keys.filter { $0.subscription.pid == pid }
+        for registration in removals {
+            self.pendingRemovals.removeValue(forKey: registration)
+        }
+    }
+
+    private func advanceStateEpoch() {
+        self.globalStateEpoch &+= 1
+    }
+
+    private func advanceStateEpoch(for pid: pid_t) {
+        self.processStateEpochs[pid, default: 0] &+= 1
+    }
+
+    private func currentStateEpoch(for pid: pid_t) -> ObserverStateEpoch {
+        ObserverStateEpoch(
+            global: self.globalStateEpoch,
+            process: self.processStateEpochs[pid, default: 0])
     }
 
     private func createObserver(for pid: pid_t, expectedGeneration: UInt64) -> AXObserver? {
@@ -513,10 +1083,16 @@ extension AXObserverCenter {
     private func removePidObserverInstance(pid: pid_t) {
         self.observers.removeAll { $0.pid == pid }
         self.observerGenerations.removeValue(forKey: pid)
+        self.nativeRegistrationStates = self.nativeRegistrationStates.filter {
+            $0.key.subscription.pid != pid
+        }
+        self.asynchronousNativeRegistrations = self.asynchronousNativeRegistrations.filter {
+            $0.subscription.pid != pid
+        }
         axDebugLog("Removed AXObserver instance for effective PID \(pid).")
     }
 
-    static func nativeProcessUniqueIdentity(_ processIdentifier: pid_t) -> UInt64? {
+    nonisolated static func nativeProcessUniqueIdentity(_ processIdentifier: pid_t) -> UInt64? {
         guard processIdentifier > 0 else { return nil }
         var info = ProcessUniqueIdentifierInfo()
         let expectedSize = Int32(MemoryLayout<ProcessUniqueIdentifierInfo>.stride)

--- a/Sources/AXorcist/Core/NotificationWatcher.swift
+++ b/Sources/AXorcist/Core/NotificationWatcher.swift
@@ -121,9 +121,13 @@ public class NotificationWatcher {
         axDebugLog("NotificationWatcher deinit")
         let token = self.subscriptionToken
         let globalTokens = Array(self.globalSubscriptionTokens.values)
-        let globalRetryTasks = Array(self.globalRetryTasks.values)
+        let globalRegistrationTasks = self.globalRegistrationTasks.values.map(\.task)
+        let globalRetryTasks = self.globalRetryTasks.values.map(\.task)
         let registry = self.registry
         let applicationMonitor = self.globalApplicationMonitor
+        for task in globalRegistrationTasks {
+            task.cancel()
+        }
         for task in globalRetryTasks {
             task.cancel()
         }
@@ -245,6 +249,16 @@ public class NotificationWatcher {
         case global
     }
 
+    private struct GlobalRegistrationTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private struct GlobalRetryTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
     private let target: ObservationTarget
     private let notification: AXNotification
     private let handler: AXNotificationSubscriptionHandler
@@ -253,8 +267,9 @@ public class NotificationWatcher {
     private let globalRetrySleep: @Sendable (Int) async throws -> Void
     private var subscriptionToken: SubscriptionToken?
     private var globalSubscriptionTokens: [pid_t: SubscriptionToken] = [:]
-    private var globalRetryTasks: [pid_t: Task<Void, Never>] = [:]
-    private var globalObservationStarting = false
+    private var globalRegistrationTasks: [pid_t: GlobalRegistrationTask] = [:]
+    private var globalRegistrationRefreshRequests: Set<pid_t> = []
+    private var globalRetryTasks: [pid_t: GlobalRetryTask] = [:]
     private var isObserving: Bool = false
 }
 
@@ -265,81 +280,129 @@ extension NotificationWatcher {
             throw AccessibilityError.observerSetupFailed(details: "Global application lifecycle monitor unavailable")
         }
 
-        self.globalObservationStarting = true
-        defer { self.globalObservationStarting = false }
+        // Process registration is intentionally asynchronous: a wedged AX endpoint
+        // must never keep the lifecycle monitor or its caller on the main actor.
+        self.isObserving = true
         globalApplicationMonitor.start(
             onLaunch: { [weak self] pid in
                 self?.handleGlobalLaunch(pid)
             },
             onTermination: { [weak self] pid in
+                self?.cancelGlobalRegistration(pid)
                 self?.cancelGlobalRetry(pid)
+                self?.globalRegistrationRefreshRequests.remove(pid)
                 self?.unsubscribeGlobalProcess(pid)
             })
 
         let processIdentifiers = Array(Set(globalApplicationMonitor.runningProcessIdentifiers)).sorted()
-        var failures: [AccessibilityError] = []
-        for pid in processIdentifiers {
-            guard self.globalSubscriptionTokens[pid] == nil,
-                  self.globalRetryTasks[pid] == nil
-            else { continue }
-            if let error = self.subscribeGlobalProcess(pid) {
-                failures.append(error)
-                axWarningLog("Global observer skipped running PID \(pid): \(error.localizedDescription)")
-                self.scheduleGlobalRetry(pid, attempt: 1, lastError: error)
-            } else {
-                self.cancelGlobalRetry(pid)
-            }
+        for pid in processIdentifiers where self.globalRegistrationTasks[pid] == nil {
+            self.startGlobalRegistration(pid, retryAttempt: 0)
         }
 
-        if !processIdentifiers.isEmpty, self.globalSubscriptionTokens.isEmpty {
-            self.cancelAllGlobalRetries()
-            globalApplicationMonitor.stop()
-            throw failures.first ?? AccessibilityError.observerSetupFailed(
-                details: "No running application accepted \(self.notification.rawValue)")
-        }
-
-        self.isObserving = true
         axInfoLog(
-            "Global observer started with \(self.globalSubscriptionTokens.count) process registrations for " +
+            "Global observer started; scheduling \(processIdentifiers.count) process registrations for " +
                 self.notification.rawValue)
     }
 
     private func stopGlobalObservation() {
-        guard self.isObserving || !self.globalSubscriptionTokens.isEmpty else { return }
+        guard self.isObserving ||
+            !self.globalSubscriptionTokens.isEmpty ||
+            !self.globalRegistrationTasks.isEmpty ||
+            !self.globalRetryTasks.isEmpty
+        else { return }
+        self.isObserving = false
         self.globalApplicationMonitor?.stop()
+        self.cancelAllGlobalRegistrations()
         self.cancelAllGlobalRetries()
+        self.globalRegistrationRefreshRequests.removeAll()
         for pid in self.globalSubscriptionTokens.keys.sorted() {
             self.unsubscribeGlobalProcess(pid)
         }
-        self.isObserving = false
         axInfoLog("Global observer stopped for \(self.notification.rawValue)")
     }
 
-    private func subscribeGlobalProcess(_ pid: pid_t) -> AccessibilityError? {
-        guard pid > 0, self.globalSubscriptionTokens[pid] == nil else { return nil }
-        switch self.registry.subscribeProcess(
-            pid: pid,
-            element: nil,
-            notification: self.notification,
-            handler: self.handler)
-        {
+    private func handleGlobalLaunch(_ pid: pid_t) {
+        guard self.isObserving, pid > 0, self.globalSubscriptionTokens[pid] == nil else { return }
+        self.cancelGlobalRetry(pid)
+        if self.globalRegistrationTasks[pid] != nil {
+            self.globalRegistrationRefreshRequests.insert(pid)
+            return
+        }
+        self.startGlobalRegistration(pid, retryAttempt: 0)
+    }
+
+    private func startGlobalRegistration(_ pid: pid_t, retryAttempt: Int) {
+        guard self.isObserving,
+              pid > 0,
+              self.globalSubscriptionTokens[pid] == nil,
+              self.globalRegistrationTasks[pid] == nil
+        else { return }
+
+        let id = UUID()
+        let registry = self.registry
+        let notification = self.notification
+        let handler = self.handler
+        let task = Task { @MainActor [weak self] in
+            let result = await registry.subscribeProcessAsync(
+                pid: pid,
+                element: nil,
+                notification: notification,
+                handler: handler)
+            guard let self else {
+                if case let .success(token) = result {
+                    try? registry.unsubscribe(token: token)
+                }
+                return
+            }
+            self.completeGlobalRegistration(
+                pid,
+                id: id,
+                retryAttempt: retryAttempt,
+                result: result)
+        }
+        self.globalRegistrationTasks[pid] = GlobalRegistrationTask(id: id, task: task)
+    }
+
+    private func completeGlobalRegistration(
+        _ pid: pid_t,
+        id: UUID,
+        retryAttempt: Int,
+        result: Result<SubscriptionToken, AccessibilityError>)
+    {
+        guard self.globalRegistrationTasks[pid]?.id == id else {
+            if case let .success(token) = result {
+                try? self.registry.unsubscribe(token: token)
+            }
+            return
+        }
+        self.globalRegistrationTasks.removeValue(forKey: pid)
+
+        guard self.isObserving else {
+            if case let .success(token) = result {
+                try? self.registry.unsubscribe(token: token)
+            }
+            return
+        }
+
+        switch result {
         case let .success(token):
+            self.globalRegistrationRefreshRequests.remove(pid)
             self.globalSubscriptionTokens[pid] = token
-            return nil
+            if retryAttempt > 0 {
+                axInfoLog("Global observer recovered registration for PID \(pid) on retry \(retryAttempt)")
+            }
         case let .failure(error):
-            return error
+            axWarningLog("Global observer skipped PID \(pid): \(error.localizedDescription)")
+            if self.globalRegistrationRefreshRequests.remove(pid) != nil {
+                self.startGlobalRegistration(pid, retryAttempt: retryAttempt)
+                return
+            }
+            self.scheduleGlobalRetry(pid, attempt: retryAttempt + 1, lastError: error)
         }
     }
 
-    private func handleGlobalLaunch(_ pid: pid_t) {
-        self.cancelGlobalRetry(pid)
-        guard let error = self.subscribeGlobalProcess(pid) else { return }
-        axWarningLog("Global observer skipped launched PID \(pid): \(error.localizedDescription)")
-        self.scheduleGlobalRetry(pid, attempt: 1, lastError: error)
-    }
-
     private func scheduleGlobalRetry(_ pid: pid_t, attempt: Int, lastError: AccessibilityError) {
-        guard self.isObserving || self.globalObservationStarting else { return }
+        guard self.isObserving else { return }
         guard attempt <= AXGlobalObserverRetryPolicy.maximumAttempts else {
             axWarningLog(
                 "Global observer exhausted retries for PID \(pid): \(lastError.localizedDescription)")
@@ -348,30 +411,41 @@ extension NotificationWatcher {
         guard self.globalRetryTasks[pid] == nil else { return }
 
         let retrySleep = self.globalRetrySleep
-        self.globalRetryTasks[pid] = Task { @MainActor [weak self] in
+        let id = UUID()
+        let task = Task { @MainActor [weak self] in
             do {
                 try await retrySleep(attempt)
             } catch {
                 return
             }
             guard !Task.isCancelled, let self else { return }
+            guard self.globalRetryTasks[pid]?.id == id else { return }
             self.globalRetryTasks.removeValue(forKey: pid)
-            guard self.isObserving || self.globalObservationStarting else { return }
-            if let error = self.subscribeGlobalProcess(pid) {
-                self.scheduleGlobalRetry(pid, attempt: attempt + 1, lastError: error)
-            } else {
-                axInfoLog("Global observer recovered registration for PID \(pid) on retry \(attempt)")
-            }
+            guard self.isObserving else { return }
+            self.startGlobalRegistration(pid, retryAttempt: attempt)
         }
+        self.globalRetryTasks[pid] = GlobalRetryTask(id: id, task: task)
+    }
+
+    private func cancelGlobalRegistration(_ pid: pid_t) {
+        self.globalRegistrationTasks.removeValue(forKey: pid)?.task.cancel()
+    }
+
+    private func cancelAllGlobalRegistrations() {
+        for registration in self.globalRegistrationTasks.values {
+            registration.task.cancel()
+        }
+        self.globalRegistrationTasks = [:]
+        self.globalRegistrationRefreshRequests.removeAll()
     }
 
     private func cancelGlobalRetry(_ pid: pid_t) {
-        self.globalRetryTasks.removeValue(forKey: pid)?.cancel()
+        self.globalRetryTasks.removeValue(forKey: pid)?.task.cancel()
     }
 
     private func cancelAllGlobalRetries() {
-        for task in self.globalRetryTasks.values {
-            task.cancel()
+        for retry in self.globalRetryTasks.values {
+            retry.task.cancel()
         }
         self.globalRetryTasks = [:]
     }

--- a/Sources/AXorcist/Core/ObserverNativeWork.swift
+++ b/Sources/AXorcist/Core/ObserverNativeWork.swift
@@ -183,6 +183,24 @@ nonisolated enum NativeObserverCreation: @unchecked Sendable {
     case timedOut
 }
 
+struct PendingObserverCreation {
+    let id: UUID
+    let expectedGeneration: UInt64
+    let task: Task<NativeObserverCreation, Never>
+    let completion: NativeObserverCreationCompletion
+
+    static func timedOut(id: UUID, expectedGeneration: UInt64) -> Self {
+        let completion = NativeObserverCreationCompletion()
+        completion.finish(with: .timedOut)
+        let task = Task<NativeObserverCreation, Never> { .timedOut }
+        return Self(
+            id: id,
+            expectedGeneration: expectedGeneration,
+            task: task,
+            completion: completion)
+    }
+}
+
 final nonisolated class FirstResultGate<Value: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<Value, Never>?
@@ -247,6 +265,23 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
                 self.condition.unlock()
             }
         }
+    }
+}
+
+final nonisolated class NativeObserverCreationCompletion: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var result: NativeObserverCreation?
+
+    func finish(with result: NativeObserverCreation) {
+        self.condition.withLock {
+            guard self.result == nil else { return }
+            self.result = result
+            self.condition.broadcast()
+        }
+    }
+
+    func currentResult() -> NativeObserverCreation? {
+        self.condition.withLock { self.result }
     }
 }
 

--- a/Sources/AXorcist/Core/ObserverNativeWork.swift
+++ b/Sources/AXorcist/Core/ObserverNativeWork.swift
@@ -1,11 +1,171 @@
 import ApplicationServices
+import Darwin
 import Foundation
 
-nonisolated enum ObserverNativeWorkerAdmission {
-    static let maximumConcurrentWorkers = 8
+nonisolated enum ObserverNativeWork {
+    private struct ProcessUniqueIdentifierInfo {
+        var executableUUIDHigh: UInt64 = 0
+        var executableUUIDLow: UInt64 = 0
+        var uniqueIdentifier: UInt64 = 0
+        var parentUniqueIdentifier: UInt64 = 0
+        var identifierVersion: Int32 = 0
+        var originalParentIdentifierVersion: Int32 = 0
+        var reserved2: UInt64 = 0
+        var reserved3: UInt64 = 0
+    }
 
-    static func allowsStartingWorker(activeWorkerCount: Int) -> Bool {
-        activeWorkerCount < self.maximumConcurrentWorkers
+    static func processUniqueIdentity(_ processIdentifier: pid_t) -> UInt64? {
+        guard processIdentifier > 0 else { return nil }
+        var info = ProcessUniqueIdentifierInfo()
+        let expectedSize = Int32(MemoryLayout<ProcessUniqueIdentifierInfo>.stride)
+        guard proc_pidinfo(
+            processIdentifier,
+            17, // PROC_PIDUNIQIDENTIFIERINFO from XNU's proc_info_private.h
+            0,
+            &info,
+            expectedSize) == expectedSize,
+            info.uniqueIdentifier != 0
+        else { return nil }
+        return info.uniqueIdentifier
+    }
+
+    static func boundedProcessUniqueIdentity(
+        _ processIdentifier: pid_t,
+        admission: ObserverNativeWorkerAdmission) async -> UInt64?
+    {
+        await self.firstResult(
+            timeout: .milliseconds(100),
+            timeoutValue: UInt64?.none,
+            admission: admission)
+        {
+            self.processUniqueIdentity(processIdentifier)
+        }
+    }
+
+    static func firstResult<Value: Sendable>(
+        timeout: Duration,
+        timeoutValue: Value,
+        admission: ObserverNativeWorkerAdmission,
+        operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        guard admission.tryAcquire() else { return timeoutValue }
+        return await withCheckedContinuation { continuation in
+            let gate = FirstResultGate(continuation: continuation)
+            Thread.detachNewThread {
+                let result = autoreleasepool { operation() }
+                admission.release()
+                gate.finish(with: result)
+            }
+            Task.detached(priority: .utility) {
+                try? await Task.sleep(for: timeout)
+                gate.finish(with: timeoutValue)
+            }
+        }
+    }
+
+    static func perform<Value: Sendable>(
+        admission: ObserverNativeWorkerAdmission,
+        refusalValue: Value,
+        operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        guard admission.tryAcquire() else { return refusalValue }
+        return await withCheckedContinuation { continuation in
+            Thread.detachNewThread {
+                let result = autoreleasepool { operation() }
+                admission.release()
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    static func performCleanup<Value: Sendable>(
+        admission: ObserverNativeWorkerAdmission,
+        operation: @escaping @Sendable () -> Value) async -> Value
+    {
+        await admission.acquireCleanup()
+        return await withCheckedContinuation { continuation in
+            Thread.detachNewThread {
+                let result = autoreleasepool { operation() }
+                admission.release()
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    static func performSynchronously<Value>(
+        admission: ObserverNativeWorkerAdmission,
+        refusalValue: Value,
+        operation: () -> Value) -> Value
+    {
+        guard admission.tryAcquire() else { return refusalValue }
+        defer { admission.release() }
+        return operation()
+    }
+
+    static func tryPerformCleanupSynchronously<Value>(
+        admission: ObserverNativeWorkerAdmission,
+        operation: () -> Value) -> Value?
+    {
+        guard admission.tryAcquireCleanup() else { return nil }
+        defer { admission.release() }
+        return operation()
+    }
+}
+
+final nonisolated class ObserverNativeWorkerAdmission: @unchecked Sendable {
+    static let maximumConcurrentWorkers = 8
+    static let maximumRegularWorkers = ObserverNativeWorkerAdmission.maximumConcurrentWorkers - 1
+
+    private let lock = NSLock()
+    private var activeWorkerCount = 0
+    private var cleanupWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func tryAcquire() -> Bool {
+        self.lock.withLock {
+            guard self.activeWorkerCount < Self.maximumRegularWorkers else { return false }
+            self.activeWorkerCount += 1
+            return true
+        }
+    }
+
+    func tryAcquireCleanup() -> Bool {
+        self.lock.withLock {
+            guard self.activeWorkerCount < Self.maximumConcurrentWorkers else { return false }
+            self.activeWorkerCount += 1
+            return true
+        }
+    }
+
+    func acquireCleanup() async {
+        await withCheckedContinuation { continuation in
+            let acquired = self.lock.withLock {
+                if self.activeWorkerCount < Self.maximumConcurrentWorkers {
+                    self.activeWorkerCount += 1
+                    return true
+                }
+                self.cleanupWaiters.append(continuation)
+                return false
+            }
+            if acquired {
+                continuation.resume()
+            }
+        }
+    }
+
+    func release() {
+        let waiter = self.lock.withLock { () -> CheckedContinuation<Void, Never>? in
+            precondition(self.activeWorkerCount > 0)
+            if !self.cleanupWaiters.isEmpty {
+                return self.cleanupWaiters.removeFirst()
+            }
+            self.activeWorkerCount -= 1
+            return nil
+        }
+        waiter?.resume()
+    }
+
+    var activeCount: Int {
+        self.lock.withLock { self.activeWorkerCount }
     }
 }
 
@@ -61,12 +221,13 @@ final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
         }
     }
 
-    func wait() -> AXError {
+    func wait(until deadline: ContinuousClock.Instant) -> AXError? {
+        let clock = ContinuousClock()
         self.condition.lock()
-        while self.result == nil {
-            self.condition.wait()
+        while self.result == nil, clock.now < deadline {
+            self.condition.wait(until: Date(timeIntervalSinceNow: 0.01))
         }
-        let result = self.result ?? .failure
+        let result = self.result
         self.condition.unlock()
         return result
     }

--- a/Sources/AXorcist/Core/ObserverNativeWork.swift
+++ b/Sources/AXorcist/Core/ObserverNativeWork.swift
@@ -1,0 +1,136 @@
+import ApplicationServices
+import Foundation
+
+nonisolated enum ObserverNativeWorkerAdmission {
+    static let maximumConcurrentWorkers = 8
+
+    static func allowsStartingWorker(activeWorkerCount: Int) -> Bool {
+        activeWorkerCount < self.maximumConcurrentWorkers
+    }
+}
+
+nonisolated struct SendableObserver: @unchecked Sendable {
+    let value: AXObserver
+}
+
+nonisolated struct SendableObserverCallback: @unchecked Sendable {
+    let value: AXObserverCallbackWithInfo
+}
+
+nonisolated enum NativeObserverCreation: @unchecked Sendable {
+    case created(SendableObserver)
+    case failed(AXError)
+    case timedOut
+}
+
+final nonisolated class FirstResultGate<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Never>?
+
+    init(continuation: CheckedContinuation<Value, Never>) {
+        self.continuation = continuation
+    }
+
+    func finish(with value: Value) {
+        let continuation = self.lock.withLock {
+            defer { self.continuation = nil }
+            return self.continuation
+        }
+        continuation?.resume(returning: value)
+    }
+}
+
+final nonisolated class NativeRemovalCompletion: @unchecked Sendable {
+    private let condition = NSCondition()
+    private var result: AXError?
+    private var continuations: [CheckedContinuation<AXError, Never>] = []
+
+    func finish(with result: AXError) {
+        self.condition.lock()
+        guard self.result == nil else {
+            self.condition.unlock()
+            return
+        }
+        self.result = result
+        let continuations = self.continuations
+        self.continuations.removeAll()
+        self.condition.broadcast()
+        self.condition.unlock()
+        for continuation in continuations {
+            continuation.resume(returning: result)
+        }
+    }
+
+    func wait() -> AXError {
+        self.condition.lock()
+        while self.result == nil {
+            self.condition.wait()
+        }
+        let result = self.result ?? .failure
+        self.condition.unlock()
+        return result
+    }
+
+    func currentResult() -> AXError? {
+        self.condition.withLock { self.result }
+    }
+
+    func value() async -> AXError {
+        await withCheckedContinuation { continuation in
+            self.condition.lock()
+            if let result = self.result {
+                self.condition.unlock()
+                continuation.resume(returning: result)
+            } else {
+                self.continuations.append(continuation)
+                self.condition.unlock()
+            }
+        }
+    }
+}
+
+nonisolated struct NativeNotificationRegistration: @unchecked Sendable {
+    let observer: AXObserver
+    let element: AXUIElement
+    let notification: CFString
+    let refcon: UnsafeMutableRawPointer
+    let appliesMessagingTimeout: Bool
+
+    static func removalConfirmsRegistrationAbsent(_ error: AXError) -> Bool {
+        error == .success || error == .notificationNotRegistered
+    }
+
+    static func normalizedAdditionResult(_ error: AXError) -> AXError {
+        error == .notificationAlreadyRegistered ? .success : error
+    }
+
+    func add() -> AXError {
+        guard self.applyTimeoutIfNeeded() else {
+            return .cannotComplete
+        }
+        defer { self.resetTimeoutIfNeeded() }
+        let error = AXObserverAddNotification(
+            self.observer,
+            self.element,
+            self.notification,
+            self.refcon)
+        return Self.normalizedAdditionResult(error)
+    }
+
+    func remove() -> AXError {
+        guard self.applyTimeoutIfNeeded() else {
+            return .cannotComplete
+        }
+        defer { self.resetTimeoutIfNeeded() }
+        return AXObserverRemoveNotification(self.observer, self.element, self.notification)
+    }
+
+    private func applyTimeoutIfNeeded() -> Bool {
+        !self.appliesMessagingTimeout || AXUIElementSetMessagingTimeout(self.element, 0.5) == .success
+    }
+
+    private func resetTimeoutIfNeeded() {
+        guard self.appliesMessagingTimeout else { return }
+        AXUIElementSetMessagingTimeout(self.element, 0)
+    }
+}

--- a/Sources/AXorcist/Core/ObserverTypes.swift
+++ b/Sources/AXorcist/Core/ObserverTypes.swift
@@ -24,7 +24,24 @@ protocol AXObservationRegistry: AnyObject, Sendable {
         notification: AXNotification,
         handler: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
 
+    func subscribeProcessAsync(
+        pid: pid_t,
+        element: Element?,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) async -> Result<SubscriptionToken, AccessibilityError>
+
     func unsubscribe(token: SubscriptionToken) throws
+}
+
+extension AXObservationRegistry {
+    func subscribeProcessAsync(
+        pid: pid_t,
+        element: Element?,
+        notification: AXNotification,
+        handler: @escaping AXNotificationSubscriptionHandler) async -> Result<SubscriptionToken, AccessibilityError>
+    {
+        self.subscribeProcess(pid: pid, element: element, notification: notification, handler: handler)
+    }
 }
 
 /// Key for tracking accessibility notification subscriptions.
@@ -48,6 +65,19 @@ struct AXObserverRegistrationKey: Hashable {
     let subscription: AXNotificationSubscriptionKey
     let element: Element
     let scope: Scope
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        guard lhs.subscription == rhs.subscription, lhs.scope == rhs.scope else { return false }
+        return lhs.scope == .process || lhs.element == rhs.element
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.subscription)
+        hasher.combine(self.scope)
+        if self.scope == .element {
+            hasher.combine(self.element)
+        }
+    }
 }
 
 /// Key combining process ID and notification type for observer tracking.

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -346,6 +346,41 @@ struct ObserverLifecycleTests {
     }
 
     @Test
+    func `process registration identity does not compare accessibility elements`() {
+        let subscription = AXNotificationSubscriptionKey(pid: 91, notification: .valueChanged)
+        let firstElement = Element(AXUIElementCreateApplication(91))
+        let unrelatedElement = Element(AXUIElementCreateApplication(92))
+        let first = AXObserverRegistrationKey(
+            subscription: subscription,
+            element: firstElement,
+            scope: .process)
+        let second = AXObserverRegistrationKey(
+            subscription: subscription,
+            element: unrelatedElement,
+            scope: .process)
+
+        #expect(first == second)
+        #expect(Set([first, second]).count == 1)
+    }
+
+    @Test
+    func `native registration result semantics remain fail closed`() {
+        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.success))
+        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.notificationNotRegistered))
+        #expect(!NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.cannotComplete))
+        #expect(NativeNotificationRegistration.normalizedAdditionResult(.notificationAlreadyRegistered) == .success)
+        #expect(NativeNotificationRegistration.normalizedAdditionResult(.cannotComplete) == .cannotComplete)
+    }
+
+    @Test
+    func `native observer worker admission is process bounded`() {
+        #expect(ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 0))
+        #expect(ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 7))
+        #expect(!ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 8))
+        #expect(!ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 80))
+    }
+
+    @Test
     func `shared registration cleans up its exact target after the final token`() throws {
         var setupCount = 0
         var cleanedElement: Element?
@@ -398,12 +433,38 @@ struct ObserverLifecycleTests {
         #expect(registry.unsubscribeCallCount == 1)
         #expect(registry.activeSubscriptionCount == 0)
     }
+
+    @Test
+    func `process watcher can restart immediately after stopping`() throws {
+        var setupCount = 0
+        var cleanupCount = 0
+        let center = AXObserverCenter(
+            observerSetup: { _, _, _ in
+                setupCount += 1
+                return .success
+            },
+            observerCleanup: { _, _, _ in cleanupCount += 1 })
+        let watcher = NotificationWatcher(
+            forPID: 42,
+            notification: .valueChanged,
+            registry: center,
+            handler: { _, _, _, _ in })
+
+        try watcher.start()
+        watcher.stop()
+        try watcher.start()
+
+        #expect(watcher.isActive)
+        #expect(setupCount == 2)
+        #expect(cleanupCount == 1)
+        watcher.stop()
+    }
 }
 
 @MainActor
 extension ObserverLifecycleTests {
     @Test
-    func `global watcher fans out by PID and follows native application lifecycle`() throws {
+    func `global watcher fans out by PID and follows native application lifecycle`() async throws {
         let registry = RecordingObservationRegistry()
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [42, 41])
         let watcher = NotificationWatcher(
@@ -413,14 +474,20 @@ extension ObserverLifecycleTests {
         { _, _, _, _ in }
 
         try watcher.start()
+        for _ in 0..<20 where registry.activeProcessIdentifiers.count < 2 {
+            await Task.yield()
+        }
 
         #expect(watcher.isActive)
-        #expect(registry.subscribedProcessIdentifiers == [41, 42])
+        #expect(registry.subscribedProcessIdentifiers.sorted() == [41, 42])
         #expect(!registry.subscribedProcessIdentifiers.contains(0))
 
         applicationMonitor.launch(processIdentifier: 43)
         applicationMonitor.launch(processIdentifier: 43)
-        #expect(registry.subscribedProcessIdentifiers == [41, 42, 43])
+        for _ in 0..<20 where !registry.activeProcessIdentifiers.contains(43) {
+            await Task.yield()
+        }
+        #expect(registry.subscribedProcessIdentifiers.sorted() == [41, 42, 43])
 
         applicationMonitor.terminate(processIdentifier: 42)
         #expect(registry.activeProcessIdentifiers == [41, 43])
@@ -477,7 +544,7 @@ extension ObserverLifecycleTests {
     }
 
     @Test
-    func `failed initial application waits for its first backoff`() throws {
+    func `failed initial application waits for its first backoff`() async throws {
         let registry = RecordingObservationRegistry(failingProcessIdentifiers: [42])
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
         let watcher = NotificationWatcher(
@@ -488,6 +555,9 @@ extension ObserverLifecycleTests {
             handler: { _, _, _, _ in })
 
         try watcher.start()
+        for _ in 0..<20 where registry.attemptCount(for: 41) == 0 || registry.attemptCount(for: 42) == 0 {
+            await Task.yield()
+        }
 
         #expect(registry.attemptCount(for: 41) == 1)
         #expect(registry.attemptCount(for: 42) == 1)
@@ -595,20 +665,95 @@ extension ObserverLifecycleTests {
     }
 
     @Test
-    func `global watcher fails when every current application rejects registration`() {
+    func `global watcher remains active when every current application rejects registration`() async throws {
         let registry = RecordingObservationRegistry(failingProcessIdentifiers: [41, 42])
         let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
         let watcher = NotificationWatcher(
             globalNotification: .focusedUIElementChanged,
             registry: registry,
-            applicationMonitor: applicationMonitor)
-        { _, _, _, _ in }
+            applicationMonitor: applicationMonitor,
+            retrySleep: { _ in },
+            handler: { _, _, _, _ in })
 
-        #expect(throws: AccessibilityError.self) {
-            try watcher.start()
+        try watcher.start()
+        for _ in 0..<100 where registry.attemptCount(for: 41) < 4 || registry.attemptCount(for: 42) < 4 {
+            await Task.yield()
         }
+
+        #expect(watcher.isActive)
+        #expect(registry.activeProcessIdentifiers.isEmpty)
+        #expect(registry.attemptCount(for: 41) == 4)
+        #expect(registry.attemptCount(for: 42) == 4)
+        watcher.stop()
+        #expect(applicationMonitor.stopCount == 1)
+    }
+
+    @Test
+    func `global watcher startup does not await a wedged application registration`() async throws {
+        let registry = SuspendingObservationRegistry()
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [41, 42])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            handler: { _, _, _, _ in })
+
+        try watcher.start()
+        #expect(watcher.isActive)
+        for _ in 0..<20 where registry.pendingProcessIdentifiers.isEmpty ||
+            !registry.activeProcessIdentifiers.contains(41)
+        {
+            await Task.yield()
+        }
+        #expect(registry.pendingProcessIdentifiers == [42])
+        #expect(registry.activeProcessIdentifiers == [41])
+
+        watcher.stop()
         #expect(!watcher.isActive)
         #expect(applicationMonitor.stopCount == 1)
+
+        registry.resume(processIdentifier: 42)
+        for _ in 0..<20 where registry.unsubscribeCallCount < 2 {
+            await Task.yield()
+        }
+        #expect(registry.unsubscribeCallCount == 2)
+        #expect(registry.activeProcessIdentifiers.isEmpty)
+    }
+
+    @Test
+    func `global watcher restart keeps only the replacement suspended registration`() async throws {
+        let registry = SuspendingObservationRegistry()
+        let applicationMonitor = RecordingGlobalApplicationMonitor(runningProcessIdentifiers: [42])
+        let watcher = NotificationWatcher(
+            globalNotification: .focusedUIElementChanged,
+            registry: registry,
+            applicationMonitor: applicationMonitor,
+            handler: { _, _, _, _ in })
+
+        try watcher.start()
+        for _ in 0..<20 where registry.pendingCount(for: 42) < 1 {
+            await Task.yield()
+        }
+        watcher.stop()
+        try watcher.start()
+        for _ in 0..<20 where registry.pendingCount(for: 42) < 2 {
+            await Task.yield()
+        }
+
+        registry.resume(processIdentifier: 42)
+        for _ in 0..<20 where registry.unsubscribeCallCount == 0 {
+            await Task.yield()
+        }
+        registry.resume(processIdentifier: 42)
+        for _ in 0..<20 where registry.activeProcessIdentifiers.isEmpty {
+            await Task.yield()
+        }
+
+        #expect(watcher.isActive)
+        #expect(registry.unsubscribeCallCount == 1)
+        #expect(registry.activeProcessIdentifiers == [42])
+        watcher.stop()
+        #expect(registry.activeProcessIdentifiers.isEmpty)
     }
 
     @Test
@@ -742,6 +887,71 @@ private final class RecordingObservationRegistry: AXObservationRegistry {
             throw AccessibilityError.tokenNotFound(tokenId: token.id)
         }
         self.processIdentifiersByToken.removeValue(forKey: token)
+    }
+}
+
+@MainActor
+private final class SuspendingObservationRegistry: AXObservationRegistry {
+    private let suspendedProcessIdentifiers: Set<pid_t> = [42]
+    private var continuations: [pid_t: [CheckedContinuation<Void, Never>]] = [:]
+    private var processIdentifiersByToken: [SubscriptionToken: pid_t] = [:]
+
+    private(set) var unsubscribeCallCount = 0
+
+    var pendingProcessIdentifiers: [pid_t] {
+        self.continuations.compactMap { $0.value.isEmpty ? nil : $0.key }.sorted()
+    }
+
+    var activeProcessIdentifiers: [pid_t] {
+        self.processIdentifiersByToken.values.sorted()
+    }
+
+    func subscribeProcess(
+        pid: pid_t,
+        element _: Element?,
+        notification _: AXNotification,
+        handler _: @escaping AXNotificationSubscriptionHandler) -> Result<SubscriptionToken, AccessibilityError>
+    {
+        .success(self.recordSubscription(processIdentifier: pid))
+    }
+
+    func subscribeProcessAsync(
+        pid: pid_t,
+        element _: Element?,
+        notification _: AXNotification,
+        handler _: @escaping AXNotificationSubscriptionHandler) async -> Result<SubscriptionToken, AccessibilityError>
+    {
+        guard self.suspendedProcessIdentifiers.contains(pid) else {
+            return .success(self.recordSubscription(processIdentifier: pid))
+        }
+        await withCheckedContinuation { continuation in
+            self.continuations[pid, default: []].append(continuation)
+        }
+        return .success(self.recordSubscription(processIdentifier: pid))
+    }
+
+    func unsubscribe(token: SubscriptionToken) throws {
+        self.unsubscribeCallCount += 1
+        guard self.processIdentifiersByToken.removeValue(forKey: token) != nil else {
+            throw AccessibilityError.tokenNotFound(tokenId: token.id)
+        }
+    }
+
+    func resume(processIdentifier: pid_t) {
+        guard var pending = self.continuations[processIdentifier], !pending.isEmpty else { return }
+        let continuation = pending.removeFirst()
+        self.continuations[processIdentifier] = pending
+        continuation.resume()
+    }
+
+    func pendingCount(for processIdentifier: pid_t) -> Int {
+        self.continuations[processIdentifier]?.count ?? 0
+    }
+
+    private func recordSubscription(processIdentifier: pid_t) -> SubscriptionToken {
+        let token = SubscriptionToken(id: UUID())
+        self.processIdentifiersByToken[token] = processIdentifier
+        return token
     }
 }
 

--- a/Tests/AXorcistTests/ObserverLifecycleTests.swift
+++ b/Tests/AXorcistTests/ObserverLifecycleTests.swift
@@ -364,23 +364,6 @@ struct ObserverLifecycleTests {
     }
 
     @Test
-    func `native registration result semantics remain fail closed`() {
-        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.success))
-        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.notificationNotRegistered))
-        #expect(!NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.cannotComplete))
-        #expect(NativeNotificationRegistration.normalizedAdditionResult(.notificationAlreadyRegistered) == .success)
-        #expect(NativeNotificationRegistration.normalizedAdditionResult(.cannotComplete) == .cannotComplete)
-    }
-
-    @Test
-    func `native observer worker admission is process bounded`() {
-        #expect(ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 0))
-        #expect(ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 7))
-        #expect(!ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 8))
-        #expect(!ObserverNativeWorkerAdmission.allowsStartingWorker(activeWorkerCount: 80))
-    }
-
-    @Test
     func `shared registration cleans up its exact target after the final token`() throws {
         var setupCount = 0
         var cleanedElement: Element?

--- a/Tests/AXorcistTests/ObserverNativeWorkTests.swift
+++ b/Tests/AXorcistTests/ObserverNativeWorkTests.swift
@@ -113,4 +113,33 @@ struct ObserverNativeWorkTests {
 
         #expect(result == .success)
     }
+
+    @Test @MainActor
+    func `observer creation completion signals while main actor pumps run loop`() {
+        let completion = NativeObserverCreationCompletion()
+        Task.detached {
+            completion.finish(with: .timedOut)
+        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+
+        while completion.currentResult() == nil, clock.now < deadline {
+            _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+        }
+
+        guard case .timedOut = completion.currentResult() else {
+            Issue.record("Expected off-actor observer creation completion")
+            return
+        }
+    }
+
+    @Test
+    func `timed out observer creation completes synchronously`() {
+        let pending = PendingObserverCreation.timedOut(id: UUID(), expectedGeneration: 1)
+
+        guard case .timedOut = pending.completion.currentResult() else {
+            Issue.record("Expected the timeout sentinel to be immediately observable")
+            return
+        }
+    }
 }

--- a/Tests/AXorcistTests/ObserverNativeWorkTests.swift
+++ b/Tests/AXorcistTests/ObserverNativeWorkTests.swift
@@ -1,0 +1,116 @@
+import ApplicationServices
+import Foundation
+import Testing
+@testable import AXorcist
+
+@Suite("Observer native work")
+struct ObserverNativeWorkTests {
+    @Test
+    func `native registration result semantics remain fail closed`() {
+        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.success))
+        #expect(NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.notificationNotRegistered))
+        #expect(!NativeNotificationRegistration.removalConfirmsRegistrationAbsent(.cannotComplete))
+        #expect(NativeNotificationRegistration.normalizedAdditionResult(.notificationAlreadyRegistered) == .success)
+        #expect(NativeNotificationRegistration.normalizedAdditionResult(.cannotComplete) == .cannotComplete)
+    }
+
+    @Test
+    func `native observer worker admission is process bounded`() {
+        let admission = ObserverNativeWorkerAdmission()
+        for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
+            #expect(admission.tryAcquire())
+        }
+        #expect(!admission.tryAcquire())
+        #expect(admission.tryAcquireCleanup())
+        #expect(admission.activeCount == ObserverNativeWorkerAdmission.maximumConcurrentWorkers)
+        #expect(!admission.tryAcquireCleanup())
+        admission.release()
+        #expect(admission.tryAcquireCleanup())
+    }
+
+    @Test
+    func `cleanup queues without spawning beyond saturation`() async {
+        let admission = ObserverNativeWorkerAdmission()
+        for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
+            #expect(admission.tryAcquire())
+        }
+        #expect(admission.tryAcquireCleanup())
+        let waiter = Task {
+            await admission.acquireCleanup()
+            return admission.activeCount
+        }
+        await Task.yield()
+
+        admission.release()
+
+        #expect(await waiter.value == ObserverNativeWorkerAdmission.maximumConcurrentWorkers)
+        admission.release()
+    }
+
+    @Test
+    func `native work releases admission before resuming its caller`() async {
+        let admission = ObserverNativeWorkerAdmission()
+        for _ in 0..<(ObserverNativeWorkerAdmission.maximumRegularWorkers - 1) {
+            #expect(admission.tryAcquire())
+        }
+
+        let result = await ObserverNativeWork.perform(
+            admission: admission,
+            refusalValue: -1,
+            operation: { 42 })
+
+        #expect(result == 42)
+        #expect(admission.tryAcquire())
+        for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
+            admission.release()
+        }
+    }
+
+    @Test
+    func `synchronous cleanup distinguishes saturation from a native result`() {
+        let admission = ObserverNativeWorkerAdmission()
+        for _ in 0..<ObserverNativeWorkerAdmission.maximumRegularWorkers {
+            #expect(admission.tryAcquire())
+        }
+        #expect(admission.tryAcquireCleanup())
+        var executed = false
+
+        let refused = ObserverNativeWork.tryPerformCleanupSynchronously(admission: admission) {
+            executed = true
+            return AXError.success
+        }
+        #expect(refused == nil)
+        #expect(!executed)
+
+        admission.release()
+        let admitted = ObserverNativeWork.tryPerformCleanupSynchronously(admission: admission) {
+            executed = true
+            return AXError.success
+        }
+        #expect(admitted == .success)
+        #expect(executed)
+    }
+
+    @Test
+    func `synchronous native removal join has a monotonic deadline`() {
+        let completion = NativeRemovalCompletion()
+        let clock = ContinuousClock()
+        let start = clock.now
+
+        #expect(completion.wait(until: start.advanced(by: .milliseconds(20))) == nil)
+        #expect(start.duration(to: clock.now) < .seconds(1))
+    }
+
+    @Test @MainActor
+    func `removal completion signals while main actor synchronously waits`() {
+        let completion = NativeRemovalCompletion()
+        Task.detached {
+            completion.finish(with: .success)
+        }
+        let clock = ContinuousClock()
+
+        let result = completion.wait(until: clock.now.advanced(by: .seconds(1)))
+
+        #expect(result == .success)
+    }
+}


### PR DESCRIPTION
## Summary

- start global Accessibility lifecycle monitoring without synchronously waiting for every running application
- move observer creation, notification registration, process identity reads, and global cleanup off the main actor with bounded native work and process-wide admission control
- bind concurrent setup and teardown to immutable operation, process-generation, and state-epoch receipts so stale completions fail closed
- preserve synchronous observer restart behavior and structural process registration identity without mutating caller-owned AX element timeout state

## Why

A single unresponsive Accessibility endpoint could block `AXObserverCreateWithInfoCallback` or notification registration while global fan-out was starting on the main actor. Downstream daemon and MCP startup therefore hung before accepting requests. Registration and cleanup also needed one serialized state model so cancellation, PID reuse, sync/async callers, and uncertain native outcomes could not create logical tokens without a current native registration.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (144 library tests and 1 command-conversion test)
- `swift build -c release --disable-automatic-resolution`
- focused wedged-registration, healthy-peer fan-out, restart, process-generation, native outcome, and worker-admission regressions
- structured P0-P2 autoreview: clean
