### PR TITLE
fix: key AX timeout scopes by reference

### DIFF
--- a/Sources/AXorcist/Core/AXTimeoutPolicy.swift
+++ b/Sources/AXorcist/Core/AXTimeoutPolicy.swift
@@ -84,14 +84,27 @@ public enum AXMessagingTimeoutError: Error, Equatable, Sendable, CustomStringCon
 
 @MainActor
 private enum AXMessagingTimeoutRegistry {
-    private static var activeElements: Set<Element> = []
+    private enum Key: Hashable {
+        case systemWide
+        case element(ObjectIdentifier)
+    }
+
+    private static let systemWideElement = AXUIElementCreateSystemWide()
+    private static var activeElements: Set<Key> = []
 
     static func begin(_ element: Element) -> Bool {
-        self.activeElements.insert(element).inserted
+        self.activeElements.insert(self.key(for: element)).inserted
     }
 
     static func end(_ element: Element) {
-        self.activeElements.remove(element)
+        self.activeElements.remove(self.key(for: element))
+    }
+
+    private static func key(for element: Element) -> Key {
+        if CFEqual(element.underlyingElement, self.systemWideElement) {
+            return .systemWide
+        }
+        return .element(ObjectIdentifier(element.underlyingElement))
     }
 }
 

--- a/Tests/AXorcistTests/AXTimeoutHelperTests.swift
+++ b/Tests/AXorcistTests/AXTimeoutHelperTests.swift
@@ -209,4 +209,34 @@ struct AXTimeoutHelperTests {
         }
         #expect(result == 42)
     }
+
+    @Test
+    @MainActor
+    func `equal elements with distinct references keep independent messaging scopes`() throws {
+        let first = Element(AXUIElementCreateApplication(getpid()))
+        let second = Element(AXUIElementCreateApplication(getpid()))
+        #expect(first == second)
+        #expect(ObjectIdentifier(first.underlyingElement) != ObjectIdentifier(second.underlyingElement))
+
+        let result = try first.withMessagingTimeout(0.5) { _ in
+            try second.withMessagingTimeout(0.5) { _ in 42 }
+        }
+        #expect(result == 42)
+    }
+
+    @Test
+    @MainActor
+    func `distinct system-wide references share one messaging scope`() throws {
+        let first = Element(AXUIElementCreateSystemWide())
+        let second = Element(AXUIElementCreateSystemWide())
+        #expect(ObjectIdentifier(first.underlyingElement) != ObjectIdentifier(second.underlyingElement))
+
+        _ = try first.withMessagingTimeout(0.5) { _ in
+            #expect(throws: AXMessagingTimeoutError.nestedScope) {
+                try second.withMessagingTimeout(0.25) { _ in
+                    Issue.record("The nested system-wide operation must not run")
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- key checked AX messaging-timeout scopes by concrete `AXUIElement` reference identity for ordinary elements
- keep all system-wide element references on one shared process-global scope key
- prove separately created equal application elements remain independent while separately created system-wide elements reject nested timeout replacement

## Why

`Element` equality uses `CFEqual`, but macOS stores an ordinary element's messaging timeout on the concrete accessibility object. Two independently fetched references can compare equal without sharing timeout state. The system-wide element is the exception: its timeout is process-global even across distinct references. The registry now models both ownership rules exactly.

## Validation

- `make check`
- `swift test --disable-automatic-resolution` (163 library tests plus 1 command-conversion test passed; permission-gated automation suites skipped)
- `swift build -c release --disable-automatic-resolution`
- focused reference-identity and system-wide scope regressions
- structured P0-P2 autoreview clean after accepting and fixing the system-wide identity exception
